### PR TITLE
fix: gemm-common uses SIMD explicitly, so we need to let the rust

### DIFF
--- a/core/.cargo/config.toml
+++ b/core/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=+fp16"]

--- a/core/.cargo/config.toml
+++ b/core/.cargo/config.toml
@@ -1,2 +1,2 @@
 [target.aarch64-unknown-linux-gnu]
-rustflags = ["-C", "target-feature=+fp16"]
+rustflags = ["-C", "target-feature=+fp16,+fullfp16"]


### PR DESCRIPTION
compiler know about this (fixes build errors on some ARM architectures)

The proper fix for this may be to build for specific architectures (not just 'unknown'), but this will make CI/CD more complex. The reality is that SIMD is needed regardless and any fix should belong in gemm-common (see https://github.com/sarah-quinones/gemm/issues/31)
