### PR TITLE
fix: don't allow the map to override an explicitly configured model

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cargo install --git https://github.com/Kwaai-AI-Lab/KwaaiNet kwaainet
 | Linux — aarch64 (ARM64) | [kwaainet-aarch64-unknown-linux-gnu.tar.xz](https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/latest/download/kwaainet-aarch64-unknown-linux-gnu.tar.xz) |
 | Windows — x86_64 | [kwaainet-x86_64-pc-windows-msvc.zip](https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/latest/download/kwaainet-x86_64-pc-windows-msvc.zip) |
 
-After installing, run:
+After installing, run (on Windows run as separate commands):
 ```bash
 kwaainet setup && kwaainet benchmark && kwaainet start --daemon
 ```

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -346,8 +346,15 @@ impl KwaaiNetConfig {
         if cfg_file.exists() {
             let text = std::fs::read_to_string(&cfg_file)
                 .with_context(|| format!("reading {}", cfg_file.display()))?;
-            let cfg: KwaaiNetConfig = serde_yaml::from_str(&text)
+            let mut cfg: KwaaiNetConfig = serde_yaml::from_str(&text)
                 .with_context(|| format!("parsing {}", cfg_file.display()))?;
+            // Map-derived fields are only valid for the model that was active when
+            // the map was consulted. If the configured model is an explicit HF path,
+            // clear them so node.rs derives the correct values from the model name.
+            if cfg.model.contains('/') {
+                cfg.model_dht_prefix = None;
+                cfg.model_repository = None;
+            }
             debug!("Loaded config from {}", cfg_file.display());
             Ok(cfg)
         } else {

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -154,12 +154,23 @@ async fn main() -> Result<()> {
                                             mn, choice.server_count
                                         );
                                     }
-                                    if let Some(ref dp) = choice.dht_prefix {
-                                        println!("    DHT prefix: {}", dp);
-                                        cfg.model_dht_prefix = Some(dp.clone());
-                                    }
-                                    if let Some(ref repo) = choice.repository {
-                                        cfg.model_repository = Some(repo.clone());
+                                    // Only adopt the map's DHT prefix and repository when the
+                                    // map selection actually drove the model choice (Ollama ref).
+                                    // For HF models the user configured explicitly, the fallback
+                                    // derivation in node.rs is correct and we must not overwrite
+                                    // it with metadata for a different (Ollama-matched) model.
+                                    if !is_hf_model {
+                                        if let Some(ref dp) = choice.dht_prefix {
+                                            println!("    DHT prefix: {}", dp);
+                                            cfg.model_dht_prefix = Some(dp.clone());
+                                        }
+                                        if let Some(ref repo) = choice.repository {
+                                            cfg.model_repository = Some(repo.clone());
+                                        }
+                                    } else {
+                                        // Clear any stale map-derived values from a previous model.
+                                        cfg.model_dht_prefix = None;
+                                        cfg.model_repository = None;
                                     }
                                     // Persist so the daemon child picks it up.
                                     let _ = cfg.save();


### PR DESCRIPTION
This fixes a problem where the locally configured model is advertised to the map, changed, and then gives the map authority to override config (via model_dht_prefix and model_repository).

Please verify this is what _should_ happen before merging.

Issue repro steps:
1. Changed the model in config
2. Run kwaainet start to publishethis model to the map
3. Changed the model back to unsloth/Llama-3.1-8B-Instruct locally
4. Restart kwaainet

Observed:
1. model_dht_prefix and model_repository are written based on what the map knows (overriding my intentional config change)


