### PR TITLE
fix(updater): install CUDA binary on Windows GPU machines

### DIFF
--- a/core/crates/kwaai-cli/src/updater.rs
+++ b/core/crates/kwaai-cli/src/updater.rs
@@ -240,29 +240,30 @@ impl UpdateChecker {
                 ping -n 2 127.0.0.1 > nul\r\n";
 
             let bat_content = if cuda_installed {
-                // Fast path: download the CPU-only archive (much smaller), extract
-                // just the .exe files, and leave the existing CUDA DLLs in place.
+                // CUDA path: download the CUDA-enabled archive so the installed
+                // kwaainet.exe has GPU support compiled in.  The archive also
+                // contains updated CUDA runtime DLLs which replace any older ones.
                 let archive_url = format!(
-                    "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v{version}/kwaainet-x86_64-pc-windows-msvc.zip"
+                    "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v{version}/kwaainet-x86_64-pc-windows-msvc-cuda.zip"
                 );
                 let dir = install_dir.to_string_lossy().into_owned();
                 format!(
                     "{kill_header}\
                      powershell -ExecutionPolicy Bypass -Command \"\
-                       $zip = [System.IO.Path]::GetTempPath() + 'kwaainet-cpu-update.zip'; \
-                       $tmp = [System.IO.Path]::GetTempPath() + 'kwaainet-cpu-extract'; \
-                       Write-Host 'Downloading CPU archive...'; \
+                       $zip = [System.IO.Path]::GetTempPath() + 'kwaainet-cuda-update.zip'; \
+                       $tmp = [System.IO.Path]::GetTempPath() + 'kwaainet-cuda-extract'; \
+                       Write-Host 'Downloading CUDA archive...'; \
                        Invoke-WebRequest -Uri '{archive_url}' -OutFile $zip -UseBasicParsing; \
                        Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue; \
                        Expand-Archive -Path $zip -DestinationPath $tmp -Force; \
-                       Get-ChildItem $tmp -Recurse -Filter '*.exe' | ForEach-Object {{ \
+                       Get-ChildItem $tmp -Recurse -Include '*.exe','*.dll' | ForEach-Object {{ \
                          $dest = '{dir}\\' + $_.Name; \
                          Write-Host ('Installing ' + $_.Name); \
                          Move-Item $_.FullName $dest -Force \
                        }}; \
                        Remove-Item $zip -Force -ErrorAction SilentlyContinue; \
                        Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue; \
-                       Write-Host 'Update complete. CUDA DLLs preserved.' \
+                       Write-Host 'Update complete. CUDA binary and DLLs installed.' \
                      \" >> \"{log_path}\" 2>&1\r\n\
                      del /f \"%~f0\"\r\n"
                 )
@@ -293,7 +294,7 @@ impl UpdateChecker {
                     "cublas DLLs in install dir"
                 };
                 println!(
-                    "  CUDA detected ({reason}) — downloading CPU archive only (fast update)."
+                    "  CUDA detected ({reason}) — downloading CUDA archive."
                 );
             }
 


### PR DESCRIPTION
## Bug

`kwaainet update` on a Windows machine with an NVIDIA GPU was silently reverting inference from GPU back to CPU on every update.

**Root cause** (`updater.rs:246`): The CUDA detection logic correctly identified GPU machines, but then downloaded `kwaainet-x86_64-pc-windows-msvc.zip` (the CPU-only binary) and installed it — leaving the CUDA DLLs in place but replacing the executable with one that has no CUDA support compiled in. The comment even called this a "fast path" for CUDA machines.

The result: users with GPUs got the worst of both worlds — CUDA DLLs on disk, CPU binary running.

## Fix

- Download `kwaainet-x86_64-pc-windows-msvc-cuda.zip` instead of the CPU archive when CUDA is detected
- Install both `*.exe` and `*.dll` files from the archive so CUDA runtime libraries stay in sync with the binary
- Update the user-facing log message to say "CUDA archive" not "CPU archive"

## Reproduction

On a Windows machine with any NVIDIA GPU:
1. Install kwaainet (CUDA binary correctly installed by the PS1 installer)
2. Run `kwaainet update`
3. Observe "CUDA detected — downloading CPU archive only" in output
4. After update: `kwaainet shard serve` logs "Using CPU for inference" ← was the bug

## After this fix

Step 3 prints "CUDA detected — downloading CUDA archive."  
The installed binary has `candle_core::Device::Cuda(0)` and logs "CUDA device detected" on startup.

## Related

- Companion to #36 (flash attention) and #37 (PS1 installer checksum)
- All three together form the complete GPU inference fix for Windows users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
