### PR TITLE
Bugfix/announce addr

### DIFF
--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -194,8 +194,8 @@ async fn main() -> Result<()> {
                 print_separator();
             }
 
-            // Auto-detect public IP if not set
-            if cfg.public_ip.is_none() {
+            // Auto-detect public IP if neither announce_addr nor public_ip is set
+            if cfg.announce_addr.is_none() && cfg.public_ip.is_none() {
                 if let Some(ip) = config::detect_public_ip().await {
                     cfg.public_ip = Some(ip);
                 }

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -183,8 +183,8 @@ async fn main() -> Result<()> {
                 print_separator();
             }
 
-            // Auto-detect public IP if not set
-            if cfg.public_ip.is_none() {
+            // Auto-detect public IP if neither announce_addr nor public_ip is set
+            if cfg.announce_addr.is_none() && cfg.public_ip.is_none() {
                 if let Some(ip) = config::detect_public_ip().await {
                     cfg.public_ip = Some(ip);
                 }

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -443,9 +443,10 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // Determine effective throughput using the Petals formula:
     //   effective_tps = min(compute_tps, network_rps × relay_penalty)
     //   network_rps   = download_bps / (hidden_size × 16)
-    // using_relay: true only if we have no public IP (behind NAT) and relay is allowed.
-    // If a public IP is configured, we're directly reachable — no relay needed.
-    let using_relay = config.public_ip.is_none() && !config.no_relay;
+    // using_relay: true only if we have no reachable address (behind NAT) and relay is allowed.
+    // If a public IP or announce_addr is configured, we're directly reachable — no relay needed.
+    let using_relay =
+        config.public_ip.is_none() && config.announce_addr.is_none() && !config.no_relay;
 
     // Measure network bandwidth once at startup (1 MiB Cloudflare probe).
     // Stored so re-announcements can recompute effective_tps without re-probing.

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -347,15 +347,12 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // Announce address: prefer explicit announce_addr, fall back to public_ip.
     // announce_addr is a raw multiaddr (e.g. /dns/kwaainet/tcp/8080).
     // public_ip is an IP address formatted as /ip4/<ip>/tcp/<port>.
-    let announce_addr = config
-        .announce_addr
-        .clone()
-        .or_else(|| {
-            config
-                .public_ip
-                .as_deref()
-                .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port))
-        });
+    let announce_addr = config.announce_addr.clone().or_else(|| {
+        config
+            .public_ip
+            .as_deref()
+            .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port))
+    });
 
     let identity_key_path = NodeIdentity::key_file_path();
 
@@ -949,13 +946,11 @@ async fn dial_and_wait_for_bootstrap(
     // spurious timeout warning when list_peers() just hasn't caught up yet.
     let mut dialed_ok = false;
     for addr in bootstrap_peers {
-        match tokio::time::timeout(
-            Duration::from_secs(10),
-            client.connect_peer(addr),
-        )
-        .await
-        {
-            Ok(Ok(_)) => { info!("Dialed bootstrap peer {}", addr); dialed_ok = true; }
+        match tokio::time::timeout(Duration::from_secs(10), client.connect_peer(addr)).await {
+            Ok(Ok(_)) => {
+                info!("Dialed bootstrap peer {}", addr);
+                dialed_ok = true;
+            }
             Ok(Err(e)) => warn!("Bootstrap dial failed ({}): {}", addr, e),
             Err(_) => warn!("Bootstrap dial timeout ({}): exceeded 10s", addr),
         }

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -344,11 +344,18 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // p2pd listens for P2P traffic on the configured port
     let host_addr = format!("/ip4/0.0.0.0/tcp/{}", config.port);
 
-    // Announce the public IP so the health monitor can reach us
+    // Announce address: prefer explicit announce_addr, fall back to public_ip.
+    // announce_addr is a raw multiaddr (e.g. /dns/kwaainet/tcp/8080).
+    // public_ip is an IP address formatted as /ip4/<ip>/tcp/<port>.
     let announce_addr = config
-        .public_ip
-        .as_deref()
-        .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port));
+        .announce_addr
+        .clone()
+        .or_else(|| {
+            config
+                .public_ip
+                .as_deref()
+                .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port))
+        });
 
     let identity_key_path = NodeIdentity::key_file_path();
 


### PR DESCRIPTION
This fixes announce_addr, which was never actually read from config.yaml, even though it's added with a default of null

This means that:
- public_ip will be ignored if announce_addr has been set explicitly
- Allows for dev environment testing using an internal/docker network (e.g. by setting announce_addr to /dns/192.168.1.1/tcp/8080)
- No call to https://api.ipify.org is needed and hostnames (not IP addresses) can be used
