### PR TITLE
fix(cli): use unicode-width for box-header alignment

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3073,6 +3073,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unicode-width",
  "uuid",
 ]
 
@@ -6407,6 +6408,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/core/crates/kwaai-cli/Cargo.toml
+++ b/core/crates/kwaai-cli/Cargo.toml
@@ -57,6 +57,7 @@ sha1 = "0.10"
 hex = "0.4"
 rmpv = "1.0"
 half = { workspace = true }
+unicode-width = "0.1"
 
 # HTTP server (OpenAI API)
 axum = { version = "0.7", features = ["json", "multipart"] }

--- a/core/crates/kwaai-cli/src/display.rs
+++ b/core/crates/kwaai-cli/src/display.rs
@@ -1,11 +1,13 @@
 //! Console formatting helpers
 
+use unicode_width::UnicodeWidthStr;
+
 const WIDTH: usize = 69;
 
-/// Returns the display width of a string, counting ASCII chars as 1 column
-/// and non-ASCII (emoji, CJK, etc.) as 2 columns.
+/// Returns the display width of a string in terminal columns, accounting for
+/// East Asian Width and emoji presentation flags via `unicode-width`.
 fn display_width(s: &str) -> usize {
-    s.chars().map(|c| if c.is_ascii() { 1 } else { 2 }).sum()
+    UnicodeWidthStr::width(s)
 }
 
 pub fn print_box_header(title: &str) {


### PR DESCRIPTION
The CLI's `print_box_header` (in `kwaai-cli/src/display.rs`) used a hand-rolled `display_width` that scored every non-ASCII char as 2 columns. Characters like `🛰` (U+1F6F0) and `—` (U+2014) actually render as 1 cell in most terminals, so the right border landed in the wrong column.

This patch swaps `display_width` to call `unicode_width::UnicodeWidthStr::width`, which respects Unicode East Asian Width and emoji presentation flags. No behavioural change beyond correct column accounting; benefits every `print_box_header` call site.

Verified by building the `kwaainet` binary and running `kwaainet status` against a live daemon.