### PR TITLE
Feature/public ip

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -112,6 +112,15 @@ pub struct KwaaiNetConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vpk_local_port: Option<u16>,
 
+    /// Minimum number of independent IDENTIFY responses that must report the
+    /// same address before it is accepted as confirmed (default: 2).
+    #[serde(default = "default_identify_min_confirmations")]
+    pub identify_min_confirmations: usize,
+
+    /// How long to poll IDENTIFY for address confirmations, in seconds (default: 10).
+    #[serde(default = "default_identify_timeout_secs")]
+    pub identify_timeout_secs: u64,
+
     // ── Block rebalancing ─────────────────────────────────────────────────────
     /// Enable periodic block rebalancing (only active with `shard serve --auto`).
     /// When true, the shard server periodically checks DHT coverage and moves
@@ -264,6 +273,12 @@ fn default_backoff_multiplier() -> f64 {
 fn default_jitter_factor() -> f64 {
     0.5
 }
+fn default_identify_min_confirmations() -> usize {
+    2
+}
+fn default_identify_timeout_secs() -> u64 {
+    10
+}
 fn default_rebalance_interval() -> u64 {
     300
 }
@@ -297,6 +312,8 @@ impl Default for KwaaiNetConfig {
             vpk_mode: None,
             vpk_endpoint: None,
             vpk_local_port: None,
+            identify_min_confirmations: default_identify_min_confirmations(),
+            identify_timeout_secs: default_identify_timeout_secs(),
             auto_rebalance: false,
             rebalance_interval_secs: default_rebalance_interval(),
             rebalance_min_redundancy: default_rebalance_min_redundancy(),
@@ -455,6 +472,16 @@ impl KwaaiNetConfig {
             "rebalance_min_redundancy" => {
                 self.rebalance_min_redundancy = value.parse().map_err(|_| {
                     anyhow::anyhow!("rebalance_min_redundancy must be a positive integer")
+                })?
+            }
+            "identify_min_confirmations" => {
+                self.identify_min_confirmations = value.parse().map_err(|_| {
+                    anyhow::anyhow!("identify_min_confirmations must be a positive integer")
+                })?
+            }
+            "identify_timeout_secs" => {
+                self.identify_timeout_secs = value.parse().map_err(|_| {
+                    anyhow::anyhow!("identify_timeout_secs must be a positive integer")
                 })?
             }
             _ => anyhow::bail!(

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -474,29 +474,6 @@ fn parse_bool(s: &str) -> Result<bool> {
     }
 }
 
-/// Detect public IP via ipify.org (async).
-pub async fn detect_public_ip() -> Option<String> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .ok()?;
-    let ip = client
-        .get("https://api.ipify.org")
-        .send()
-        .await
-        .ok()?
-        .text()
-        .await
-        .ok()?
-        .trim()
-        .to_string();
-    if ip.is_empty() {
-        None
-    } else {
-        Some(ip)
-    }
-}
-
 mod dirs_sys {
     use std::path::PathBuf;
     pub fn home_dir() -> Option<PathBuf> {

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -194,13 +194,6 @@ async fn main() -> Result<()> {
                 print_separator();
             }
 
-            // Auto-detect public IP if neither announce_addr nor public_ip is set
-            if cfg.announce_addr.is_none() && cfg.public_ip.is_none() {
-                if let Some(ip) = config::detect_public_ip().await {
-                    cfg.public_ip = Some(ip);
-                }
-            }
-
             let mgr = DaemonManager::new();
 
             if mgr.is_running() && !args.concurrent {

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -194,8 +194,8 @@ async fn main() -> Result<()> {
                 print_separator();
             }
 
-            // Auto-detect public IP if not set
-            if cfg.public_ip.is_none() {
+            // Auto-detect public IP if neither announce_addr nor public_ip is set
+            if cfg.announce_addr.is_none() && cfg.public_ip.is_none() {
                 if let Some(ip) = config::detect_public_ip().await {
                     cfg.public_ip = Some(ip);
                 }

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -446,7 +446,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // poll until 2 separate responses agree on the same address, then restart
     // p2pd with that address as its announce addr so map.kwaai.ai can reach us.
     // -----------------------------------------------------------------------
-    let discovered_addrs: Vec<String>;
+    let mut discovered_addrs: Vec<String>;
     if announce_addr.is_none() {
         (daemon, client, discovered_addrs) = discover_and_restart_with_announce(
             daemon,
@@ -620,6 +620,17 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // start_block/blocks when SIGHUP triggers a config re-read.
     let mut config = config.clone();
     let storage_clone = storage.clone();
+
+    // Tracks the number of RPC stream handler tasks currently in-flight.
+    // Used to gate p2pd restarts: we defer any restart until this reaches zero
+    // so we never tear down the daemon mid-request.
+    let active_rpc_streams: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+
+    // When IDENTIFY detects an address change while RPC streams are active we
+    // store the new addresses here and apply the restart at the next reannounce
+    // tick once the node is idle (active_rpc_streams == 0).
+    let mut pending_restart: Option<Vec<String>> = None;
+
     let mut reannounce = tokio::time::interval(Duration::from_secs(120));
     reannounce.tick().await; // skip the immediate first tick
 
@@ -648,10 +659,13 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                     Ok((mut stream, addr)) => {
                         info!("Incoming RPC from {}", addr);
                         let s = storage_clone.clone();
+                        let counter = active_rpc_streams.clone();
+                        counter.fetch_add(1, Ordering::Relaxed);
                         tokio::spawn(async move {
                             if let Err(e) = handle_rpc_stream(&mut stream, s).await {
                                 warn!("RPC handler error: {}", e);
                             }
+                            counter.fetch_sub(1, Ordering::Relaxed);
                         });
                     }
                     Err(e) => warn!("Accept error: {}", e),
@@ -692,6 +706,34 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
 
             // Periodic re-announcement
             _ = reannounce.tick() => {
+                // If IDENTIFY detected an address change while RPC streams were
+                // active, apply the deferred p2pd restart now — but only once
+                // all in-flight RPC handler tasks have completed.
+                if let Some(ref new_addrs) = pending_restart.clone() {
+                    if active_rpc_streams.load(Ordering::Relaxed) > 0 {
+                        info!(
+                            "p2pd restart pending ({} active RPC stream(s)) — will retry next tick",
+                            active_rpc_streams.load(Ordering::Relaxed)
+                        );
+                    } else {
+                        info!("Applying deferred p2pd restart with new announce addr(s):");
+                        for addr in new_addrs {
+                            info!("  {}", addr);
+                        }
+                        if let Err(e) = restart_p2pd(
+                            &mut daemon, &mut client, new_addrs,
+                            &host_addr, &bootstrap_peers, &identity_key_path,
+                            &p2pd_path, &handler_addr, config.no_relay,
+                        ).await {
+                            warn!("Deferred p2pd restart failed: {}", e);
+                        } else {
+                            discovered_addrs = new_addrs.clone();
+                            server_info.using_relay = false;
+                            pending_restart = None;
+                        }
+                    }
+                }
+
                 // Re-read config to pick up start_block changes written by
                 // `shard serve` (via signal_reannounce) or `kwaainet config set`.
                 // On Windows this also drains the reannounce.flag file.
@@ -743,74 +785,19 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             _ = identify_check.tick(), if !explicit_announce => {
                 let fresh = collect_observed_addresses(&mut client, 2, Duration::from_secs(8)).await;
                 if !fresh.is_empty() && fresh != discovered_addrs {
-                    info!("External address changed — restarting p2pd:");
+                    info!("External address changed:");
                     for addr in &discovered_addrs {
                         info!("  old: {}", addr);
                     }
                     for addr in &fresh {
                         info!("  new: {}", addr);
                     }
-                    // Unregister handlers, restart p2pd with new announce addrs.
-                    let _ = client
-                        .remove_stream_handler(
-                            &format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port()),
-                            vec![
-                                "DHTProtocol.rpc_ping".to_string(),
-                                "DHTProtocol.rpc_store".to_string(),
-                                "DHTProtocol.rpc_find".to_string(),
-                            ],
-                        )
-                        .await;
-                    let _ = daemon.shutdown().await;
-
-                    let builder = P2PDaemon::builder()
-                        .dht(true)
-                        .relay(!config.no_relay)
-                        .auto_relay(true)
-                        .auto_nat(true)
-                        .nat_portmap(true)
-                        .host_addrs([host_addr.clone()])
-                        .bootstrap_peers(bootstrap_peers.clone())
-                        .announce_addrs(fresh.iter().map(|s| s.as_str()))
-                        .with_identity_key(&identity_key_path);
-                    let builder = if let Some(ref path) = p2pd_path {
-                        builder.with_binary_path(path)
-                    } else {
-                        builder
-                    };
-                    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
-                        #[cfg(unix)]
-                        let sock_addr = format!("/unix/{}", sock);
-                        #[cfg(not(unix))]
-                        let sock_addr = sock;
-                        builder.with_listen_addr(sock_addr)
-                    } else {
-                        builder
-                    };
-
-                    match builder.spawn().await {
-                        Ok(new_daemon) => {
-                            daemon = new_daemon;
-                            match daemon.client().await {
-                                Ok(new_client) => {
-                                    client = new_client;
-                                    discovered_addrs = fresh;
-                                    server_info.using_relay = false;
-                                    let sb = config.start_block as i32;
-                                    let eb = config.effective_end_block() as i32;
-                                    if let Err(e) = announce(
-                                        &mut client, peer_id, &storage, &bootstrap_peers,
-                                        &prefix, &repository, config.model_total_blocks(),
-                                        sb, eb, &server_info,
-                                    ).await {
-                                        warn!("Re-announce after address change failed: {}", e);
-                                    }
-                                }
-                                Err(e) => warn!("p2pd client reconnect failed: {}", e),
-                            }
-                        }
-                        Err(e) => warn!("p2pd restart failed: {}", e),
-                    }
+                    // Don't restart p2pd immediately — doing so mid-inference would
+                    // tear down active relay circuits and orphan in-flight RPC streams.
+                    // Instead record the new addresses and let the reannounce tick
+                    // apply the restart once the node is idle.
+                    pending_restart = Some(fresh);
+                    info!("  p2pd restart deferred until node is idle");
                 }
             }
 
@@ -1043,6 +1030,86 @@ async fn send_to_bootstrap(
 ///
 /// Explicitly dials each bootstrap peer so p2pd opens the TCP connection
 /// immediately, then polls list_peers() until ≥1 peer is confirmed
+/// Unregister DHT stream handlers, shut down p2pd, rebuild and spawn it with
+/// new announce addresses, reconnect the client, and re-register handlers.
+///
+/// This is the common restart sequence shared by the startup IDENTIFY restart
+/// and the deferred reannounce-tick restart. The only thing that varies between
+/// call sites is `announce_addrs`; all builder flags are fixed.
+///
+/// `remove_stream_handler` failures are non-fatal (daemon may already be
+/// unresponsive). All other failures are returned as `Err` for the caller to
+/// handle at the appropriate severity.
+async fn restart_p2pd(
+    daemon: &mut kwaai_p2p_daemon::P2PDaemon,
+    client: &mut kwaai_p2p_daemon::P2PClient,
+    announce_addrs: &[String],
+    host_addr: &str,
+    bootstrap_peers: &[String],
+    identity_key_path: &std::path::Path,
+    p2pd_path: &Option<std::path::PathBuf>,
+    handler_addr: &std::net::SocketAddr,
+    no_relay: bool,
+) -> anyhow::Result<()> {
+    let handler_addr_str = format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port());
+    let dht_protocols = vec![
+        "DHTProtocol.rpc_ping".to_string(),
+        "DHTProtocol.rpc_store".to_string(),
+        "DHTProtocol.rpc_find".to_string(),
+    ];
+
+    // Unregister handlers before shutdown so the listener port is freed
+    // cleanly before we rebind. Non-fatal if the daemon is already gone.
+    if let Err(e) = client
+        .remove_stream_handler(&handler_addr_str, dht_protocols.clone())
+        .await
+    {
+        warn!("remove_stream_handler before restart: {}", e);
+    }
+    daemon.shutdown().await?;
+
+    let builder = P2PDaemon::builder()
+        .dht(true)
+        .relay(!no_relay)
+        .auto_relay(true)
+        .auto_nat(true)
+        .nat_portmap(true)
+        .host_addrs([host_addr])
+        .bootstrap_peers(bootstrap_peers.to_vec())
+        .announce_addrs(announce_addrs.iter().map(|s| s.as_str()))
+        .with_identity_key(identity_key_path);
+    let builder = if let Some(ref path) = p2pd_path {
+        builder.with_binary_path(path)
+    } else {
+        builder
+    };
+    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
+        #[cfg(unix)]
+        let sock_addr = format!("/unix/{}", sock);
+        #[cfg(not(unix))]
+        let sock_addr = sock;
+        builder.with_listen_addr(sock_addr)
+    } else {
+        builder
+    };
+
+    *daemon = builder.spawn().await.context("restarting p2pd")?;
+    *client = daemon.client().await.context("p2pd client reconnect after restart")?;
+
+    client
+        .register_stream_handler(&handler_addr_str, dht_protocols)
+        .await
+        .context("re-registering stream handlers after restart")?;
+    info!("  p2pd restarted and handlers re-registered");
+
+    Ok(())
+}
+
+/// Apply a deferred p2pd restart if one is pending and the node is idle.
+///
+/// Called from the reannounce tick. If `pending_restart` holds new addresses
+/// and `active_rpc_streams` is zero, delegates to `restart_p2pd` then updates
+/// the caller's mutable state. If streams are still active, logs and returns.
 /// Self-discover external address via IDENTIFY and restart p2pd with announce addrs.
 ///
 /// When no explicit `announce_addr` or `public_ip` is configured, we rely on the
@@ -1085,49 +1152,11 @@ async fn discover_and_restart_with_announce(
         info!("  - {}", addr);
     }
 
-    // Unregister stream handlers before shutting down the daemon so
-    // the RPC listener port is freed before we rebind.
-    let _ = client
-        .remove_stream_handler(
-            &format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port()),
-            vec![
-                "DHTProtocol.rpc_ping".to_string(),
-                "DHTProtocol.rpc_store".to_string(),
-                "DHTProtocol.rpc_find".to_string(),
-            ],
-        )
-        .await;
-    daemon.shutdown().await?;
-
-    // Rebuild the builder with the same settings + announce addrs.
-    let builder = P2PDaemon::builder()
-        .dht(true)
-        .relay(!no_relay)
-        .auto_relay(true)
-        .auto_nat(true)
-        .nat_portmap(true)
-        .host_addrs([host_addr])
-        .bootstrap_peers(bootstrap_peers.to_vec())
-        .announce_addrs(discovered_addrs.iter().map(|s| s.as_str()))
-        .with_identity_key(identity_key_path);
-    let builder = if let Some(ref path) = p2pd_path {
-        builder.with_binary_path(path)
-    } else {
-        builder
-    };
-    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
-        #[cfg(unix)]
-        let sock_addr = format!("/unix/{}", sock);
-        #[cfg(not(unix))]
-        let sock_addr = sock;
-        builder.with_listen_addr(sock_addr)
-    } else {
-        builder
-    };
-
-    daemon = builder.spawn().await.context("restarting p2pd with announce addrs")?;
-    client = daemon.client().await.context("p2pd client (restart)")?;
-    info!("  p2pd restarted with announce addr(s)");
+    restart_p2pd(
+        &mut daemon, &mut client, &discovered_addrs,
+        host_addr, bootstrap_peers, identity_key_path,
+        p2pd_path, handler_addr, no_relay,
+    ).await?;
 
     Ok((daemon, client, discovered_addrs))
 }

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -15,7 +15,14 @@ use kwaai_p2p::NetworkConfig;
 use kwaai_p2p_daemon::{stream, P2PDaemon};
 use libp2p::PeerId;
 use sha1::{Digest, Sha1};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 use tokio::{io::AsyncWriteExt, net::TcpListener, signal, sync::RwLock};
 use tracing::{info, warn};
 
@@ -335,7 +342,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // -----------------------------------------------------------------------
     // Step 1: Start p2pd
     // -----------------------------------------------------------------------
-    info!("[1/5] Starting p2p daemon...");
+    info!("[1/6] Starting p2p daemon...");
     let p2pd_path = find_p2pd_binary();
     if p2pd_path.is_none() {
         eprintln!("  ⚠️  p2pd not found — run `kwaainet setup --get-deps` to install it");
@@ -347,15 +354,12 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // Announce address: prefer explicit announce_addr, fall back to public_ip.
     // announce_addr is a raw multiaddr (e.g. /dns/kwaainet/tcp/8080).
     // public_ip is an IP address formatted as /ip4/<ip>/tcp/<port>.
-    let announce_addr = config
-        .announce_addr
-        .clone()
-        .or_else(|| {
-            config
-                .public_ip
-                .as_deref()
-                .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port))
-        });
+    let announce_addr = config.announce_addr.clone().or_else(|| {
+        config
+            .public_ip
+            .as_deref()
+            .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port))
+    });
 
     let identity_key_path = NodeIdentity::key_file_path();
 
@@ -365,7 +369,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
         .auto_relay(true)
         .auto_nat(true)
         .nat_portmap(true)
-        .host_addrs([host_addr])
+        .host_addrs([host_addr.clone()])
         .bootstrap_peers(bootstrap_peers.clone())
         .with_identity_key(&identity_key_path);
 
@@ -404,13 +408,13 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // -----------------------------------------------------------------------
     // Step 2: DHT storage
     // -----------------------------------------------------------------------
-    info!("[2/5] Initialising DHT storage...");
+    info!("[2/6] Initialising DHT storage...");
     let storage: SharedStorage = Arc::new(RwLock::new(DHTStorage::new(peer_id)));
 
     // -----------------------------------------------------------------------
     // Step 3: Register Hivemind RPC stream handlers with p2pd
     // -----------------------------------------------------------------------
-    info!("[3/5] Registering Hivemind RPC handlers...");
+    info!("[3/6] Registering Hivemind RPC handlers...");
     let handler_listener = TcpListener::bind("127.0.0.1:0")
         .await
         .context("binding RPC handler listener")?;
@@ -432,20 +436,45 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // -----------------------------------------------------------------------
     // Step 4: Wait for DHT bootstrap (intelligent polling)
     // -----------------------------------------------------------------------
-    info!("[4/5] Bootstrapping...");
+    info!("[4/6] Bootstrapping...");
     dial_and_wait_for_bootstrap(&mut client, &bootstrap_peers).await?;
 
     // -----------------------------------------------------------------------
-    // Step 5: Initial DHT announcement
+    // Step 5: Self-discover external address via IDENTIFY (when not manually
+    // configured). After at least one bootstrap peer connects, the libp2p
+    // IDENTIFY protocol lets peers report our observed external address. We
+    // poll until 2 separate responses agree on the same address, then restart
+    // p2pd with that address as its announce addr so map.kwaai.ai can reach us.
     // -----------------------------------------------------------------------
-    info!("[5/5] Announcing to DHT...");
+    let discovered_addrs: Vec<String>;
+    if announce_addr.is_none() {
+        (daemon, client, discovered_addrs) = discover_and_restart_with_announce(
+            daemon,
+            client,
+            &host_addr,
+            &bootstrap_peers,
+            &identity_key_path,
+            &p2pd_path,
+            &handler_addr,
+            config.no_relay,
+        )
+        .await?;
+    } else {
+        discovered_addrs = Vec::new();
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 6: Initial DHT announcement
+    // -----------------------------------------------------------------------
+    info!("[6/6] Announcing to DHT...");
 
     // Determine effective throughput using the Petals formula:
     //   effective_tps = min(compute_tps, network_rps × relay_penalty)
     //   network_rps   = download_bps / (hidden_size × 16)
-    // using_relay: true only if we have no public IP (behind NAT) and relay is allowed.
-    // If a public IP is configured, we're directly reachable — no relay needed.
-    let using_relay = config.public_ip.is_none() && !config.no_relay;
+    // using_relay: true only if we have no explicit address and IDENTIFY
+    // discovery also came up empty. If we confirmed an external address
+    // (directly or via IDENTIFY) we are directly reachable — no relay needed.
+    let using_relay = announce_addr.is_none() && discovered_addrs.is_empty() && !config.no_relay;
 
     // Measure network bandwidth once at startup (1 MiB Cloudflare probe).
     // Stored so re-announcements can recompute effective_tps without re-probing.
@@ -594,6 +623,14 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     let mut reannounce = tokio::time::interval(Duration::from_secs(120));
     reannounce.tick().await; // skip the immediate first tick
 
+    // Periodic IDENTIFY check — only active when no explicit announce_addr is
+    // configured. Every 5 minutes we re-poll our observed addresses; if they
+    // differ from what we announced at startup (e.g. after a network change)
+    // we restart p2pd and trigger an immediate re-announcement.
+    let mut identify_check = tokio::time::interval(Duration::from_secs(300));
+    identify_check.tick().await; // skip the immediate first tick
+    let explicit_announce = announce_addr.is_some();
+
     // SIGHUP handler: shard serve sends SIGHUP after updating config.yaml so
     // the daemon re-announces the new block range immediately (Unix only).
     // On non-Unix this future never resolves — the branch is dead code.
@@ -698,6 +735,82 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                     sb, eb, &server_info,
                 ).await {
                     warn!("Re-announce failed: {}", e);
+                }
+            }
+
+            // Periodic IDENTIFY address check (every 5 minutes).
+            // Skipped when announce_addr/public_ip was explicitly configured.
+            _ = identify_check.tick(), if !explicit_announce => {
+                let fresh = collect_observed_addresses(&mut client, 2, Duration::from_secs(8)).await;
+                if !fresh.is_empty() && fresh != discovered_addrs {
+                    info!("External address changed — restarting p2pd:");
+                    for addr in &discovered_addrs {
+                        info!("  old: {}", addr);
+                    }
+                    for addr in &fresh {
+                        info!("  new: {}", addr);
+                    }
+                    // Unregister handlers, restart p2pd with new announce addrs.
+                    let _ = client
+                        .remove_stream_handler(
+                            &format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port()),
+                            vec![
+                                "DHTProtocol.rpc_ping".to_string(),
+                                "DHTProtocol.rpc_store".to_string(),
+                                "DHTProtocol.rpc_find".to_string(),
+                            ],
+                        )
+                        .await;
+                    let _ = daemon.shutdown().await;
+
+                    let builder = P2PDaemon::builder()
+                        .dht(true)
+                        .relay(!config.no_relay)
+                        .auto_relay(true)
+                        .auto_nat(true)
+                        .nat_portmap(true)
+                        .host_addrs([host_addr.clone()])
+                        .bootstrap_peers(bootstrap_peers.clone())
+                        .announce_addrs(fresh.iter().map(|s| s.as_str()))
+                        .with_identity_key(&identity_key_path);
+                    let builder = if let Some(ref path) = p2pd_path {
+                        builder.with_binary_path(path)
+                    } else {
+                        builder
+                    };
+                    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
+                        #[cfg(unix)]
+                        let sock_addr = format!("/unix/{}", sock);
+                        #[cfg(not(unix))]
+                        let sock_addr = sock;
+                        builder.with_listen_addr(sock_addr)
+                    } else {
+                        builder
+                    };
+
+                    match builder.spawn().await {
+                        Ok(new_daemon) => {
+                            daemon = new_daemon;
+                            match daemon.client().await {
+                                Ok(new_client) => {
+                                    client = new_client;
+                                    discovered_addrs = fresh;
+                                    server_info.using_relay = false;
+                                    let sb = config.start_block as i32;
+                                    let eb = config.effective_end_block() as i32;
+                                    if let Err(e) = announce(
+                                        &mut client, peer_id, &storage, &bootstrap_peers,
+                                        &prefix, &repository, config.model_total_blocks(),
+                                        sb, eb, &server_info,
+                                    ).await {
+                                        warn!("Re-announce after address change failed: {}", e);
+                                    }
+                                }
+                                Err(e) => warn!("p2pd client reconnect failed: {}", e),
+                            }
+                        }
+                        Err(e) => warn!("p2pd restart failed: {}", e),
+                    }
                 }
             }
 
@@ -930,6 +1043,187 @@ async fn send_to_bootstrap(
 ///
 /// Explicitly dials each bootstrap peer so p2pd opens the TCP connection
 /// immediately, then polls list_peers() until ≥1 peer is confirmed
+/// Self-discover external address via IDENTIFY and restart p2pd with announce addrs.
+///
+/// When no explicit `announce_addr` or `public_ip` is configured, we rely on the
+/// libp2p IDENTIFY protocol: after bootstrap peers connect they report our observed
+/// external address back to us. Once 2 independent responses agree we shut the
+/// initial p2pd down, rebuild it with the confirmed address as its announce addr,
+/// and return the new daemon + client along with the discovered addresses.
+///
+/// If IDENTIFY yields nothing the original daemon is returned unchanged and the
+/// returned address list is empty (the node will fall back to relay mode).
+async fn discover_and_restart_with_announce(
+    mut daemon: kwaai_p2p_daemon::P2PDaemon,
+    mut client: kwaai_p2p_daemon::P2PClient,
+    host_addr: &str,
+    bootstrap_peers: &[String],
+    identity_key_path: &std::path::Path,
+    p2pd_path: &Option<std::path::PathBuf>,
+    handler_addr: &std::net::SocketAddr,
+    no_relay: bool,
+) -> anyhow::Result<(
+    kwaai_p2p_daemon::P2PDaemon,
+    kwaai_p2p_daemon::P2PClient,
+    Vec<String>,
+)> {
+    info!("No explicit announce address — discovering via IDENTIFY...");
+    let discovered_addrs =
+        collect_observed_addresses(&mut client, 2, Duration::from_secs(10)).await;
+
+    if discovered_addrs.is_empty() {
+        warn!(
+            "⚠️ Could not confirm external address via IDENTIFY \
+             — node may appear Unreachable on map.kwaai.ai. \
+             Set public_ip or announce_addr in config to override."
+        );
+        return Ok((daemon, client, discovered_addrs));
+    }
+
+    info!("Confirmed external address(es) — restarting p2pd with announce addrs:");
+    for addr in &discovered_addrs {
+        info!("  - {}", addr);
+    }
+
+    // Unregister stream handlers before shutting down the daemon so
+    // the RPC listener port is freed before we rebind.
+    let _ = client
+        .remove_stream_handler(
+            &format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port()),
+            vec![
+                "DHTProtocol.rpc_ping".to_string(),
+                "DHTProtocol.rpc_store".to_string(),
+                "DHTProtocol.rpc_find".to_string(),
+            ],
+        )
+        .await;
+    daemon.shutdown().await?;
+
+    // Rebuild the builder with the same settings + announce addrs.
+    let builder = P2PDaemon::builder()
+        .dht(true)
+        .relay(!no_relay)
+        .auto_relay(true)
+        .auto_nat(true)
+        .nat_portmap(true)
+        .host_addrs([host_addr])
+        .bootstrap_peers(bootstrap_peers.to_vec())
+        .announce_addrs(discovered_addrs.iter().map(|s| s.as_str()))
+        .with_identity_key(identity_key_path);
+    let builder = if let Some(ref path) = p2pd_path {
+        builder.with_binary_path(path)
+    } else {
+        builder
+    };
+    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
+        #[cfg(unix)]
+        let sock_addr = format!("/unix/{}", sock);
+        #[cfg(not(unix))]
+        let sock_addr = sock;
+        builder.with_listen_addr(sock_addr)
+    } else {
+        builder
+    };
+
+    daemon = builder.spawn().await.context("restarting p2pd with announce addrs")?;
+    client = daemon.client().await.context("p2pd client (restart)")?;
+    info!("  p2pd restarted with announce addr(s)");
+
+    Ok((daemon, client, discovered_addrs))
+}
+
+/// Poll `identify_with_addrs()` until `min_confirmations` separate responses
+/// all include the same public multiaddr, or `timeout` elapses.
+///
+/// Returns the confirmed public addresses as multiaddr strings (e.g.
+/// `/ip4/203.0.113.1/tcp/8080`). Private/loopback addresses are filtered out.
+///
+/// "Confirmation" here means the address appeared in at least
+/// `min_confirmations` distinct IDENTIFY responses. p2pd refreshes its
+/// observed-address list as more bootstrap peers connect and run IDENTIFY, so
+/// polling with a short interval naturally accumulates multiple independent
+/// observations.
+async fn collect_observed_addresses(
+    client: &mut kwaai_p2p_daemon::P2PClient,
+    min_confirmations: usize,
+    timeout: Duration,
+) -> Vec<String> {
+    use libp2p::Multiaddr;
+    use std::collections::HashMap;
+
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut counts: HashMap<String, usize> = HashMap::new();
+
+    loop {
+        match client.identify_with_addrs().await {
+            Ok((_peer_id, addrs)) => {
+                for addr_bytes in &addrs {
+                    // Parse as libp2p Multiaddr so we can inspect the components.
+                    if let Ok(ma) = Multiaddr::try_from(addr_bytes.clone()) {
+                        let s = ma.to_string();
+                        if is_public_multiaddr(&ma) {
+                            *counts.entry(s).or_insert(0) += 1;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::debug!("identify_with_addrs error: {}", e);
+            }
+        }
+
+        let confirmed: Vec<String> = counts
+            .iter()
+            .filter(|(_, &c)| c >= min_confirmations)
+            .map(|(addr, _)| addr.clone())
+            .collect();
+
+        if !confirmed.is_empty() {
+            return confirmed;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            // Return whatever we have (even unconfirmed) as a best-effort
+            // fallback if we got at least one observation.
+            let best_effort: Vec<String> = counts.into_keys().collect();
+            if !best_effort.is_empty() {
+                tracing::warn!(
+                    "IDENTIFY: could not get {} confirmations within {:?}; \
+                     using best-effort address(es): {:?}",
+                    min_confirmations,
+                    timeout,
+                    best_effort
+                );
+            }
+            return best_effort;
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+/// Returns true if the multiaddr represents a publicly routable address.
+/// Filters out loopback, RFC-1918 private ranges, and link-local.
+fn is_public_multiaddr(ma: &libp2p::Multiaddr) -> bool {
+    use libp2p::multiaddr::Protocol;
+    for proto in ma.iter() {
+        match proto {
+            Protocol::Ip4(ip) => {
+                return !ip.is_loopback()
+                    && !ip.is_private()
+                    && !ip.is_link_local()
+                    && !ip.is_unspecified();
+            }
+            Protocol::Ip6(ip) => {
+                return !ip.is_loopback() && !ip.is_unspecified();
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Dial bootstrap peers and poll `list_peers()` until at least one is
 /// connected or the 30 s timeout expires. Called once at startup only —
 /// subsequent re-announcements use send_to_bootstrap() directly.
 async fn dial_and_wait_for_bootstrap(

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -344,11 +344,18 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // p2pd listens for P2P traffic on the configured port
     let host_addr = format!("/ip4/0.0.0.0/tcp/{}", config.port);
 
-    // Announce the public IP so the health monitor can reach us
+    // Announce address: prefer explicit announce_addr, fall back to public_ip.
+    // announce_addr is a raw multiaddr (e.g. /dns/kwaainet/tcp/8080).
+    // public_ip is an IP address formatted as /ip4/<ip>/tcp/<port>.
     let announce_addr = config
-        .public_ip
-        .as_deref()
-        .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port));
+        .announce_addr
+        .clone()
+        .or_else(|| {
+            config
+                .public_ip
+                .as_deref()
+                .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port))
+        });
 
     let identity_key_path = NodeIdentity::key_file_path();
 

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -440,11 +440,11 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     dial_and_wait_for_bootstrap(&mut client, &bootstrap_peers).await?;
 
     // -----------------------------------------------------------------------
-    // Step 5: Self-discover external address via IDENTIFY (when not manually
+    // Step 5: Self-discover announce addresses via IDENTIFY (when not manually
     // configured). After at least one bootstrap peer connects, the libp2p
-    // IDENTIFY protocol lets peers report our observed external address. We
-    // poll until 2 separate responses agree on the same address, then restart
-    // p2pd with that address as its announce addr so map.kwaai.ai can reach us.
+    // IDENTIFY protocol lets peers report our observed addresses. We poll until
+    // min_confirmations separate responses agree on the same address, then
+    // restart p2pd with those addresses as its announce addrs.
     // -----------------------------------------------------------------------
     let mut discovered_addrs: Vec<String>;
     if announce_addr.is_none() {
@@ -457,6 +457,9 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             &p2pd_path,
             &handler_addr,
             config.no_relay,
+            config.port,
+            config.identify_min_confirmations,
+            config.identify_timeout_secs,
         )
         .await?;
     } else {
@@ -472,7 +475,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     //   effective_tps = min(compute_tps, network_rps × relay_penalty)
     //   network_rps   = download_bps / (hidden_size × 16)
     // using_relay: true only if we have no explicit address and IDENTIFY
-    // discovery also came up empty. If we confirmed an external address
+    // discovery also came up empty. If we have confirmed announce addresses
     // (directly or via IDENTIFY) we are directly reachable — no relay needed.
     let using_relay = announce_addr.is_none() && discovered_addrs.is_empty() && !config.no_relay;
 
@@ -783,9 +786,15 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             // Periodic IDENTIFY address check (every 5 minutes).
             // Skipped when announce_addr/public_ip was explicitly configured.
             _ = identify_check.tick(), if !explicit_announce => {
-                let fresh = collect_observed_addresses(&mut client, 2, Duration::from_secs(8)).await;
-                if !fresh.is_empty() && fresh != discovered_addrs {
-                    info!("External address changed:");
+                info!("Checking announce addresses via IDENTIFY...");
+                let fresh = collect_observed_addresses(&mut client, config.identify_min_confirmations, Duration::from_secs(config.identify_timeout_secs), config.port).await;
+                info!("  IDENTIFY result: {} addr(s) confirmed", fresh.len());
+                let mut fresh_sorted = fresh.clone();
+                let mut current_sorted = discovered_addrs.clone();
+                fresh_sorted.sort();
+                current_sorted.sort();
+                if !fresh_sorted.is_empty() && fresh_sorted != current_sorted {
+                    info!("Announce addresses changed:");
                     for addr in &discovered_addrs {
                         info!("  old: {}", addr);
                     }
@@ -1094,13 +1103,16 @@ async fn restart_p2pd(
     };
 
     *daemon = builder.spawn().await.context("restarting p2pd")?;
-    *client = daemon.client().await.context("p2pd client reconnect after restart")?;
+    *client = daemon
+        .client()
+        .await
+        .context("p2pd client reconnect after restart")?;
 
     client
         .register_stream_handler(&handler_addr_str, dht_protocols)
         .await
         .context("re-registering stream handlers after restart")?;
-    info!("  p2pd restarted and handlers re-registered");
+    info!("p2pd restarted and handlers re-registered");
 
     Ok(())
 }
@@ -1110,13 +1122,13 @@ async fn restart_p2pd(
 /// Called from the reannounce tick. If `pending_restart` holds new addresses
 /// and `active_rpc_streams` is zero, delegates to `restart_p2pd` then updates
 /// the caller's mutable state. If streams are still active, logs and returns.
-/// Self-discover external address via IDENTIFY and restart p2pd with announce addrs.
+/// Discover observed addresses via IDENTIFY and restart p2pd with them.
 ///
 /// When no explicit `announce_addr` or `public_ip` is configured, we rely on the
 /// libp2p IDENTIFY protocol: after bootstrap peers connect they report our observed
-/// external address back to us. Once 2 independent responses agree we shut the
-/// initial p2pd down, rebuild it with the confirmed address as its announce addr,
-/// and return the new daemon + client along with the discovered addresses.
+/// addresses back to us. Once `min_confirmations` independent responses agree we
+/// shut the initial p2pd down, rebuild it with the confirmed addresses as its
+/// announce addrs, and return the new daemon + client along with those addresses.
 ///
 /// If IDENTIFY yields nothing the original daemon is returned unchanged and the
 /// returned address list is empty (the node will fall back to relay mode).
@@ -1129,43 +1141,64 @@ async fn discover_and_restart_with_announce(
     p2pd_path: &Option<std::path::PathBuf>,
     handler_addr: &std::net::SocketAddr,
     no_relay: bool,
+    port: u16,
+    min_confirmations: usize,
+    timeout_secs: u64,
 ) -> anyhow::Result<(
     kwaai_p2p_daemon::P2PDaemon,
     kwaai_p2p_daemon::P2PClient,
     Vec<String>,
 )> {
-    info!("No explicit announce address — discovering via IDENTIFY...");
-    let discovered_addrs =
-        collect_observed_addresses(&mut client, 2, Duration::from_secs(10)).await;
+    info!("No explicit announce address — discovering addresses via IDENTIFY...");
+
+    // Give bootstrap peer(s) a moment to complete the IDENTIFY exchange before
+    // polling. The TCP connection is established by the time we're called, but
+    // IDENTIFY runs asynchronously after it.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let discovered_addrs = collect_observed_addresses(
+        &mut client,
+        min_confirmations,
+        Duration::from_secs(timeout_secs),
+        port,
+    )
+    .await;
 
     if discovered_addrs.is_empty() {
         warn!(
-            "⚠️ Could not confirm external address via IDENTIFY \
+            "⚠️ Could not confirm any announce addresses via IDENTIFY \
              — node may appear Unreachable on map.kwaai.ai. \
              Set public_ip or announce_addr in config to override."
         );
         return Ok((daemon, client, discovered_addrs));
     }
 
-    info!("Confirmed external address(es) — restarting p2pd with announce addrs:");
+    info!("Confirmed announce address(es) — restarting p2pd:");
     for addr in &discovered_addrs {
         info!("  - {}", addr);
     }
 
     restart_p2pd(
-        &mut daemon, &mut client, &discovered_addrs,
-        host_addr, bootstrap_peers, identity_key_path,
-        p2pd_path, handler_addr, no_relay,
-    ).await?;
+        &mut daemon,
+        &mut client,
+        &discovered_addrs,
+        host_addr,
+        bootstrap_peers,
+        identity_key_path,
+        p2pd_path,
+        handler_addr,
+        no_relay,
+    )
+    .await?;
 
     Ok((daemon, client, discovered_addrs))
 }
 
 /// Poll `identify_with_addrs()` until `min_confirmations` separate responses
-/// all include the same public multiaddr, or `timeout` elapses.
+/// all include the same multiaddr, or `timeout` elapses.
 ///
-/// Returns the confirmed public addresses as multiaddr strings (e.g.
-/// `/ip4/203.0.113.1/tcp/8080`). Private/loopback addresses are filtered out.
+/// Returns the confirmed addresses as multiaddr strings (e.g.
+/// `/ip4/203.0.113.1/tcp/8080`). Unspecified and link-local addresses are
+/// filtered out; private/loopback addresses are included.
 ///
 /// "Confirmation" here means the address appeared in at least
 /// `min_confirmations` distinct IDENTIFY responses. p2pd refreshes its
@@ -1176,80 +1209,116 @@ async fn collect_observed_addresses(
     client: &mut kwaai_p2p_daemon::P2PClient,
     min_confirmations: usize,
     timeout: Duration,
+    port: u16,
 ) -> Vec<String> {
     use libp2p::Multiaddr;
     use std::collections::HashMap;
 
+    // Poll for the full timeout window so every address has an equal chance
+    // to accumulate confirmations. Returning early as soon as any address hits
+    // the threshold causes addresses that appear later (e.g. the public IP
+    // observed by the second bootstrap peer) to be dropped.
     let deadline = tokio::time::Instant::now() + timeout;
     let mut counts: HashMap<String, usize> = HashMap::new();
 
     loop {
         match client.identify_with_addrs().await {
             Ok((_peer_id, addrs)) => {
+                tracing::debug!("IDENTIFY returned {} addr(s)", addrs.len());
                 for addr_bytes in &addrs {
-                    // Parse as libp2p Multiaddr so we can inspect the components.
                     if let Ok(ma) = Multiaddr::try_from(addr_bytes.clone()) {
                         let s = ma.to_string();
-                        if is_public_multiaddr(&ma) {
-                            *counts.entry(s).or_insert(0) += 1;
+                        if let Some(normalized) = normalize_announce_addr(&ma, port) {
+                            let count = counts.entry(normalized.clone()).or_insert(0);
+                            *count += 1;
+                            tracing::debug!("  addr={} → {} ({}x)", s, normalized, count);
+                        } else {
+                            tracing::debug!("  addr={} → filtered", s);
                         }
                     }
                 }
             }
-            Err(e) => {
-                tracing::debug!("identify_with_addrs error: {}", e);
-            }
-        }
-
-        let confirmed: Vec<String> = counts
-            .iter()
-            .filter(|(_, &c)| c >= min_confirmations)
-            .map(|(addr, _)| addr.clone())
-            .collect();
-
-        if !confirmed.is_empty() {
-            return confirmed;
+            Err(e) => tracing::debug!("identify_with_addrs error: {}", e),
         }
 
         if tokio::time::Instant::now() >= deadline {
-            // Return whatever we have (even unconfirmed) as a best-effort
-            // fallback if we got at least one observation.
-            let best_effort: Vec<String> = counts.into_keys().collect();
-            if !best_effort.is_empty() {
-                tracing::warn!(
-                    "IDENTIFY: could not get {} confirmations within {:?}; \
-                     using best-effort address(es): {:?}",
-                    min_confirmations,
-                    timeout,
-                    best_effort
-                );
-            }
-            return best_effort;
+            break;
         }
 
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+
+    let confirmed: Vec<String> = counts
+        .into_iter()
+        .filter(|(_, c)| *c >= min_confirmations)
+        .map(|(addr, _)| addr)
+        .collect();
+
+    if confirmed.is_empty() {
+        tracing::warn!(
+            "IDENTIFY: no addresses reached {} confirmation(s) within {:?}",
+            min_confirmations,
+            timeout,
+        );
+    }
+
+    confirmed
 }
 
-/// Returns true if the multiaddr represents a publicly routable address.
-/// Filters out loopback, RFC-1918 private ranges, and link-local.
-fn is_public_multiaddr(ma: &libp2p::Multiaddr) -> bool {
+/// Normalise a multiaddr from `host.Addrs()` into an announce address, or
+/// return `None` if it should be filtered.
+///
+/// `host.Addrs()` contains two kinds of entries:
+///   - Our own listen addresses (loopback, LAN) — always on `our_port`.
+///   - Peer-observed addresses from the libp2p IDENTIFY protocol — our IP as
+///     seen by the peer, but with an ephemeral source port because they were
+///     recorded from our outbound TCP connections to those peers.
+///
+/// Private and loopback addresses are accepted as-is — `host.Addrs()` only
+/// ever contains our own interfaces for these ranges, so no port filter is
+/// needed.
+///
+/// Unspecified (`0.0.0.0`/`::`) and link-local addresses are rejected.
+/// Addresses with no TCP component are rejected.
+fn normalize_announce_addr(ma: &libp2p::Multiaddr, our_port: u16) -> Option<String> {
     use libp2p::multiaddr::Protocol;
+    use std::net::IpAddr;
+
+    let mut ip: Option<IpAddr> = None;
+    let mut has_tcp = false;
+
     for proto in ma.iter() {
         match proto {
-            Protocol::Ip4(ip) => {
-                return !ip.is_loopback()
-                    && !ip.is_private()
-                    && !ip.is_link_local()
-                    && !ip.is_unspecified();
+            Protocol::Ip4(a) => {
+                if a.is_unspecified() || a.is_link_local() {
+                    return None;
+                }
+                ip = Some(IpAddr::V4(a));
             }
-            Protocol::Ip6(ip) => {
-                return !ip.is_loopback() && !ip.is_unspecified();
+            Protocol::Ip6(a) => {
+                if a.is_unspecified() {
+                    return None;
+                }
+                ip = Some(IpAddr::V6(a));
             }
+            Protocol::Tcp(_) => has_tcp = true,
             _ => {}
         }
     }
-    false
+
+    let ip = ip?;
+    if !has_tcp {
+        return None;
+    }
+
+    // Always announce on our_port. For peer-observed addresses the port is
+    // ephemeral (outbound NAT mapping) and must be replaced. For listen
+    // addresses our_port is already correct.
+    let normalized = match ip {
+        IpAddr::V4(a) => format!("/ip4/{}/tcp/{}", a, our_port),
+        IpAddr::V6(a) => format!("/ip6/{}/tcp/{}", a, our_port),
+    };
+    Some(normalized)
 }
 
 /// Dial bootstrap peers and poll `list_peers()` until at least one is

--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -263,6 +263,16 @@ impl P2PClient {
     ///
     /// Returns the peer ID as hex-encoded string
     pub async fn identify(&mut self) -> Result<String> {
+        let (peer_id, _) = self.identify_with_addrs().await?;
+        Ok(peer_id)
+    }
+
+    /// Send an IDENTIFY request and return both the peer ID and observed multiaddrs.
+    ///
+    /// Returns `(peer_id_hex, addrs)` where `addrs` is the list of multiaddr bytes
+    /// that p2pd has observed for itself (populated by the libp2p IDENTIFY protocol
+    /// as peers connect and report our external address).
+    pub async fn identify_with_addrs(&mut self) -> Result<(String, Vec<Vec<u8>>)> {
         let request = Request {
             r#type: request::Type::Identify as i32,
             connect: None,
@@ -278,9 +288,8 @@ impl P2PClient {
         let response = self.send_request(request).await?;
 
         if let Some(id) = response.identify {
-            // Peer ID is binary data, encode as hex for display
             let peer_id = hex::encode(&id.id);
-            Ok(peer_id)
+            Ok((peer_id, id.addrs))
         } else {
             Err(Error::InvalidResponse(
                 "Expected IDENTIFY response".to_string(),

--- a/docs/IP_DISCOVERY.md
+++ b/docs/IP_DISCOVERY.md
@@ -1,0 +1,164 @@
+# IP Address Discovery and p2pd Restart Safety
+
+This document explains how a KwaaiNet node discovers its public IP address, how
+that address propagates to `map.kwaai.ai`, and the safety mechanism that
+prevents p2pd restarts from disrupting in-flight inference.
+
+---
+
+## Overview
+
+For a node to appear **Online** on the map and be reachable for PING/FIND
+operations, the Hivemind DHT record for that node must contain a publicly
+routable multiaddr. There are three ways this address can be established,
+in priority order:
+
+| Priority | Source | Config field | Behaviour |
+|----------|--------|--------------|-----------|
+| 1 | Manual multiaddr | `announce_addr` | Passed directly to p2pd at startup; no discovery needed |
+| 2 | Manual IP | `public_ip` | Formatted as `/ip4/<ip>/tcp/<port>` and passed to p2pd |
+| 3 | **IDENTIFY (default)** | _(neither set)_ | p2pd starts with no announce addr; address discovered dynamically |
+
+When neither `announce_addr` nor `public_ip` is set the node relies entirely
+on the IDENTIFY-based discovery path described below.
+
+---
+
+## Phase 1 — p2pd starts without an announce address
+
+p2pd is spawned with only a host listen address (`/ip4/0.0.0.0/tcp/<port>`).
+At this point the daemon has no knowledge of its public address and will not
+advertise one in DHT records.
+
+## Phase 2 — DHT bootstrap
+
+The node dials each configured bootstrap peer and waits until at least one
+connection is confirmed. Bootstrap peers are the entry point into the Hivemind
+DHT and are also the peers that will run the IDENTIFY protocol with us.
+
+## Phase 3 — IDENTIFY polling (external address discovery)
+
+Once a bootstrap peer is connected, the libp2p
+[IDENTIFY protocol](https://github.com/libp2p/specs/blob/master/identify/README.md)
+fires automatically. Each peer that connects reports back what address it
+_observed_ us connecting from — i.e., our public IP and port as seen from the
+internet.
+
+`collect_observed_addresses()` polls `identify_with_addrs()` in a loop,
+filtering out private/loopback addresses. It requires **two independent
+confirmations** from distinct peers before accepting an address as authoritative.
+This guards against a single rogue or misconfigured peer reporting a wrong
+address.
+
+```
+Bootstrap peer A  ──identify──▶  "I see you at /ip4/203.0.113.1/tcp/8080"
+Bootstrap peer B  ──identify──▶  "I see you at /ip4/203.0.113.1/tcp/8080"
+                                                          ↓
+                                              2 confirmations → accepted
+```
+
+Polling runs for up to 10 seconds. If no confirmed address is found within that
+window a warning is logged and the node falls back to relay mode.
+
+## Phase 4 — p2pd restart with announce address
+
+Once the address is confirmed, p2pd is restarted with the discovered multiaddr
+passed as its `--announceAddr` flag. This causes p2pd to include the address in
+all DHT advertisements and IDENTIFY responses going forward.
+
+Before shutdown, DHT stream handlers (`DHTProtocol.rpc_ping/store/find`) are
+explicitly unregistered so the listener port is freed cleanly. After the new
+p2pd starts the handlers are re-registered with the new client.
+
+**The startup restart (Step 5)** happens before the event loop begins, so no
+inference traffic can be in-flight at this point.
+
+## Phase 5 — DHT announcement
+
+With p2pd now advertising the correct address, the node announces itself to the
+DHT. `map.kwaai.ai` reads these records and marks the node **Online**. PING and
+FIND operations from other peers now route to the correct address.
+
+---
+
+## Periodic address refresh
+
+Network conditions change — DHCP leases expire, NAT mappings shift, the node
+moves between networks. Every 5 minutes (when running without an explicit
+`announce_addr`) the node re-runs IDENTIFY polling with the same 2-confirmation
+requirement.
+
+If the observed address has changed a **deferred restart** is scheduled (see
+below). If the address is unchanged nothing happens.
+
+---
+
+## Deferred restart safety mechanism
+
+### The problem
+
+Restarting p2pd tears down:
+
+- All active peer connections and relay circuits
+- DHT handler registrations (these must be re-registered after restart)
+- Any libp2p streams currently being forwarded
+
+If a p2pd restart fires during an in-flight inference request the stream
+carrying that request is torn down. The coordinator's retry logic handles
+this, but the disruption is unnecessary and wastes KV-cache state on the
+downstream shard.
+
+### The solution
+
+When IDENTIFY detects an address change inside the event loop, the new
+addresses are stored in `pending_restart` rather than triggering an immediate
+restart:
+
+```
+IDENTIFY tick  →  address changed  →  pending_restart = Some(new_addrs)
+                                       (log: "restart deferred until idle")
+```
+
+At the next **reannounce tick** (every 120 seconds), before the regular DHT
+announcement, the event loop checks two conditions:
+
+1. `pending_restart` is `Some(_)` — there is a restart waiting
+2. `active_rpc_streams == 0` — no DHT RPC handler tasks are currently running
+
+If both are true the restart proceeds. If streams are still active the tick logs
+the count and tries again at the next tick.
+
+```
+Reannounce tick
+  ├─ pending_restart? yes
+  ├─ active_rpc_streams? 0  ──▶  restart p2pd now
+  │                               re-register handlers
+  │                               pending_restart = None
+  │                               continue with normal re-announce
+  └─ active_rpc_streams? N  ──▶  log "N stream(s) active, retrying next tick"
+```
+
+`active_rpc_streams` is an `Arc<AtomicUsize>` incremented when `accept()`
+returns a new stream and decremented when the spawned handler task completes.
+
+### What this guarantees
+
+- A restart will never fire while a DHT RPC (ping/store/find) is in progress.
+- Restarts are applied within at most `120 + 300 = 420 seconds` of an address
+  change in the worst case (IDENTIFY fires at the end of its 5-minute window,
+  all streams happen to be active for the next full 120-second reannounce
+  interval).
+- Handler re-registration always happens as part of the restart, eliminating
+  the previous bug where handlers were lost after a periodic restart.
+
+---
+
+## Remaining risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `shard serve` inference stream torn down by startup restart (Step 5) | Low — startup precedes inference | `shard serve` is a separate process; its handler survives p2pd restart. The coordinator retries on stream error. |
+| Relay circuit torn down mid-inference (relay-mode nodes only) | Low — only affects nodes with no confirmed public address | Direct-reachable nodes are unaffected. Relay nodes already tolerate circuit loss. |
+| Address change goes undetected if IDENTIFY peers are slow | Medium | 10-second timeout at startup; 8-second timeout on periodic checks. Bootstrap peers are expected to be stable. |
+| Node stays on stale address longer than expected if always busy | Low | In practice DHT RPC streams complete in milliseconds. Sustained load would need to span multiple 120-second ticks. |
+| `announce_addr` or `public_ip` set but wrong (manual misconfiguration) | User error | IDENTIFY path is bypassed entirely when either field is set. The node relies on the user-provided value. |


### PR DESCRIPTION
**New Feature**
Implements announce IP address auto-discovery by using p2p's IDENTIFY protocol
- public_ip and announce_address must be null (otherwise they will be used as a manual override)
- At least 2 confirmations (config: identify_min_confirmations) of an observed address must be seen before it is accepted
- A timeout of 10s (config: identify_timeout_secs) for address discovery results to come in
- Loopback and any internal network addresses will be confirmed (it's typical that a node will have 3x announce addresses)
- Initially, p2pd is started without any announce addresses. Later, it will be restarted once addresses have been found (this is an unavoidable chicken-and-egg with p2pd)
- Rediscovery occurs every 5 minutes (in case, e.g. DHCP or BGP change an observed IP address)
- The number of RPC streams is now tracked and p2pd restarts are deferred until the count reaches zero
- The call to ipify.org is no longer needed and has been removed

**Risks**
- If observed addresses keep changing (e.g. round robin routing behavior), then p2pd could restart every 5 minutes
- An increase in P2P connections when p2pd first starts and then later restarts

**Possible TODO**
Confirmed IP addresses could be saved locally to avoid a p2pd restart if kwaainet itself is restarted