### PR TITLE
chore(p2p-daemon): demote IPC wire-format logs to trace!

### DIFF
--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -41,11 +41,11 @@ impl P2PClient {
     /// - **Windows**: `addr` should be a multiaddr like `/ip4/127.0.0.1/tcp/5005`
     /// - **Unix**: `addr` should be a multiaddr like `/unix/tmp/p2pd.sock`
     pub async fn connect(addr: &str) -> Result<Self> {
-        debug!("Connecting to daemon at: {}", addr);
+        trace!("Connecting to daemon at: {}", addr);
 
         let stream = Self::connect_stream(addr).await?;
 
-        debug!("Connected to daemon");
+        trace!("Connected to daemon");
 
         Ok(Self {
             stream,
@@ -138,8 +138,7 @@ impl P2PClient {
 
     /// Send a request to the daemon and receive a response
     pub async fn send_request(&mut self, request: Request) -> Result<Response> {
-        // Debug: print request type
-        debug!("Request type field = {}", request.r#type);
+        trace!("Request type field = {}", request.r#type);
 
         // Serialize request
         let mut buf = BytesMut::new();
@@ -147,7 +146,7 @@ impl P2PClient {
             .encode(&mut buf)
             .map_err(|e| Error::Protocol(format!("Failed to encode request: {}", e)))?;
 
-        debug!(
+        trace!(
             "Encoded {} bytes - hex: {}",
             buf.len(),
             buf.iter()
@@ -362,9 +361,9 @@ impl P2PClient {
             pubsub: None,
         };
 
-        debug!("Connecting to peer with multiaddr: {}", peer_multiaddr);
+        trace!("Connecting to peer with multiaddr: {}", peer_multiaddr);
         let _response = self.send_request(request).await?;
-        debug!("Connected successfully");
+        trace!("Connected successfully");
         Ok(())
     }
 
@@ -446,9 +445,10 @@ impl P2PClient {
             remove_stream_handler: None,
         };
 
-        debug!(
+        trace!(
             "STREAM_HANDLER request: type={}, protocols={:?}",
-            request.r#type, protocols
+            request.r#type,
+            protocols
         );
 
         let response = self.send_request(request).await?;
@@ -536,7 +536,7 @@ impl P2PClient {
             .stream_info
             .ok_or_else(|| Error::Protocol("No StreamInfo in response".to_string()))?;
 
-        debug!(
+        trace!(
             "StreamInfo received: proto={}, peer_len={}, addr_len={}",
             stream_info.proto,
             stream_info.peer.len(),
@@ -573,14 +573,14 @@ impl P2PClient {
         let port = port.ok_or_else(|| Error::Protocol("No TCP port in multiaddr".to_string()))?;
 
         let socket_addr = std::net::SocketAddr::new(ip, port);
-        debug!("Connecting to daemon stream at: {}", socket_addr);
+        trace!("Connecting to daemon stream at: {}", socket_addr);
 
         // Connect to the daemon's forwarded stream
         let stream = tokio::net::TcpStream::connect(socket_addr)
             .await
             .map_err(Error::Io)?;
 
-        debug!("Connected to daemon stream");
+        trace!("Connected to daemon stream");
         Ok(stream)
     }
 
@@ -658,7 +658,7 @@ impl P2PClient {
             )));
         }
 
-        debug!("Successfully upgraded to persistent connection");
+        trace!("Successfully upgraded to persistent connection");
 
         // Create persistent connection
         let conn = Arc::new(PersistentConnection::new(reader, writer));

--- a/core/crates/kwaai-p2p-daemon/src/dht.rs
+++ b/core/crates/kwaai-p2p-daemon/src/dht.rs
@@ -10,7 +10,7 @@
 use crate::client::P2PClient;
 use crate::error::{Error, Result};
 use crate::protocol::p2pd::{dht_request, request, DhtRequest, Request};
-use tracing::{debug, trace};
+use tracing::trace;
 
 /// DHT peer information
 #[derive(Debug, Clone)]
@@ -43,7 +43,7 @@ impl P2PClient {
         value: Vec<u8>,
         timeout_secs: Option<i64>,
     ) -> Result<()> {
-        debug!(
+        trace!(
             "DHT PUT_VALUE: key len={}, value len={}",
             key.len(),
             value.len()
@@ -94,7 +94,7 @@ impl P2PClient {
         key: Vec<u8>,
         timeout_secs: Option<i64>,
     ) -> Result<DhtValue> {
-        debug!("DHT GET_VALUE: key len={}", key.len());
+        trace!("DHT GET_VALUE: key len={}", key.len());
 
         let dht_request = DhtRequest {
             r#type: dht_request::Type::GetValue as i32,
@@ -146,7 +146,7 @@ impl P2PClient {
         peer_id: Vec<u8>,
         timeout_secs: Option<i64>,
     ) -> Result<DhtPeerInfo> {
-        debug!("DHT FIND_PEER: peer_id len={}", peer_id.len());
+        trace!("DHT FIND_PEER: peer_id len={}", peer_id.len());
 
         let dht_request = DhtRequest {
             r#type: dht_request::Type::FindPeer as i32,
@@ -200,7 +200,7 @@ impl P2PClient {
         count: i32,
         timeout_secs: Option<i64>,
     ) -> Result<Option<DhtPeerInfo>> {
-        debug!("DHT FIND_PROVIDERS: cid len={}, count={}", cid.len(), count);
+        trace!("DHT FIND_PROVIDERS: cid len={}, count={}", cid.len(), count);
 
         let dht_request = DhtRequest {
             r#type: dht_request::Type::FindProviders as i32,
@@ -245,7 +245,7 @@ impl P2PClient {
     /// * `cid` - Content identifier (binary)
     /// * `timeout_secs` - Optional timeout in seconds
     pub async fn dht_provide(&mut self, cid: Vec<u8>, timeout_secs: Option<i64>) -> Result<()> {
-        debug!("DHT PROVIDE: cid len={}", cid.len());
+        trace!("DHT PROVIDE: cid len={}", cid.len());
 
         let dht_request = DhtRequest {
             r#type: dht_request::Type::Provide as i32,


### PR DESCRIPTION
## Summary

`P2PClient` and the DHT helpers logged every protobuf request type, every hex-prefix of the encoded payload, and every connect/connected/upgrade handshake at `debug!`. Useful when debugging the IPC layer itself, useless (and noisy) for everyone running `RUST_LOG=debug` on the CLI to investigate something at a higher layer.

Compare to the existing `peers list` UX, which is clean at debug level because its higher-level helpers don't trip these wire-format messages. This PR brings the rest of the `kwaainet p2p` commands (and any other caller of `P2PClient`) up to that same level of polish.

## What moved

**Demoted to `trace!`:**
- `client.rs`:
  - "Connecting to daemon at <addr>", "Connected to daemon"
  - "Connecting to daemon stream at <addr>", "Connected to daemon stream"
  - "Successfully upgraded to persistent connection"
  - "Connecting to peer with multiaddr: …" + "Connected successfully"
  - "Request type field = N", "Encoded N bytes - hex: …", "Received response (N bytes)"
  - "STREAM_HANDLER request: type=…, protocols=…"
  - "StreamInfo received: proto=…, peer_len=…, addr_len=…"
- `dht.rs`:
  - "DHT PUT_VALUE: key len=…, value len=…"
  - "DHT GET_VALUE: key len=…"
  - "DHT FIND_PEER: peer_id len=…"
  - "DHT FIND_PROVIDERS: cid len=…, count=…"
  - "DHT PROVIDE: cid len=…"

**Kept at debug!:**
- TCP / Unix-socket retry warnings (signal a real, actionable problem)
- "Stream handler registered/removed for protocols: …"
- "Opening stream for protocols: …"
- "Upgrading to persistent connection for unary handlers"

Anyone who genuinely needs the wire-level detail can ask for it via RUST_LOG=trace.

## Test plan

- [x] cargo fmt --all -- --check clean
- [x] cargo clippy --all-targets --all-features -- -D warnings clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)