### PR TITLE
setup: add optional build and install of kwaainet CLI after setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -162,8 +162,43 @@ echo "=========================================="
 echo "✅ Setup complete!"
 echo "=========================================="
 echo ""
-echo "Next steps:"
-echo "  1. Build the project: cargo build"
-echo "  2. Run tests: cargo test"
-echo "  3. Run example: cargo run --example petals_visible"
+
+# Optional: build and install kwaainet CLI
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_BIN="${HOME}/.cargo/bin"
+INSTALL_CLI="n"
+if [[ -t 0 ]]; then
+    echo "Build and install the kwaainet CLI to ${INSTALL_BIN}? (y/n)"
+    read -r INSTALL_CLI
+fi
+INSTALL_CLI="$(echo "${INSTALL_CLI}" | tr '[:upper:]' '[:lower:]')"
+
+if [[ "${INSTALL_CLI}" == "y" || "${INSTALL_CLI}" == "yes" ]]; then
+    echo ""
+    echo "Building kwaainet (this may take a few minutes)..."
+    if (cd "${SCRIPT_DIR}/core" && cargo build --release -p kwaainet); then
+        mkdir -p "${INSTALL_BIN}"
+        if cp "${SCRIPT_DIR}/core/target/release/kwaainet" "${INSTALL_BIN}/kwaainet"; then
+            chmod +x "${INSTALL_BIN}/kwaainet"
+            echo "✅ kwaainet installed to ${INSTALL_BIN}/kwaainet"
+            if ! echo ":${PATH}:" | grep -q ":${INSTALL_BIN}:"; then
+                echo "⚠️  Add ${INSTALL_BIN} to your PATH if needed (e.g. in .bashrc: export PATH=\"\${HOME}/.cargo/bin:\${PATH}\")"
+            fi
+            echo "   Run: kwaainet --help"
+        else
+            echo "❌ Failed to copy binary to ${INSTALL_BIN}"
+        fi
+    else
+        echo "❌ Build failed. You can try later with: cd core && cargo build --release -p kwaainet"
+    fi
+    echo ""
+else
+    echo "Skipping CLI install. You can build and run from the repo:"
+    echo "  cd core && cargo build --release -p kwaainet && ./target/release/kwaainet --help"
+    echo ""
+fi
+
+echo "Other next steps:"
+echo "  • Run tests: cd core && cargo test"
+echo "  • Run example: cd core && cargo run --example petals_visible"
 echo ""


### PR DESCRIPTION
Here’s a concise description you can use for a PR or doc:

What we did — KwaaiNet Node Dashboard & Network section
1. Node Dashboard (Web UI)
Location: systems/node-dashboard/
Stack: React (Vite) frontend + Node.js (Express) backend on 127.0.0.1:3456.
Features:
Status — Running/not running, PID, uptime, CPU, memory, shard; Start / Stop / Restart.
Config — View and edit node config (model, blocks, port, etc.) with save.
Logs — Tail of ~/.kwaainet/logs/kwaainet.log with refresh and line count.
Identity — DID, Peer ID, trust tier from kwaainet identity show.
Health monitoring — Enable/Disable and status from kwaainet health-status / health-enable / health-disable.
First-run flow: If ~/.kwaainet/ has no valid config, the UI runs a setup wizard (Initialize → Download p2pd → Benchmark → Start). If a valid config already exists, the wizard is skipped.
Launch: Root scripts start-ui.sh (Linux/macOS) and start-ui.ps1 (Windows); CLI: kwaainet ui (from repo root).
2. CLI changes for the UI
kwaainet ui — Opens the dashboard (starts backend, then browser).
--json on status, config, identity show — Machine-readable output for the dashboard.
3. Health monitoring fixes
Backend uses execFileSync('kwaainet', ['health-enable'|'health-disable']) so the command runs reliably.
Frontend parses API responses safely (no crash on non-JSON); shows errors and refetches state after enable/disable.
4. Network section (bootstrap & reconnect)
New “Network” page in the dashboard:
Bootstrap / map status — Fetches https://map.kwaai.ai/api/v1/state and shows whether the map API (and thus bootstrap visibility) is reachable.
Reconnect P2P — Button that runs kwaainet reconnect (restarts the node to re-establish P2P and retry bootstrap).
Troubleshooting — Short checklist (Reconnect, allow TCP 8000, check logs, link to GitHub troubleshooting doc).
Backend:
GET /api/network-status — Proxies map.kwaai.ai state (e.g. bootstrap_states).
POST /api/reconnect — Runs kwaainet reconnect.
Status page — When the node is running, a line links to the Network page for “Connection or map issues?”.
5. Docs
docs/NODE_UI_PLANNING.md — UI goals, setup flow, data sources, design (Kwaai colours), API map.
docs/DEBUGGING_MAP_VISIBILITY.md — New section: “Bootstrap connect failed” and “Broken pipe (os error 32)” — what they mean and what to check (map API, outbound connectivity, firewall, retry).
systems/node-dashboard/README.md — Purpose, quick start, API list (including network and reconnect).
Root README.md — Link to Node UI planning and how to start the UI (./start-ui.sh or start-ui.ps1).
6. Branches
feature/webb-ui — Web UI and dashboard work (pushed to fork).
feature/network-section — Branch for the Network section (bootstrap status, Reconnect button, troubleshooting); also pushed to fork.
Short one-liner:
We added a local KwaaiNet Node Dashboard (Status, Config, Logs, Identity, Health, first-run setup), a Network section with bootstrap/map status and a Reconnect P2P button, CLI kwaainet ui and --json flags, and troubleshooting docs for bootstrap “Broken pipe” issues.