### PR TITLE
fix(p2p-daemon): use destination peer ID, not relay's, when dialing relay'd address

### DIFF
--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -331,12 +331,13 @@ impl P2PClient {
             .parse()
             .map_err(|e| Error::Connection(format!("Invalid multiaddr: {}", e)))?;
 
-        // Extract the peer ID from the multiaddr
+        // Extract the destination peer ID from the multiaddr.
+        // For a relay'd address like /ip4/.../p2p/<RELAY>/p2p-circuit/p2p/<DEST>,
+        // the destination is the LAST /p2p/ component, not the first.
         let mut peer_id_bytes = None;
         for component in maddr.iter() {
             if let libp2p::multiaddr::Protocol::P2p(hash) = component {
                 peer_id_bytes = Some(hash.to_bytes());
-                break;
             }
         }
 


### PR DESCRIPTION
## Summary

`P2PClient::connect_peer` extracts the peer ID from the supplied multiaddr by
walking its components. The loop returned the **first** `/p2p/` component it
encountered — which for a relay'd address like
`/ip4/<addr>/p2p/<RELAY>/p2p-circuit/p2p/<DEST>` is the **relay's** peer ID,
not the destination's.

The Connect request sent to the daemon then named the relay as the target.
Since the daemon was already connected to the relay, it short-circuited and
returned success without dialing the destination — a silent no-op from the
caller's perspective.

The fix drops the `break;` so the loop walks the full multiaddr and the
**last** `/p2p/` component (the destination) is what gets passed to the
daemon, matching the [libp2p multiaddr convention][1] for relay'd addresses.

[1]: https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md#protocol

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Reproduced the silent no-op manually before the fix and verified that
  after the fix, `connect_peer` against `/ip4/<relay>/.../p2p-circuit/p2p/<dest>`
  actually establishes a connection to `<dest>` (visible in both peers'
  `LIST_PEERS` output as a `/p2p-circuit/` connection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)