### PR TITLE
Network bootstrapping fixes

### DIFF
--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -360,9 +360,11 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
         .relay(!config.no_relay)
         .auto_relay(true)
         .auto_nat(true)
+        .force_reachability_private(announce_addr.is_none() && !config.no_relay)
         .nat_portmap(true)
         .host_addrs([host_addr])
         .bootstrap_peers(bootstrap_peers.clone())
+        .trusted_relays(bootstrap_peers.clone())
         .with_identity_key(&identity_key_path);
 
     let builder = if let Some(ref addr) = announce_addr {

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -344,10 +344,12 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // p2pd listens for P2P traffic on the configured port
     let host_addr = format!("/ip4/0.0.0.0/tcp/{}", config.port);
 
-    // Announce the public IP so the health monitor can reach us
+    // Announce the public IP so the health monitor can reach us.
+    // An empty string means "no public IP" (disables auto-detected announce).
     let announce_addr = config
         .public_ip
         .as_deref()
+        .filter(|ip| !ip.is_empty())
         .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port));
 
     let identity_key_path = NodeIdentity::key_file_path();
@@ -449,7 +451,11 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     //   network_rps   = download_bps / (hidden_size × 16)
     // using_relay: true only if we have no public IP (behind NAT) and relay is allowed.
     // If a public IP is configured, we're directly reachable — no relay needed.
-    let using_relay = config.public_ip.is_none() && !config.no_relay;
+    let has_public_ip = config
+        .public_ip
+        .as_deref()
+        .is_some_and(|ip| !ip.is_empty());
+    let using_relay = !has_public_ip && !config.no_relay;
 
     // Measure network bandwidth once at startup (1 MiB Cloudflare probe).
     // Stored so re-announcements can recompute effective_tps without re-probing.

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -354,6 +354,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
 
     let builder = P2PDaemon::builder()
         .dht(true)
+        .bootstrap(!bootstrap_peers.is_empty())
         .relay(!config.no_relay)
         .auto_relay(true)
         .auto_nat(true)

--- a/core/crates/kwaai-p2p-daemon/src/daemon.rs
+++ b/core/crates/kwaai-p2p-daemon/src/daemon.rs
@@ -27,6 +27,8 @@ pub struct DaemonBuilder {
     nat_portmap: bool,
     host_addrs: Vec<String>,
     announce_addrs: Vec<String>,
+    trusted_relays: Vec<String>,
+    force_reachability_private: bool,
     metrics: bool,
     metrics_addr: Option<String>,
     /// Path to a protobuf-encoded Ed25519 private key file (`-id` flag).
@@ -101,6 +103,30 @@ impl DaemonBuilder {
     {
         self.announce_addrs
             .extend(addrs.into_iter().map(|s| s.into()));
+        self
+    }
+
+    /// Set trusted relay peers for AutoRelay (`-trustedRelays` flag)
+    ///
+    /// These peers are tried as circuit relay servers. Typically the bootstrap
+    /// peers, which run with `-relay=1 -relayService=1`.
+    pub fn trusted_relays<I, S>(mut self, relays: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.trusted_relays
+            .extend(relays.into_iter().map(|s| s.into()));
+        self
+    }
+
+    /// Force the node to be treated as behind NAT (`-forceReachabilityPrivate`)
+    ///
+    /// Skips AutoNAT probing and immediately activates AutoRelay to obtain
+    /// relay circuit addresses. Without this, a NATed node must wait for 3+
+    /// peers to probe it — which may never happen in small networks.
+    pub fn force_reachability_private(mut self, enable: bool) -> Self {
+        self.force_reachability_private = enable;
         self
     }
 
@@ -215,11 +241,22 @@ impl DaemonBuilder {
         // AutoRelay (this node uses relay servers when behind NAT)
         if self.auto_relay {
             cmd.arg("-autoRelay");
+            // Use static trusted relays instead of DHT-based relay discovery
+            // when trusted relays are configured. DHT discovery requires a
+            // populated routing table which NATed nodes may not have.
+            if !self.trusted_relays.is_empty() {
+                cmd.arg("-relayDiscovery=false");
+            }
         }
 
         // AutoNAT
         if self.auto_nat {
             cmd.arg("-autonat");
+        }
+
+        // Force reachability private (skip AutoNAT, activate relay immediately)
+        if self.force_reachability_private {
+            cmd.arg("-forceReachabilityPrivate");
         }
 
         // NAT port mapping
@@ -235,6 +272,12 @@ impl DaemonBuilder {
         // Announce addrs (public addresses to advertise in the DHT)
         if !self.announce_addrs.is_empty() {
             cmd.arg("-announceAddrs").arg(self.announce_addrs.join(","));
+        }
+
+        // Trusted relay peers for AutoRelay
+        if !self.trusted_relays.is_empty() {
+            cmd.arg("-trustedRelays")
+                .arg(self.trusted_relays.join(","));
         }
 
         // Metrics
@@ -262,6 +305,11 @@ impl DaemonBuilder {
             cmd.arg("-id").arg(key_path);
         }
 
+        // Forward GOLOG_LOG_LEVEL to the Go daemon for diagnostics
+        if let Ok(level) = std::env::var("GOLOG_LOG_LEVEL") {
+            cmd.env("GOLOG_LOG_LEVEL", level);
+        }
+
         // Redirect stderr for logging
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
@@ -284,19 +332,24 @@ impl DaemonBuilder {
 
         info!("Daemon process spawned (PID: {:?})", child.id());
 
-        // Capture stderr in a background task so we can surface crash reasons
+        // Capture stderr in a background task so we can surface crash reasons.
+        // When GOLOG_LOG_LEVEL is set, also log lines as they arrive so
+        // go-libp2p diagnostics are visible in `docker compose logs`.
         let stderr_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
         if let Some(stderr) = child.stderr.take() {
             let buf = stderr_buf.clone();
+            let forward_logs = std::env::var("GOLOG_LOG_LEVEL").is_ok();
             tokio::spawn(async move {
-                let mut reader = stderr;
+                use tokio::io::AsyncBufReadExt;
+                let mut lines = tokio::io::BufReader::new(stderr).lines();
                 let mut output = String::new();
-                // Read up to 8KB — enough for crash diagnostics
-                let mut raw = vec![0u8; 8192];
-                loop {
-                    match reader.read(&mut raw).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(n) => output.push_str(&String::from_utf8_lossy(&raw[..n])),
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if forward_logs {
+                        debug!(target: "p2pd", "{}", line);
+                    }
+                    if output.len() < 8192 {
+                        output.push_str(&line);
+                        output.push('\n');
                     }
                 }
                 *buf.lock().await = output;

--- a/core/crates/kwaai-p2p-daemon/src/daemon.rs
+++ b/core/crates/kwaai-p2p-daemon/src/daemon.rs
@@ -19,6 +19,7 @@ pub struct DaemonBuilder {
     binary_path: Option<PathBuf>,
     listen_addr: Option<String>,
     bootstrap_peers: Vec<String>,
+    bootstrap: bool,
     dht: bool,
     relay: bool,
     auto_relay: bool,
@@ -138,6 +139,17 @@ impl DaemonBuilder {
         self
     }
 
+    /// Enable Kademlia DHT bootstrap (`-b` flag)
+    ///
+    /// When enabled, the daemon connects to the bootstrap peers and runs a
+    /// Kademlia self-lookup to populate routing tables. Without this, the
+    /// daemon's DHT routing table stays empty and the node is invisible to
+    /// peers performing DHT lookups (e.g. the health service).
+    pub fn bootstrap(mut self, enable: bool) -> Self {
+        self.bootstrap = enable;
+        self
+    }
+
     /// Set the path to a protobuf-encoded Ed25519 private key file (`-id` flag)
     ///
     /// When provided, p2pd uses this key so the node's `PeerId` is stable
@@ -233,9 +245,15 @@ impl DaemonBuilder {
             }
         }
 
-        // Bootstrap peers
-        for peer in &self.bootstrap_peers {
-            cmd.arg("-bootstrapPeers").arg(peer);
+        // Bootstrap peers (comma-separated; Go flag.String accepts one value)
+        if !self.bootstrap_peers.is_empty() {
+            cmd.arg("-bootstrapPeers")
+                .arg(self.bootstrap_peers.join(","));
+        }
+
+        // Kademlia bootstrap walk (connect to bootstrap peers + self-lookup)
+        if self.bootstrap {
+            cmd.arg("-b");
         }
 
         // Persistent identity key — makes PeerId stable across restarts


### PR DESCRIPTION
A few commits here to get a working p2p network with just a couple of bootstrap servers:

- Set bootstrap peers as a comma-separated list (this is actually a bug-fix for all nodes, which are currently only connecting to bootstrap-2.kwaai.ai)
- Treat an empty public_ip as having no IP address. This is a simple bug-fix to prevent garbage used as the announce address
- Add -forceReachabilityPrivate, which skips AutoNAT when we're a relay, thus reducing the time for AutoNAT to converge (which normally requires 3 nodes as well)
- Add -trustedRelays using the bootstrap nodes (mirrors Petals behavior) and sets -relayDiscovery=false (so we don't waste time scanning for relays)
- Improved pass-through debugging when GOLOG_LOG_LEVEL is being used

Tested on macOS (arm64, x86_x64), Linux (x86_64, aarch64)
