### PR TITLE
Bugfix/go linux aarch64

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -76,7 +76,7 @@ else
     echo "✅ Rust found: $(cargo --version)"
 
     # Check Rust version - need 1.80+ for edition2024 support
-    RUST_VERSION=$(cargo --version | grep -oP '\d+\.\d+' | head -1)
+    RUST_VERSION=$(cargo --version | grep -oE '[0-9]+\.[0-9]+' | head -1)
     MAJOR=$(echo $RUST_VERSION | cut -d. -f1)
     MINOR=$(echo $RUST_VERSION | cut -d. -f2)
 
@@ -124,7 +124,7 @@ else
     echo "✅ Go found: $(go version)"
 
     # Check Go version - need 1.20+
-    GO_VERSION=$(go version | grep -oP 'go\d+\.\d+' | grep -oP '\d+\.\d+')
+    GO_VERSION=$(go version | grep -oE 'go[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+')
     GO_MAJOR=$(echo $GO_VERSION | cut -d. -f1)
     GO_MINOR=$(echo $GO_VERSION | cut -d. -f2)
 

--- a/setup.sh
+++ b/setup.sh
@@ -134,12 +134,12 @@ if [ -n "$GO_ACTION" ]; then
     sudo tar -C /usr/local -xzf "go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz"
     rm "go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz"
 
-    export PATH=$PATH:/usr/local/go/bin
+    export PATH=/usr/local/go/bin:$PATH
     RC_UPDATED=false
     if [[ "$SHELL" == */zsh ]]; then
-        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.zshrc  || { echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.zshrc;  RC_UPDATED=true; }
+        grep -qxF 'export PATH=/usr/local/go/bin:$PATH' ~/.zshrc  || { echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.zshrc;  RC_UPDATED=true; }
     else
-        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.bashrc || { echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.bashrc; RC_UPDATED=true; }
+        grep -qxF 'export PATH=/usr/local/go/bin:$PATH' ~/.bashrc || { echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.bashrc; RC_UPDATED=true; }
     fi
 
     if [ "$GO_ACTION" = "install" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -135,16 +135,25 @@ if [ -n "$GO_ACTION" ]; then
     rm "go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz"
 
     export PATH=$PATH:/usr/local/go/bin
+    RC_UPDATED=false
     if [[ "$SHELL" == */zsh ]]; then
-        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.zshrc  || echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.zshrc
+        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.zshrc  || { echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.zshrc;  RC_UPDATED=true; }
     else
-        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.bashrc || echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.bashrc || { echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc; RC_UPDATED=true; }
     fi
 
     if [ "$GO_ACTION" = "install" ]; then
         echo "✅ Go installed: $(go version)"
     else
         echo "✅ Go upgraded to: $(go version)"
+    fi
+
+    if [ "$RC_UPDATED" = true ]; then
+        if [[ "$SHELL" == */zsh ]]; then
+            echo "⚠️  Run 'source ~/.zshrc' to update your PATH for Go."
+        else
+            echo "⚠️  Run 'source ~/.bashrc' to update your PATH for Go."
+        fi
     fi
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -91,7 +91,24 @@ else
 fi
 
 # 5. Go toolchain
+GO_ACTION=""
 if ! command -v go &> /dev/null; then
+    GO_ACTION="install"
+else
+    echo "✅ Go found: $(go version)"
+
+    # Check Go version - need 1.20+
+    GO_VERSION=$(go version | grep -oE 'go[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+')
+    GO_MAJOR=$(echo $GO_VERSION | cut -d. -f1)
+    GO_MINOR=$(echo $GO_VERSION | cut -d. -f2)
+
+    if [ "$GO_MAJOR" -lt 1 ] || ([ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 20 ]); then
+        echo "⚠️  Go version $GO_VERSION is too old (need 1.20+)"
+        GO_ACTION="upgrade"
+    fi
+fi
+
+if [ -n "$GO_ACTION" ]; then
     echo "📦 Installing Go 1.21..."
 
     if [ "$OS" = "linux" ]; then
@@ -107,10 +124,11 @@ if ! command -v go &> /dev/null; then
             rm go1.21.13.linux-amd64.tar.gz
         fi
 
-        export PATH=$PATH:/usr/local/go/bin
-        echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
-    else
-        # macOS
+        if [ "$GO_ACTION" = "install" ]; then
+            export PATH=$PATH:/usr/local/go/bin
+            echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+        fi
+    elif [ "$OS" = "macos" ]; then
         if [ "$(uname -m)" = "arm64" ]; then
             wget https://go.dev/dl/go1.21.13.darwin-arm64.tar.gz
             sudo tar -C /usr/local -xzf go1.21.13.darwin-arm64.tar.gz
@@ -121,49 +139,20 @@ if ! command -v go &> /dev/null; then
             rm go1.21.13.darwin-amd64.tar.gz
         fi
 
-        export PATH=$PATH:/usr/local/go/bin
-        echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.zshrc
-        echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+        if [ "$GO_ACTION" = "install" ]; then
+            export PATH=$PATH:/usr/local/go/bin
+            echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.zshrc
+            echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+        fi
+    else
+        echo "❌ Unsupported platform for Go installation: $OS"
+        exit 1
     fi
 
-    echo "✅ Go installed: $(go version)"
-else
-    echo "✅ Go found: $(go version)"
-
-    # Check Go version - need 1.20+
-    GO_VERSION=$(go version | grep -oE 'go[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+')
-    GO_MAJOR=$(echo $GO_VERSION | cut -d. -f1)
-    GO_MINOR=$(echo $GO_VERSION | cut -d. -f2)
-
-    if [ "$GO_MAJOR" -lt 1 ] || ([ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 20 ]); then
-        echo "⚠️  Go version $GO_VERSION is too old (need 1.20+)"
-        echo "📦 Installing Go 1.21..."
-
-        if [ "$OS" = "linux" ]; then
-            if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
-                wget https://go.dev/dl/go1.21.13.linux-arm64.tar.gz
-                sudo rm -rf /usr/local/go
-                sudo tar -C /usr/local -xzf go1.21.13.linux-arm64.tar.gz
-                rm go1.21.13.linux-arm64.tar.gz
-            else
-                wget https://go.dev/dl/go1.21.13.linux-amd64.tar.gz
-                sudo rm -rf /usr/local/go
-                sudo tar -C /usr/local -xzf go1.21.13.linux-amd64.tar.gz
-                rm go1.21.13.linux-amd64.tar.gz
-            fi
-        else
-            if [ "$(uname -m)" = "arm64" ]; then
-                wget https://go.dev/dl/go1.21.13.darwin-arm64.tar.gz
-                sudo tar -C /usr/local -xzf go1.21.13.darwin-arm64.tar.gz
-                rm go1.21.13.darwin-arm64.tar.gz
-            else
-                wget https://go.dev/dl/go1.21.13.darwin-amd64.tar.gz
-                sudo tar -C /usr/local -xzf go1.21.13.darwin-amd64.tar.gz
-                rm go1.21.13.darwin-amd64.tar.gz
-            fi
-        fi
-
-        echo "✅ Go updated to: $(go version)"
+    if [ "$GO_ACTION" = "install" ]; then
+        echo "✅ Go installed: $(go version)"
+    else
+        echo "✅ Go upgraded to: $(go version)"
     fi
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -109,44 +109,36 @@ else
 fi
 
 if [ -n "$GO_ACTION" ]; then
-    echo "📦 Installing Go 1.21..."
+    GO_VERSION="1.21.13"
+    echo "📦 Installing Go ${GO_VERSION}..."
 
-    if [ "$OS" = "linux" ]; then
-        if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
-            wget https://go.dev/dl/go1.21.13.linux-arm64.tar.gz
-            sudo rm -rf /usr/local/go
-            sudo tar -C /usr/local -xzf go1.21.13.linux-arm64.tar.gz
-            rm go1.21.13.linux-arm64.tar.gz
-        else
-            wget https://go.dev/dl/go1.21.13.linux-amd64.tar.gz
-            sudo rm -rf /usr/local/go
-            sudo tar -C /usr/local -xzf go1.21.13.linux-amd64.tar.gz
-            rm go1.21.13.linux-amd64.tar.gz
-        fi
+    case "$OSTYPE" in
+        linux-gnu*)
+            GO_OS="linux"
+            GO_ARCH="amd64"
+            [ "$(uname -m)" = "aarch64" ] && GO_ARCH="arm64"
+            ;;
+        darwin*)
+            GO_OS="darwin"
+            GO_ARCH="amd64"
+            [ "$(uname -m)" = "arm64" ] && GO_ARCH="arm64"
+            ;;
+        *)
+            echo "❌ Unsupported platform for Go installation: $OSTYPE"
+            exit 1
+            ;;
+    esac
 
-        if [ "$GO_ACTION" = "install" ]; then
-            export PATH=$PATH:/usr/local/go/bin
-            echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
-        fi
-    elif [ "$OS" = "macos" ]; then
-        if [ "$(uname -m)" = "arm64" ]; then
-            wget https://go.dev/dl/go1.21.13.darwin-arm64.tar.gz
-            sudo tar -C /usr/local -xzf go1.21.13.darwin-arm64.tar.gz
-            rm go1.21.13.darwin-arm64.tar.gz
-        else
-            wget https://go.dev/dl/go1.21.13.darwin-amd64.tar.gz
-            sudo tar -C /usr/local -xzf go1.21.13.darwin-amd64.tar.gz
-            rm go1.21.13.darwin-amd64.tar.gz
-        fi
+    wget "https://go.dev/dl/go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz"
+    sudo rm -rf /usr/local/go
+    sudo tar -C /usr/local -xzf "go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz"
+    rm "go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz"
 
-        if [ "$GO_ACTION" = "install" ]; then
-            export PATH=$PATH:/usr/local/go/bin
-            echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.zshrc
-            echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
-        fi
+    export PATH=$PATH:/usr/local/go/bin
+    if [[ "$SHELL" == */zsh ]]; then
+        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.zshrc  || echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.zshrc
     else
-        echo "❌ Unsupported platform for Go installation: $OS"
-        exit 1
+        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.bashrc || echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
     fi
 
     if [ "$GO_ACTION" = "install" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -95,10 +95,17 @@ if ! command -v go &> /dev/null; then
     echo "📦 Installing Go 1.21..."
 
     if [ "$OS" = "linux" ]; then
-        wget https://go.dev/dl/go1.21.13.linux-amd64.tar.gz
-        sudo rm -rf /usr/local/go
-        sudo tar -C /usr/local -xzf go1.21.13.linux-amd64.tar.gz
-        rm go1.21.13.linux-amd64.tar.gz
+        if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+            wget https://go.dev/dl/go1.21.13.linux-arm64.tar.gz
+            sudo rm -rf /usr/local/go
+            sudo tar -C /usr/local -xzf go1.21.13.linux-arm64.tar.gz
+            rm go1.21.13.linux-arm64.tar.gz
+        else
+            wget https://go.dev/dl/go1.21.13.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go
+            sudo tar -C /usr/local -xzf go1.21.13.linux-amd64.tar.gz
+            rm go1.21.13.linux-amd64.tar.gz
+        fi
 
         export PATH=$PATH:/usr/local/go/bin
         echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
@@ -133,10 +140,17 @@ else
         echo "📦 Installing Go 1.21..."
 
         if [ "$OS" = "linux" ]; then
-            wget https://go.dev/dl/go1.21.13.linux-amd64.tar.gz
-            sudo rm -rf /usr/local/go
-            sudo tar -C /usr/local -xzf go1.21.13.linux-amd64.tar.gz
-            rm go1.21.13.linux-amd64.tar.gz
+            if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+                wget https://go.dev/dl/go1.21.13.linux-arm64.tar.gz
+                sudo rm -rf /usr/local/go
+                sudo tar -C /usr/local -xzf go1.21.13.linux-arm64.tar.gz
+                rm go1.21.13.linux-arm64.tar.gz
+            else
+                wget https://go.dev/dl/go1.21.13.linux-amd64.tar.gz
+                sudo rm -rf /usr/local/go
+                sudo tar -C /usr/local -xzf go1.21.13.linux-amd64.tar.gz
+                rm go1.21.13.linux-amd64.tar.gz
+            fi
         else
             if [ "$(uname -m)" = "arm64" ]; then
                 wget https://go.dev/dl/go1.21.13.darwin-arm64.tar.gz

--- a/setup.sh
+++ b/setup.sh
@@ -137,9 +137,9 @@ if [ -n "$GO_ACTION" ]; then
     export PATH=$PATH:/usr/local/go/bin
     RC_UPDATED=false
     if [[ "$SHELL" == */zsh ]]; then
-        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.zshrc  || { echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.zshrc;  RC_UPDATED=true; }
+        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.zshrc  || { echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.zshrc;  RC_UPDATED=true; }
     else
-        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.bashrc || { echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc; RC_UPDATED=true; }
+        grep -qxF 'export PATH=$PATH:/usr/local/go/bin' ~/.bashrc || { echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.bashrc; RC_UPDATED=true; }
     fi
 
     if [ "$GO_ACTION" = "install" ]; then


### PR DESCRIPTION
Adds support to install/upgrade go on Linux aarch64
- Rather than add another duplicate install section, I've refactored to generate the URL needed first
- It also ensures bashrc/zshrc is updated if there is already a system go installed, but it's too old
- Rather than arbitrarily updating both bashrc and zshrc, it now checks the running shell and performs an idempotent change (this changes previous behavior, but should be safe)

Tested on macOS arm64, macOS x86_64, Linux aarch64, and Linux x86_64

