### PR TITLE
fix(installer): CUDA archive checksum override on Windows

### DIFF
--- a/scripts/patch-installer-cuda-ps1.sh
+++ b/scripts/patch-installer-cuda-ps1.sh
@@ -20,6 +20,7 @@ cat > "$CUDA_FUNC" <<'CUDA_PATCH'
 
 # ── NVIDIA CUDA variant auto-detection (injected by CI) ──────────
 $global:_cuda_selected = $false
+$global:_cuda_checksum = ""
 
 function Invoke-CudaUpgrade($download_url, [ref]$artifact_name_ref) {
     $current = $artifact_name_ref.Value
@@ -37,6 +38,18 @@ function Invoke-CudaUpgrade($download_url, [ref]$artifact_name_ref) {
         Write-Host "NVIDIA GPU detected: $gpuName - using CUDA-enabled build"
         $artifact_name_ref.Value = $cudaName
         $global:_cuda_selected = $true
+        # Fetch the CUDA archive hash so the installer verifies the right file.
+        # On failure we set an empty string, which skips verification rather than
+        # hard-failing with the CPU archive's embedded hash.
+        try {
+            $hashContent = (Invoke-WebRequest -Uri "$cudaUrl.sha256" -UseBasicParsing -ErrorAction Stop).Content
+            $cudaHash = ($hashContent -split '[\s\r\n]+')[0].Trim().ToLower()
+            if ($cudaHash -match '^[0-9a-f]{64}$') {
+                $global:_cuda_checksum = $cudaHash
+            }
+        } catch {
+            $global:_cuda_checksum = ""
+        }
     } catch {
         Write-Host "CUDA archive not found for this release - falling back to CPU build"
     }
@@ -68,7 +81,11 @@ rm -f "$CUDA_FUNC"
 # Inject the call just before the URL is constructed from $artifact_name.
 if grep -q '\$url = "\$download_url/\$artifact_name"' "$INSTALLER"; then
     sed -i '/\$url = "\$download_url\/\$artifact_name"/i\  Invoke-CudaUpgrade $download_url ([ref]$artifact_name)' "$INSTALLER"
-    echo "Patched ${INSTALLER}: CUDA auto-detection added"
+    # After the URL is set, override the embedded CPU checksum with the CUDA one.
+    # The installer embeds the CPU archive hash at build time; without this patch
+    # the CUDA archive would fail hash verification and abort the install.
+    sed -i '/\$url = "\$download_url\/\$artifact_name"/a\  if ($global:_cuda_selected) { if ($global:_cuda_checksum -ne "") { $checksum = $global:_cuda_checksum } else { $checksum = "" } }' "$INSTALLER"
+    echo "Patched ${INSTALLER}: CUDA auto-detection and checksum override added"
 else
     echo "WARNING: Could not find '\$url = \"\$download_url/\$artifact_name\"' in PS1 installer"
     echo "  Searching for download-related lines:"


### PR DESCRIPTION
## Problem

Windows users with NVIDIA GPUs were silently falling back to the CPU binary after install, even though the installer correctly detected `nvidia-smi` and selected the CUDA archive.

**Root cause**: `patch-installer-cuda-ps1.sh` swapped `$artifact_name` to the CUDA `.zip` but left `$checksum` pointing at the CPU archive's embedded hash. The cargo-dist installer verifies the download before extracting — with a mismatched hash it throws and aborts, then the user is left with no binary at all.

## Fix

`Invoke-CudaUpgrade` now:
1. Fetches the CUDA archive's `.sha256` file from the release URL
2. Stores the hash in `$global:_cuda_checksum`

A new `sed` injection (right after `$url` is set) overrides `$checksum` with the correct CUDA hash, or clears it to skip verification if the `.sha256` file is unreachable.

## What this unblocks

Any user running the PowerShell installer on a machine with an NVIDIA GPU will now actually receive and install the CUDA-enabled `kwaainet.exe` (built with `--features cuda` in CI), which selects `Device::Cuda(0)` instead of `Device::Cpu` for inference.

## Related

Companion to #36 (flash attention + KV cache). Once #36 merges, the CUDA binary built by CI will also include flash attention — users who reinstall will get both improvements automatically.

## Test plan

- [ ] On a Windows machine with NVIDIA GPU, run the PowerShell installer
- [ ] Confirm install prints "NVIDIA GPU detected ... using CUDA-enabled build"
- [ ] Confirm `kwaainet shard serve` logs "CUDA device detected" not "Using CPU for inference"
- [ ] On a machine without NVIDIA GPU, confirm installer falls back to CPU build without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
