### PR TITLE
fix: free GPU memory when shard is stopped or restarted

### DIFF
--- a/core/crates/kwaai-cli/src/daemon.rs
+++ b/core/crates/kwaai-cli/src/daemon.rs
@@ -394,6 +394,9 @@ impl ShardManager {
     }
 
     /// Stop the shard serve child, if running.
+    ///
+    /// Sends SIGTERM and waits up to 5 s for a clean exit, then sends SIGKILL
+    /// so the CUDA context (and VRAM) is always freed before returning.
     pub fn stop_process(&self) {
         let Some(pid) = self.read_pid() else { return };
         info!("Stopping shard server PID {}", pid);
@@ -408,9 +411,12 @@ impl ShardManager {
                 let mut sys = System::new();
                 sys.refresh_process(Pid::from_u32(pid));
                 if sys.process(Pid::from_u32(pid)).is_none() {
-                    break;
+                    self.remove_pid();
+                    return;
                 }
             }
+            warn!("Shard process {} did not exit after SIGTERM — sending SIGKILL", pid);
+            let _ = kill(NixPid::from_raw(pid as i32), Signal::SIGKILL);
         }
         #[cfg(not(unix))]
         {
@@ -424,7 +430,18 @@ impl ShardManager {
 
     /// Spawn `kwaainet shard serve --auto --auto-rebalance` as a detached
     /// background process, appending output to `shard.log`.
+    ///
+    /// Kills any already-running shard child first so its CUDA context is freed
+    /// before the new process allocates GPU memory.
     pub fn spawn_shard_child() -> Result<u32> {
+        let mgr = Self::new();
+        if mgr.is_running() {
+            info!("Existing shard child running — stopping it before respawn");
+            mgr.stop_process();
+        }
+        // Clear stale ready sentinel so callers don't see the old state.
+        let _ = std::fs::remove_file(Self::ready_file());
+
         let exe = std::env::current_exe().context("finding own executable")?;
         let log = log_dir().join("shard.log");
         std::fs::create_dir_all(log.parent().unwrap()).ok();


### PR DESCRIPTION
ShardManager::stop_process() sent SIGTERM but had no SIGKILL fallback — after 5 s it just removed the PID file, leaving the process alive with its CUDA context (and all VRAM) still allocated.

spawn_shard_child() did not kill any existing shard before spawning a new one, so a restart left two shard processes running simultaneously, consuming ~34 GB on the A6000 and leaving only ~14 GB free — not enough for subsequent --local or distributed inference runs.

Fixes:
- stop_process(): early-return on clean exit, send SIGKILL after 5 s if process hasn't exited (mirrors DaemonManager::stop_process behaviour)
- spawn_shard_child(): stop any running child and clear the ready sentinel before spawning, so GPU memory is freed before the new process starts