### PR TITLE
feat(cli): add p2p subcommand for live diagnostics

### DIFF
--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -128,6 +128,9 @@ pub enum Command {
     /// Manage node identity and verifiable credentials
     Identity(IdentityArgs),
 
+    /// Inspect live p2p state (identity, connected peers) via the local p2pd
+    P2p(P2pArgs),
+
     /// Manage VPK (Virtual Private Knowledge) vector database integration
     Vpk(VpkArgs),
 
@@ -1109,5 +1112,46 @@ pub enum RagAction {
         /// Polling interval in seconds (watch mode only)
         #[arg(long, default_value = "60")]
         interval: u64,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// p2p
+// ---------------------------------------------------------------------------
+
+#[derive(Args)]
+pub struct P2pArgs {
+    #[command(subcommand)]
+    pub action: P2pAction,
+}
+
+#[derive(Subcommand)]
+pub enum P2pAction {
+    /// Show this node's peer ID, listen addresses, observed addresses, and a NAT verdict
+    Info,
+
+    /// Inspect active connections to other peers
+    Peers(PeersArgs),
+}
+
+#[derive(Args)]
+pub struct PeersArgs {
+    #[command(subcommand)]
+    pub action: PeersAction,
+}
+
+#[derive(Subcommand)]
+pub enum PeersAction {
+    /// List all live connections (one row per connection — direct or via relay)
+    List,
+
+    /// Active DHT lookup: what addresses does the network advertise for this peer?
+    Find {
+        /// Peer ID (base58, e.g. 12D3KooW…)
+        peer_id: String,
+
+        /// Lookup timeout in seconds
+        #[arg(long, default_value = "10")]
+        timeout: i64,
     },
 }

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -15,6 +15,7 @@ mod map;
 mod monitor;
 mod node;
 mod ollama;
+mod p2p_cmd;
 mod progress;
 mod rebalancer;
 mod reputation;
@@ -1441,6 +1442,13 @@ async fn main() -> Result<()> {
         // -------------------------------------------------------------------
         Command::Identity(args) => {
             identity::run_identity_command(args).await?;
+        }
+
+        // -------------------------------------------------------------------
+        // p2p
+        // -------------------------------------------------------------------
+        Command::P2p(args) => {
+            p2p_cmd::run(args).await?;
         }
 
         // -------------------------------------------------------------------

--- a/core/crates/kwaai-cli/src/p2p_cmd.rs
+++ b/core/crates/kwaai-cli/src/p2p_cmd.rs
@@ -93,7 +93,7 @@ async fn info() -> Result<()> {
     };
 
     let (peer_id_hex, addrs_bytes) = client
-        .identify_with_addrs()
+        .identify_full()
         .await
         .context("IDENTIFY request to p2pd failed")?;
 

--- a/core/crates/kwaai-cli/src/p2p_cmd.rs
+++ b/core/crates/kwaai-cli/src/p2p_cmd.rs
@@ -92,14 +92,16 @@ async fn info() -> Result<()> {
         return Ok(());
     };
 
-    let (peer_id_bytes, addrs_bytes) = client
+    let (peer_id_hex, addrs_bytes) = client
         .identify_with_addrs()
         .await
         .context("IDENTIFY request to p2pd failed")?;
 
-    let peer_id = PeerId::from_bytes(&peer_id_bytes)
+    let peer_id = hex::decode(&peer_id_hex)
+        .ok()
+        .and_then(|b| PeerId::from_bytes(&b).ok())
         .map(|p| p.to_base58())
-        .unwrap_or_else(|_| format!("0x{} (unparseable)", hex::encode(&peer_id_bytes)));
+        .unwrap_or_else(|| format!("0x{} (unparseable)", peer_id_hex));
 
     let addrs: Vec<Multiaddr> = addrs_bytes
         .iter()

--- a/core/crates/kwaai-cli/src/p2p_cmd.rs
+++ b/core/crates/kwaai-cli/src/p2p_cmd.rs
@@ -1,0 +1,278 @@
+//! `kwaainet p2p` — live diagnostics for the local p2pd
+//!
+//! All commands talk only to the local p2pd over its IPC socket. `info` and
+//! `peers list` return p2pd's in-memory view; `peers find` issues an active
+//! Kademlia lookup via p2pd.
+
+use std::collections::HashSet;
+
+use anyhow::{Context, Result};
+use kwaai_p2p::NetworkConfig;
+use kwaai_p2p_daemon::P2PClient;
+use libp2p::{Multiaddr, PeerId};
+
+use crate::cli::{P2pAction, P2pArgs, PeersAction, PeersArgs};
+use crate::config::KwaaiNetConfig;
+use crate::display::*;
+use crate::shard_cmd::daemon_socket;
+
+pub async fn run(args: P2pArgs) -> Result<()> {
+    match args.action {
+        P2pAction::Info => info().await,
+        P2pAction::Peers(p) => peers(p).await,
+    }
+}
+
+async fn peers(args: PeersArgs) -> Result<()> {
+    match args.action {
+        PeersAction::List => peers_list().await,
+        PeersAction::Find { peer_id, timeout } => peers_find(peer_id, timeout).await,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/// Connect to the local p2pd, or print the standard "node not running" message
+/// and return `Ok(None)` so the caller exits cleanly with status 0.
+async fn connect_p2pd() -> Result<Option<P2PClient>> {
+    let addr = daemon_socket();
+    match P2PClient::connect(&addr).await {
+        Ok(c) => Ok(Some(c)),
+        Err(_) => {
+            print_error("Cannot connect to the KwaaiNet node — is it running?");
+            print_info("Start it:     kwaainet start --daemon");
+            print_info("Check status: kwaainet status");
+            print_info("View logs:    kwaainet logs --follow");
+            print_separator();
+            Ok(None)
+        }
+    }
+}
+
+/// Decode raw protobuf-bytes multiaddr into the displayable text form.
+/// Falls back to a hex preview so `peers list` never panics on a malformed
+/// addr from p2pd.
+fn fmt_addr(bytes: &[u8]) -> String {
+    Multiaddr::try_from(bytes.to_vec())
+        .map(|m| m.to_string())
+        .unwrap_or_else(|_| format!("0x{} (unparseable)", hex::encode(bytes)))
+}
+
+/// Classify a multiaddr for the dcutr signal we care about most: is this
+/// connection going through a relay circuit, or directly?
+fn is_relayed(m: &Multiaddr) -> bool {
+    m.iter()
+        .any(|p| matches!(p, libp2p::multiaddr::Protocol::P2pCircuit))
+}
+
+/// Build the set of bootstrap peer IDs the local node was configured to use.
+/// Prefers the user's `initial_peers` override; falls back to the built-in
+/// KwaaiNet/Petals defaults. Same precedence as `vpk discover` and `node.rs`.
+fn bootstrap_peer_ids() -> HashSet<PeerId> {
+    let bootstraps: Vec<String> = match KwaaiNetConfig::load_or_create() {
+        Ok(cfg) if !cfg.initial_peers.is_empty() => cfg.initial_peers,
+        _ => NetworkConfig::with_petals_bootstrap().bootstrap_peers,
+    };
+
+    bootstraps
+        .iter()
+        .filter_map(|addr| addr.split("/p2p/").nth(1))
+        .filter_map(|id| id.parse::<PeerId>().ok())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// info
+// ---------------------------------------------------------------------------
+
+async fn info() -> Result<()> {
+    let Some(mut client) = connect_p2pd().await? else {
+        return Ok(());
+    };
+
+    let (peer_id_bytes, addrs_bytes) = client
+        .identify_with_addrs()
+        .await
+        .context("IDENTIFY request to p2pd failed")?;
+
+    let peer_id = PeerId::from_bytes(&peer_id_bytes)
+        .map(|p| p.to_base58())
+        .unwrap_or_else(|_| format!("0x{} (unparseable)", hex::encode(&peer_id_bytes)));
+
+    let addrs: Vec<Multiaddr> = addrs_bytes
+        .iter()
+        .filter_map(|a| Multiaddr::try_from(a.clone()).ok())
+        .collect();
+
+    print_box_header("🛰  KwaaiNet P2P — Local Node Identity");
+    println!("  Peer ID:  {}", peer_id);
+    println!();
+
+    if addrs.is_empty() {
+        println!("  Addresses: (none reported by p2pd)");
+        print_warning(
+            "p2pd hasn't reported any listen/observed addresses yet. \
+             The node may have just started — try again in a few seconds.",
+        );
+    } else {
+        println!("  Addresses ({}):", addrs.len());
+        for a in &addrs {
+            let kind = if is_relayed(a) { "relay" } else { "direct" };
+            println!("    [{:>6}] {}", kind, a);
+        }
+    }
+
+    println!();
+    let direct_count = addrs.iter().filter(|a| !is_relayed(a)).count();
+    let relay_count = addrs.len() - direct_count;
+    if addrs.is_empty() {
+        print_info("Reachability: unknown (no addresses yet)");
+    } else if direct_count > 0 && relay_count == 0 {
+        print_info("Reachability: direct addresses only — looks publicly reachable");
+    } else if direct_count > 0 {
+        print_info(&format!(
+            "Reachability: mixed ({} direct, {} via relay) — partially reachable",
+            direct_count, relay_count
+        ));
+    } else {
+        print_info(&format!(
+            "Reachability: relay-only ({} circuit addrs) — likely behind NAT",
+            relay_count
+        ));
+    }
+    print_separator();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// peers list / info / find
+// ---------------------------------------------------------------------------
+
+async fn peers_list() -> Result<()> {
+    let Some(mut client) = connect_p2pd().await? else {
+        return Ok(());
+    };
+
+    let peers = client
+        .list_peers()
+        .await
+        .context("LIST_PEERS request to p2pd failed")?;
+
+    print_box_header("🛰  KwaaiNet P2P — Active Connections");
+
+    if peers.is_empty() {
+        println!("  (no active connections)");
+        print_separator();
+        return Ok(());
+    }
+
+    let bootstraps = bootstrap_peer_ids();
+
+    let mut direct = 0usize;
+    let mut relayed = 0usize;
+    let mut bootstrap_hits = 0usize;
+    for p in &peers {
+        let parsed_id = PeerId::from_bytes(&p.id).ok();
+        let id_str = parsed_id
+            .map(|p| p.to_base58())
+            .unwrap_or_else(|| format!("0x{}", hex::encode(&p.id)));
+        let is_bootstrap = parsed_id.map_or(false, |pid| bootstraps.contains(&pid));
+        if is_bootstrap {
+            bootstrap_hits += 1;
+        }
+
+        let any_relay = p
+            .addrs
+            .iter()
+            .filter_map(|a| Multiaddr::try_from(a.clone()).ok())
+            .any(|m| is_relayed(&m));
+        if any_relay {
+            relayed += 1;
+        } else {
+            direct += 1;
+        }
+        let kind = if any_relay { "relay" } else { "direct" };
+        let preview = p
+            .addrs
+            .first()
+            .map(|a| fmt_addr(a))
+            .unwrap_or_else(|| "(no addrs)".to_string());
+        let extra = if p.addrs.len() > 1 {
+            format!(" (+{} more)", p.addrs.len() - 1)
+        } else {
+            String::new()
+        };
+        // Cyan for bootstrap so the label stands out at a glance without
+        // being garish. Inline ANSI keeps us off the dep treadmill for a
+        // single annotation; revisit if color use spreads.
+        let label = if is_bootstrap {
+            "  \x1b[36m(bootstrap)\x1b[0m"
+        } else {
+            ""
+        };
+        println!("  [{:>6}] {}{}", kind, id_str, label);
+        println!("           {}{}", preview, extra);
+    }
+
+    println!();
+    print_info(&format!(
+        "Total {} connection(s): {} direct, {} via relay; {} to bootstrap peer(s)",
+        peers.len(),
+        direct,
+        relayed,
+        bootstrap_hits
+    ));
+    print_info(
+        "Each row is one live connection — a peer with both a direct and a \
+         relay path (e.g. during a dcutr upgrade) appears twice.",
+    );
+    print_separator();
+    Ok(())
+}
+
+async fn peers_find(peer_id_str: String, timeout: i64) -> Result<()> {
+    let target: PeerId = peer_id_str
+        .parse()
+        .context("invalid peer ID (expected base58, e.g. 12D3KooW…)")?;
+
+    let Some(mut client) = connect_p2pd().await? else {
+        return Ok(());
+    };
+
+    print_box_header("🛰  KwaaiNet P2P — DHT Peer Lookup");
+    println!("  Looking up: {}", target.to_base58());
+    println!("  Timeout:    {}s", timeout);
+    println!();
+
+    match client.dht_find_peer(target.to_bytes(), Some(timeout)).await {
+        Ok(info) => {
+            if info.addrs.is_empty() {
+                println!("  Found in DHT, but no addresses advertised.");
+            } else {
+                println!("  Addresses advertised in DHT ({}):", info.addrs.len());
+                for a in &info.addrs {
+                    match Multiaddr::try_from(a.clone()) {
+                        Ok(m) => {
+                            let kind = if is_relayed(&m) { "relay" } else { "direct" };
+                            println!("    [{:>6}] {}", kind, m);
+                        }
+                        Err(_) => {
+                            println!("    [   ?   ] 0x{} (unparseable)", hex::encode(a))
+                        }
+                    }
+                }
+            }
+        }
+        Err(_) => {
+            print_warning(&format!("not found in DHT (timeout: {}s)", timeout));
+            print_info(
+                "Either the peer hasn't published its addresses, or the \
+                 lookup didn't finish in time. Try a longer --timeout.",
+            );
+        }
+    }
+    print_separator();
+    Ok(())
+}

--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -288,13 +288,13 @@ impl P2PClient {
         }
     }
 
-    /// Send an IDENTIFY request and return both our peer ID (binary) and the
+    /// Send an IDENTIFY request and return both the peer ID (hex) and the
     /// listen + observed multiaddrs the daemon is reporting.
     ///
     /// `identify()` only returns the peer ID and discards the addresses; this
     /// variant preserves them for diagnostic use (e.g. comparing bound vs
     /// observed addrs to infer NAT status).
-    pub async fn identify_with_addrs(&mut self) -> Result<(Vec<u8>, Vec<Vec<u8>>)> {
+    pub async fn identify_with_addrs(&mut self) -> Result<(String, Vec<Vec<u8>>)> {
         let request = Request {
             r#type: request::Type::Identify as i32,
             connect: None,
@@ -310,7 +310,8 @@ impl P2PClient {
         let response = self.send_request(request).await?;
 
         if let Some(id) = response.identify {
-            Ok((id.id, id.addrs))
+            let peer_id = hex::encode(&id.id);
+            Ok((peer_id, id.addrs))
         } else {
             Err(Error::InvalidResponse(
                 "Expected IDENTIFY response".to_string(),

--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -288,12 +288,16 @@ impl P2PClient {
         }
     }
 
-    /// Send an IDENTIFY request and return both the peer ID and observed multiaddrs.
+    /// Send an IDENTIFY request and return both the peer ID (hex) and the
+    /// observed multiaddrs the daemon is reporting.
     ///
-    /// Returns `(peer_id_hex, addrs)` where `addrs` is the list of multiaddr bytes
-    /// that p2pd has observed for itself (populated by the libp2p IDENTIFY protocol
-    /// as peers connect and report our external address).
-    pub async fn identify_with_addrs(&mut self) -> Result<(String, Vec<Vec<u8>>)> {
+    /// Distinct from `identify()` which discards the addresses. Named
+    /// `identify_full` rather than the more obvious `identify_with_addrs` to
+    /// sidestep a duplicate-definition collision when this branch is merged
+    /// alongside another in-flight branch (feature/public-ip) that
+    /// independently added the latter name. Rename to `identify_with_addrs`
+    /// once whichever branch lands second is updated.
+    pub async fn identify_full(&mut self) -> Result<(String, Vec<Vec<u8>>)> {
         let request = Request {
             r#type: request::Type::Identify as i32,
             connect: None,

--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -288,12 +288,11 @@ impl P2PClient {
         }
     }
 
-    /// Send an IDENTIFY request and return both the peer ID (hex) and the
-    /// listen + observed multiaddrs the daemon is reporting.
+    /// Send an IDENTIFY request and return both the peer ID and observed multiaddrs.
     ///
-    /// `identify()` only returns the peer ID and discards the addresses; this
-    /// variant preserves them for diagnostic use (e.g. comparing bound vs
-    /// observed addrs to infer NAT status).
+    /// Returns `(peer_id_hex, addrs)` where `addrs` is the list of multiaddr bytes
+    /// that p2pd has observed for itself (populated by the libp2p IDENTIFY protocol
+    /// as peers connect and report our external address).
     pub async fn identify_with_addrs(&mut self) -> Result<(String, Vec<Vec<u8>>)> {
         let request = Request {
             r#type: request::Type::Identify as i32,

--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -288,6 +288,36 @@ impl P2PClient {
         }
     }
 
+    /// Send an IDENTIFY request and return both our peer ID (binary) and the
+    /// listen + observed multiaddrs the daemon is reporting.
+    ///
+    /// `identify()` only returns the peer ID and discards the addresses; this
+    /// variant preserves them for diagnostic use (e.g. comparing bound vs
+    /// observed addrs to infer NAT status).
+    pub async fn identify_with_addrs(&mut self) -> Result<(Vec<u8>, Vec<Vec<u8>>)> {
+        let request = Request {
+            r#type: request::Type::Identify as i32,
+            connect: None,
+            stream_open: None,
+            stream_handler: None,
+            remove_stream_handler: None,
+            dht: None,
+            conn_manager: None,
+            disconnect: None,
+            pubsub: None,
+        };
+
+        let response = self.send_request(request).await?;
+
+        if let Some(id) = response.identify {
+            Ok((id.id, id.addrs))
+        } else {
+            Err(Error::InvalidResponse(
+                "Expected IDENTIFY response".to_string(),
+            ))
+        }
+    }
+
     /// Connect to a peer using a multiaddr
     ///
     /// The multiaddr should be in the format: /ip4/1.2.3.4/tcp/1234/p2p/QmPeerID


### PR DESCRIPTION
Adds a `kwaainet p2p` subcommand for inspecting the local node's view of the p2p network. Built while debugging dcutr / NAT / relay paths — there was no in-tree way to ask a running node "what does your p2p layer actually see?" without grepping p2pd logs.

Three read-only commands, all talking only to the local p2pd over its IPC socket:

```
kwaainet p2p info               # peer ID, listen + observed addrs, reachability verdict
kwaainet p2p peers list         # active connections, direct vs relay, bootstrap tagged
kwaainet p2p peers find <peer>  # active DHT lookup for a peer's currently-advertised addrs
```

`info` and `peers list` return p2pd's in-memory view (IDENTIFY and LIST_PEERS); `peers find` is the only one that triggers network traffic (DHT FIND_PEER, with a `--timeout` flag, default 10s).

### Sample output

```
╭─────────────────────────────────────────────────────────────────────╮
│              🛰  KwaaiNet P2P — Active Connections                  │
╰─────────────────────────────────────────────────────────────────────╯

  [direct] QmQhRuheeCLEsVD3RsnknM75gPDDqxAb8DhnWgro7KhaJc  (bootstrap)
           /ip4/18.219.43.67/tcp/8000
  [direct] Qmd3A8N5aQBATe2SYvNikaeCS9CAKN4E86jdCPacZ6RZJY  (bootstrap)
           /ip4/52.23.252.2/tcp/8000
  [ relay] 12D3KooWJckHG2fX8HCNy1n4yNyqsLbGJYoSAkeGD7h5Svf9PBzd
           /ip4/52.23.252.2/tcp/8000/p2p/Qmd3.../p2p-circuit

  💡 Total 3 connection(s): 2 direct, 1 via relay; 2 to bootstrap peer(s)
```

### What's deliberately NOT here

Several `p2p` commands were considered and dropped after looking at what p2pd's IPC actually exposes:

- **`peers info <peer>`** — `LIST_PEERS` only returns `(id, addrs)`. There's no per-connection metadata (direction, age, RTT, streams) without patching p2pd, so `info` would have been a thin filter over `list`.
- **`dht get` / `dht providers`** — these query p2pd's native libp2p Kademlia DHT, which this codebase barely populates. All the interesting records (VPK registry, shard block coverage) live in the separate hivemind DHT layer, accessed via `call_unary_handler` to `DHTProtocol.rpc_find/store` — different store, different protocol.
- **`pubsub topics`** — gossipsub is not used anywhere in this codebase (no `subscribe()` / `publish()` call sites). The PUBSUB op exists in the protobuf but would always return empty.

### Follow-up work

The genuinely high-value diagnostics for dcutr debugging require patching the maintained `docker/p2pd-patched` daemon to expose data libp2p tracks internally but doesn't surface over IPC: dcutr attempt outcomes, AutoNAT verdict, peerstore (known-but-disconnected peers), per-connection RTT and direction, relay reservations. None of those required for this PR; called out so the CLI shape doesn't have to change later.

### Implementation notes

- New file: `core/crates/kwaai-cli/src/p2p_cmd.rs` (one async fn per subcommand, ~280 lines)
- One new method on `P2PClient`: `identify_with_addrs()` — same as `identify()` but preserves the `IdentifyResponse.addrs` field instead of discarding it
- Bootstrap peer detection: same pattern as `vpk discover` and `node.rs` — prefers `cfg.initial_peers` if set, falls back to `NetworkConfig::with_petals_bootstrap()`
- Multiaddr direct/relay classification: walks the multiaddr looking for `Protocol::P2pCircuit`

### Verified

- `cargo build --package kwaainet --bin kwaainet` clean
- `cargo fmt --check` clean on all four touched files
- Manual smoke against a live local daemon (`info`, `peers list`, `peers find`) all working as expected