### PR TITLE
perf(updater): fast Windows CUDA update — exe-only archive (~30 MB vs 1 GB)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,6 +463,18 @@ jobs:
           $hash = (Get-FileHash "$LABEL.${{ matrix.ext }}" -Algorithm SHA256).Hash.ToLower()
           Set-Content -Path "$LABEL.${{ matrix.ext }}.sha256" -Value $hash -NoNewline
           Write-Host "CUDA archive: $LABEL.${{ matrix.ext }}"
+          # Produce a small exe-only archive for fast updates (no DLL re-download).
+          # kwaainet update uses this when CUDA DLLs are already installed.
+          $EXES_LABEL = "$LABEL-exes"
+          New-Item -ItemType Directory -Force -Path $EXES_LABEL
+          Copy-Item "target\release\${{ matrix.bin }}" "$EXES_LABEL\"
+          if (Test-Path "target\release\${{ matrix.p2pd }}") {
+            Copy-Item "target\release\${{ matrix.p2pd }}" "$EXES_LABEL\"
+          }
+          Compress-Archive -Path "$EXES_LABEL\*" -DestinationPath "$EXES_LABEL.${{ matrix.ext }}"
+          $exesHash = (Get-FileHash "$EXES_LABEL.${{ matrix.ext }}" -Algorithm SHA256).Hash.ToLower()
+          Set-Content -Path "$EXES_LABEL.${{ matrix.ext }}.sha256" -Value $exesHash -NoNewline
+          Write-Host "CUDA exe-only archive: $EXES_LABEL.${{ matrix.ext }}"
       - name: "Upload CUDA artifact"
         uses: actions/upload-artifact@v6
         with:
@@ -470,6 +482,8 @@ jobs:
           path: |
             core/${{ matrix.label }}.${{ matrix.ext }}
             core/${{ matrix.label }}.${{ matrix.ext }}.sha256
+            core/${{ matrix.label }}-exes.${{ matrix.ext }}
+            core/${{ matrix.label }}-exes.${{ matrix.ext }}.sha256
 
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:

--- a/core/crates/kwaai-cli/src/updater.rs
+++ b/core/crates/kwaai-cli/src/updater.rs
@@ -240,30 +240,30 @@ impl UpdateChecker {
                 ping -n 2 127.0.0.1 > nul\r\n";
 
             let bat_content = if cuda_installed {
-                // CUDA path: download the CUDA-enabled archive so the installed
-                // kwaainet.exe has GPU support compiled in.  The archive also
-                // contains updated CUDA runtime DLLs which replace any older ones.
+                // CUDA path: download the exe-only CUDA archive (~30 MB vs ~1 GB full
+                // archive) — contains only kwaainet.exe and p2pd.exe built with CUDA
+                // support, without the DLLs (already present from previous install).
                 let archive_url = format!(
-                    "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v{version}/kwaainet-x86_64-pc-windows-msvc-cuda.zip"
+                    "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v{version}/kwaainet-x86_64-pc-windows-msvc-cuda-exes.zip"
                 );
                 let dir = install_dir.to_string_lossy().into_owned();
                 format!(
                     "{kill_header}\
                      powershell -ExecutionPolicy Bypass -Command \"\
-                       $zip = [System.IO.Path]::GetTempPath() + 'kwaainet-cuda-update.zip'; \
-                       $tmp = [System.IO.Path]::GetTempPath() + 'kwaainet-cuda-extract'; \
-                       Write-Host 'Downloading CUDA archive...'; \
+                       $zip = [System.IO.Path]::GetTempPath() + 'kwaainet-cuda-exes-update.zip'; \
+                       $tmp = [System.IO.Path]::GetTempPath() + 'kwaainet-cuda-exes-extract'; \
+                       Write-Host 'Downloading CUDA binary update (~30 MB)...'; \
                        Invoke-WebRequest -Uri '{archive_url}' -OutFile $zip -UseBasicParsing; \
                        Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue; \
                        Expand-Archive -Path $zip -DestinationPath $tmp -Force; \
-                       Get-ChildItem $tmp -Recurse -Include '*.exe','*.dll' | ForEach-Object {{ \
+                       Get-ChildItem $tmp -Recurse -Filter '*.exe' | ForEach-Object {{ \
                          $dest = '{dir}\\' + $_.Name; \
                          Write-Host ('Installing ' + $_.Name); \
                          Move-Item $_.FullName $dest -Force \
                        }}; \
                        Remove-Item $zip -Force -ErrorAction SilentlyContinue; \
                        Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue; \
-                       Write-Host 'Update complete. CUDA binary and DLLs installed.' \
+                       Write-Host 'Update complete. CUDA DLLs preserved.' \
                      \" >> \"{log_path}\" 2>&1\r\n\
                      del /f \"%~f0\"\r\n"
                 )
@@ -293,7 +293,7 @@ impl UpdateChecker {
                 } else {
                     "cublas DLLs in install dir"
                 };
-                println!("  CUDA detected ({reason}) — downloading CUDA archive.");
+                println!("  CUDA detected ({reason}) — downloading CUDA binary (~30 MB, DLLs preserved).");
             }
 
             std::fs::write(&bat, &bat_content).context("Failed to write updater batch script")?;


### PR DESCRIPTION
## Problem

\`kwaainet update\` on a Windows GPU machine downloaded the full 1 GB CUDA archive on every update, even though the CUDA runtime DLLs (cublas, cudart, curand, etc.) never change between releases. Linux and macOS updates are ~25 MB; Windows CUDA was ~1 GB.

## Fix

**CI**: adds a second Windows CUDA artifact — \`kwaainet-x86_64-pc-windows-msvc-cuda-exes.zip\` (~30 MB) — containing only \`kwaainet.exe\` and \`p2pd.exe\` from the CUDA build, without any DLLs.

**Updater**: when CUDA DLLs are already present in the install directory, downloads the exe-only archive instead of the full 1 GB archive. The existing DLLs are left in place.

| Scenario | Before | After |
|---|---|---|
| First install (no DLLs) | PS1 installer → full 1 GB archive | unchanged |
| Update (DLLs present) | 1 GB CUDA archive | ~30 MB exe-only archive |
| Update message | "downloading CUDA archive" | "downloading CUDA binary (~30 MB, DLLs preserved)" |

## Related

Follow-up to #38 (which fixed the updater downloading the CPU binary on GPU machines). This PR makes the fix fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)