### PR TITLE
fix: set minimum required Go to 1.22 (which fixes netpoll bugs on con…

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -102,14 +102,14 @@ else
     GO_MAJOR=$(echo $GO_VERSION | cut -d. -f1)
     GO_MINOR=$(echo $GO_VERSION | cut -d. -f2)
 
-    if [ "$GO_MAJOR" -lt 1 ] || ([ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 20 ]); then
-        echo "⚠️  Go version $GO_VERSION is too old (need 1.20+)"
+    if [ "$GO_MAJOR" -lt 1 ] || ([ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 22 ]); then
+        echo "⚠️  Go version $GO_VERSION is too old (need 1.22+)"
         GO_ACTION="upgrade"
     fi
 fi
 
 if [ -n "$GO_ACTION" ]; then
-    GO_VERSION="1.21.13"
+    GO_VERSION="1.22.12"
     echo "📦 Installing Go ${GO_VERSION}..."
 
     case "$OSTYPE" in


### PR DESCRIPTION
…tainerized aarch64)

While no specific known issue could be found, Go 1.22 refactored calls to netpoll() which was causing a crash when building on Linux under Apple Silicon with Go 1.21.

Tested on...
- Darwin/arm64
- Darwin/x86_64
- Linux/x86_64
- Linux/aarch64
- docker/aarch64
