### PR TITLE
feat(node): IDENTIFY-based public-IP detection + public_port + announce_addr correctness

### DIFF
--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -1197,7 +1197,7 @@ pub enum PeersAction {
     /// and replies with `b"ok"`), but with `--proto` works as a generic
     /// diagnostic for any registered handler. Doubles as the in-tree
     /// example of how to invoke a custom unary protocol over the libp2p
-    /// fabric — see `p2p_hello.rs` for the handler.
+    /// fabric — see `kwaai_p2p_daemon::hello` for the handler.
     ///
     /// Specify exactly one payload source: --message, --payload-hex,
     /// --payload-bin, or --stdin. The bytes are sent as-is; no encoding,
@@ -1210,7 +1210,7 @@ pub enum PeersAction {
         /// Protocol ID. Default is the hello protocol (a peer running
         /// kwaainet logs the payload and replies with `b"ok"`); for any
         /// other in-tree or third-party unary protocol, name it here.
-        #[arg(long, default_value = HELLO_PROTO_DEFAULT)]
+        #[arg(long, default_value = kwaai_p2p_daemon::hello::HELLO_PROTO)]
         proto: String,
 
         /// Send the bytes of this UTF-8 string as the payload. Identical
@@ -1243,5 +1243,3 @@ pub enum PeersAction {
         timeout: u64,
     },
 }
-
-const HELLO_PROTO_DEFAULT: &str = "/kwaai/p2p/hello/1.0.0";

--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -1192,15 +1192,56 @@ pub enum PeersAction {
         message: Option<String>,
     },
 
-    /// Send a hello message to an already-connected peer over
-    /// /kwaai/p2p/hello/1.0.0. Doubles as the in-tree example of how to
-    /// invoke a custom unary protocol over the libp2p fabric — see
-    /// `p2p_hello.rs` for the wire format and handler.
+    /// Invoke a unary RPC on an already-connected peer. Defaults to the
+    /// `/kwaai/p2p/hello/1.0.0` protocol (the recipient logs the payload
+    /// and replies with `b"ok"`), but with `--proto` works as a generic
+    /// diagnostic for any registered handler. Doubles as the in-tree
+    /// example of how to invoke a custom unary protocol over the libp2p
+    /// fabric — see `p2p_hello.rs` for the handler.
+    ///
+    /// Specify exactly one payload source: --message, --payload-hex,
+    /// --payload-bin, or --stdin. The bytes are sent as-is; no encoding,
+    /// no wrapper. The response is displayed below.
     Send {
         /// Recipient peer ID (base58)
-        peer_id: String,
+        #[arg(long)]
+        peer: String,
 
-        /// Message body (UTF-8)
-        message: String,
+        /// Protocol ID. Default is the hello protocol (a peer running
+        /// kwaainet logs the payload and replies with `b"ok"`); for any
+        /// other in-tree or third-party unary protocol, name it here.
+        #[arg(long, default_value = HELLO_PROTO_DEFAULT)]
+        proto: String,
+
+        /// Send the bytes of this UTF-8 string as the payload. Identical
+        /// to `--payload-bin` of a file containing the same bytes.
+        #[arg(long, group = "payload")]
+        message: Option<String>,
+
+        /// Send the bytes decoded from this hex string as the payload.
+        /// Whitespace in the hex is ignored. Use for short binary payloads
+        /// you want to type inline.
+        #[arg(long, group = "payload", value_name = "HEX")]
+        payload_hex: Option<String>,
+
+        /// Send the contents of this file as the payload. Use for any
+        /// payload too large to type inline, or for binary blobs you
+        /// already have on disk.
+        #[arg(long, group = "payload", value_name = "PATH")]
+        payload_bin: Option<std::path::PathBuf>,
+
+        /// Read the payload from stdin. Combine with shell redirection
+        /// (`< file.bin`), here-docs (`<<<'hi'`), or pipes
+        /// (`echo -n hi | …`). The bytes are sent verbatim.
+        #[arg(long, group = "payload")]
+        stdin: bool,
+
+        /// Maximum seconds to wait for the recipient's response. Useful when
+        /// poking at unfamiliar protocols whose handlers might hang on
+        /// malformed input. Default 10s.
+        #[arg(long, default_value = "10")]
+        timeout: u64,
     },
 }
+
+const HELLO_PROTO_DEFAULT: &str = "/kwaai/p2p/hello/1.0.0";

--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -1168,13 +1168,23 @@ pub enum PeersAction {
         timeout: i64,
     },
 
-    /// Manually dial a peer by multiaddr. Forces a connection attempt that
-    /// hole-punching can react to; optionally sends a hello message once the
-    /// connection succeeds.
+    /// Manually dial a peer. Forces a connection attempt that hole-punching
+    /// can react to; optionally sends a hello message once the connection
+    /// succeeds. Specify exactly one of --addr or --peer.
     Connect {
         /// Full multiaddr including /p2p/<peer-id> (and, for relay'd dials,
-        /// /p2p-circuit/p2p/<destination>).
-        multiaddr: String,
+        /// /p2p-circuit/p2p/<destination>). Use this when you have a
+        /// complete address in hand — typically copied from `peers list`
+        /// or `peers find`. No DHT lookup is performed.
+        #[arg(long, conflicts_with = "peer", required_unless_present = "peer")]
+        addr: Option<String>,
+
+        /// Peer ID (base58) to look up in the DHT and dial. The CLI runs
+        /// `dht_find_peer`, picks an address (preferring direct over
+        /// relay'd), appends /p2p/<peer-id>, and dials. Use this when you
+        /// only have a peer ID — e.g. one you saw in `peers list`.
+        #[arg(long, conflicts_with = "addr", required_unless_present = "addr")]
+        peer: Option<String>,
 
         /// Optional message to send over /kwaai/p2p/hello/1.0.0 once the
         /// connection succeeds. The recipient logs the message to stdout.

--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -1167,4 +1167,30 @@ pub enum PeersAction {
         #[arg(long, default_value = "10")]
         timeout: i64,
     },
+
+    /// Manually dial a peer by multiaddr. Forces a connection attempt that
+    /// hole-punching can react to; optionally sends a hello message once the
+    /// connection succeeds.
+    Connect {
+        /// Full multiaddr including /p2p/<peer-id> (and, for relay'd dials,
+        /// /p2p-circuit/p2p/<destination>).
+        multiaddr: String,
+
+        /// Optional message to send over /kwaai/p2p/hello/1.0.0 once the
+        /// connection succeeds. The recipient logs the message to stdout.
+        #[arg(long)]
+        message: Option<String>,
+    },
+
+    /// Send a hello message to an already-connected peer over
+    /// /kwaai/p2p/hello/1.0.0. Doubles as the in-tree example of how to
+    /// invoke a custom unary protocol over the libp2p fabric — see
+    /// `p2p_hello.rs` for the wire format and handler.
+    Send {
+        /// Recipient peer ID (base58)
+        peer_id: String,
+
+        /// Message body (UTF-8)
+        message: String,
+    },
 }

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -133,6 +133,15 @@ pub struct KwaaiNetConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage: Option<StorageConfig>,
 
+    /// Minimum number of independent IDENTIFY responses that must report the
+    /// same address before it is accepted as confirmed (default: 2).
+    #[serde(default = "default_identify_min_confirmations")]
+    pub identify_min_confirmations: usize,
+
+    /// How long to poll IDENTIFY for address confirmations, in seconds (default: 10).
+    #[serde(default = "default_identify_timeout_secs")]
+    pub identify_timeout_secs: u64,
+
     // ── Block rebalancing ─────────────────────────────────────────────────────
     /// Enable periodic block rebalancing (only active with `shard serve --auto`).
     /// When true, the shard server periodically checks DHT coverage and moves
@@ -492,6 +501,12 @@ fn default_backoff_multiplier() -> f64 {
 fn default_jitter_factor() -> f64 {
     0.5
 }
+fn default_identify_min_confirmations() -> usize {
+    2
+}
+fn default_identify_timeout_secs() -> u64 {
+    10
+}
 fn default_rebalance_interval() -> u64 {
     300
 }
@@ -527,6 +542,8 @@ impl Default for KwaaiNetConfig {
             vpk_mode: None,
             vpk_local_port: None,
             storage: None,
+            identify_min_confirmations: default_identify_min_confirmations(),
+            identify_timeout_secs: default_identify_timeout_secs(),
             auto_rebalance: false,
             rebalance_interval_secs: default_rebalance_interval(),
             rebalance_min_redundancy: default_rebalance_min_redundancy(),
@@ -702,6 +719,16 @@ impl KwaaiNetConfig {
             "contribute.storage" => self.contribute.storage = parse_bool(value)?,
             "contribute.shards" => self.contribute.shards = parse_bool(value)?,
             "contribute.auto_update" => self.contribute.auto_update = parse_bool(value)?,
+            "identify_min_confirmations" => {
+                self.identify_min_confirmations = value.parse().map_err(|_| {
+                    anyhow::anyhow!("identify_min_confirmations must be a positive integer")
+                })?
+            }
+            "identify_timeout_secs" => {
+                self.identify_timeout_secs = value.parse().map_err(|_| {
+                    anyhow::anyhow!("identify_timeout_secs must be a positive integer")
+                })?
+            }
             _ => anyhow::bail!(
                 "Unknown config key '{}'. Run `kwaainet config set --help` to see valid keys.",
                 key

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -81,6 +81,22 @@ pub struct KwaaiNetConfig {
     #[serde(default = "default_peers")]
     pub initial_peers: Vec<String>,
 
+    /// Multiaddrs of peers to use as trusted circuit relays (for AutoRelay).
+    /// When set, AutoRelay reserves circuits with these peers instead of (or
+    /// in addition to) discovering relays via the DHT. Useful when DHT
+    /// discovery is unreliable (small networks, NAT-isolated test topologies)
+    /// or when you want to force traffic through specific known-good relays.
+    /// Empty means "let AutoRelay discover relays via DHT" (the default).
+    #[serde(default)]
+    pub trusted_relays: Vec<String>,
+
+    /// When true, pre-declare this node as private (`-forceReachabilityPrivate`)
+    /// so AutoRelay activates immediately without waiting for AutoNAT probes.
+    /// Side effect: AutoNAT can never *promote* the node to public, even if
+    /// it actually is. Off by default — leave AutoNAT to decide.
+    #[serde(default)]
+    pub force_private: bool,
+
     #[serde(default)]
     pub health_monitoring: HealthConfig,
 
@@ -502,6 +518,8 @@ impl Default for KwaaiNetConfig {
             announce_addr: None,
             no_relay: false,
             initial_peers: default_peers(),
+            trusted_relays: Vec::new(),
+            force_private: false,
             health_monitoring: HealthConfig::default(),
             model_dht_prefix: None,
             model_repository: None,

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -505,7 +505,7 @@ fn default_identify_min_confirmations() -> usize {
     2
 }
 fn default_identify_timeout_secs() -> u64 {
-    10
+    45
 }
 fn default_rebalance_interval() -> u64 {
     300

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -72,6 +72,15 @@ pub struct KwaaiNetConfig {
     #[serde(default)]
     pub public_ip: Option<String>,
 
+    /// Public-side TCP port to advertise in the announce_addr derived from
+    /// `public_ip`. When `None`, defaults to the listening `port`. Use this
+    /// for port-forwarded deployments where the router maps an external port
+    /// (e.g. 443 or 8443) to the node's internal listen port (e.g. 8080).
+    /// Has no effect when `announce_addr` is set explicitly — that's a full
+    /// multiaddr and carries its own port.
+    #[serde(default)]
+    pub public_port: Option<u16>,
+
     #[serde(default)]
     pub announce_addr: Option<String>,
 
@@ -530,6 +539,7 @@ impl Default for KwaaiNetConfig {
                 std::env::consts::ARCH,
             )),
             public_ip: None,
+            public_port: None,
             announce_addr: None,
             no_relay: false,
             initial_peers: default_peers(),
@@ -698,6 +708,11 @@ impl KwaaiNetConfig {
             "log_level" => self.log_level = value.to_string(),
             "public_name" => self.public_name = Some(value.to_string()),
             "public_ip" => self.public_ip = Some(value.to_string()),
+            "public_port" => {
+                self.public_port = Some(value.parse().map_err(|_| {
+                    anyhow::anyhow!("public_port must be a positive integer between 1 and 65535")
+                })?)
+            }
             "announce_addr" => self.announce_addr = Some(value.to_string()),
             "no_relay" => self.no_relay = parse_bool(value)?,
             "start_block" => {

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -719,29 +719,6 @@ fn parse_bool(s: &str) -> Result<bool> {
     }
 }
 
-/// Detect public IP via ipify.org (async).
-pub async fn detect_public_ip() -> Option<String> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .ok()?;
-    let ip = client
-        .get("https://api.ipify.org")
-        .send()
-        .await
-        .ok()?
-        .text()
-        .await
-        .ok()?
-        .trim()
-        .to_string();
-    if ip.is_empty() {
-        None
-    } else {
-        Some(ip)
-    }
-}
-
 mod dirs_sys {
     use std::path::PathBuf;
     pub fn home_dir() -> Option<PathBuf> {

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -16,7 +16,6 @@ mod monitor;
 mod node;
 mod ollama;
 mod p2p_cmd;
-mod p2p_hello;
 mod progress;
 #[cfg(feature = "rag")]
 mod rag_api;

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -16,6 +16,7 @@ mod monitor;
 mod node;
 mod ollama;
 mod p2p_cmd;
+mod p2p_hello;
 mod progress;
 #[cfg(feature = "rag")]
 mod rag_api;

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -257,13 +257,6 @@ async fn main() -> Result<()> {
                 print_separator();
             }
 
-            // Auto-detect public IP if neither announce_addr nor public_ip is set
-            if cfg.announce_addr.is_none() && cfg.public_ip.is_none() {
-                if let Some(ip) = config::detect_public_ip().await {
-                    cfg.public_ip = Some(ip);
-                }
-            }
-
             let mgr = DaemonManager::new();
 
             if mgr.is_running() && !args.concurrent {

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -492,11 +492,11 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     }
 
     // -----------------------------------------------------------------------
-    // Step 5: Self-discover external address via IDENTIFY (when not manually
+    // Step 5: Self-discover announce addresses via IDENTIFY (when not manually
     // configured). After at least one bootstrap peer connects, the libp2p
-    // IDENTIFY protocol lets peers report our observed external address. We
-    // poll until 2 separate responses agree on the same address, then restart
-    // p2pd with that address as its announce addr so map.kwaai.ai can reach us.
+    // IDENTIFY protocol lets peers report our observed addresses. We poll until
+    // min_confirmations separate responses agree on the same address, then
+    // restart p2pd with those addresses as its announce addrs.
     // -----------------------------------------------------------------------
     let mut discovered_addrs: Vec<String>;
     if announce_addr.is_none() {
@@ -509,6 +509,9 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             &p2pd_path,
             &handler_addr,
             config.no_relay,
+            config.port,
+            config.identify_min_confirmations,
+            config.identify_timeout_secs,
         )
         .await?;
     } else {
@@ -524,7 +527,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     //   effective_tps = min(compute_tps, network_rps × relay_penalty)
     //   network_rps   = download_bps / (hidden_size × 16)
     // using_relay: true only if we have no explicit address and IDENTIFY
-    // discovery also came up empty. If we confirmed an external address
+    // discovery also came up empty. If we have confirmed announce addresses
     // (directly or via IDENTIFY) we are directly reachable — no relay needed.
     let using_relay = announce_addr.is_none() && discovered_addrs.is_empty() && !config.no_relay;
 
@@ -956,9 +959,15 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             // Periodic IDENTIFY address check (every 5 minutes).
             // Skipped when announce_addr/public_ip was explicitly configured.
             _ = identify_check.tick(), if !explicit_announce => {
-                let fresh = collect_observed_addresses(&mut client, 2, Duration::from_secs(8)).await;
-                if !fresh.is_empty() && fresh != discovered_addrs {
-                    info!("External address changed:");
+                info!("Checking announce addresses via IDENTIFY...");
+                let fresh = collect_observed_addresses(&mut client, config.identify_min_confirmations, Duration::from_secs(config.identify_timeout_secs), config.port).await;
+                info!("  IDENTIFY result: {} addr(s) confirmed", fresh.len());
+                let mut fresh_sorted = fresh.clone();
+                let mut current_sorted = discovered_addrs.clone();
+                fresh_sorted.sort();
+                current_sorted.sort();
+                if !fresh_sorted.is_empty() && fresh_sorted != current_sorted {
+                    info!("Announce addresses changed:");
                     for addr in &discovered_addrs {
                         info!("  old: {}", addr);
                     }
@@ -1418,23 +1427,26 @@ async fn restart_p2pd_with_addrs(
     };
 
     *daemon = builder.spawn().await.context("restarting p2pd")?;
-    *client = daemon.client().await.context("p2pd client reconnect after restart")?;
+    *client = daemon
+        .client()
+        .await
+        .context("p2pd client reconnect after restart")?;
 
     client
         .register_stream_handler(&handler_addr_str, dht_protocols)
         .await
         .context("re-registering stream handlers after restart")?;
-    info!("  p2pd restarted and handlers re-registered");
+    info!("p2pd restarted and handlers re-registered");
 
     Ok(())
 }
-/// Self-discover external address via IDENTIFY and restart p2pd with announce addrs.
+/// Discover observed addresses via IDENTIFY and restart p2pd with them.
 ///
 /// When no explicit `announce_addr` or `public_ip` is configured, we rely on the
 /// libp2p IDENTIFY protocol: after bootstrap peers connect they report our observed
-/// external address back to us. Once 2 independent responses agree we shut the
-/// initial p2pd down, rebuild it with the confirmed address as its announce addr,
-/// and return the new daemon + client along with the discovered addresses.
+/// addresses back to us. Once `min_confirmations` independent responses agree we
+/// shut the initial p2pd down, rebuild it with the confirmed addresses as its
+/// announce addrs, and return the new daemon + client along with those addresses.
 ///
 /// If IDENTIFY yields nothing the original daemon is returned unchanged and the
 /// returned address list is empty (the node will fall back to relay mode).
@@ -1447,25 +1459,38 @@ async fn discover_and_restart_with_announce(
     p2pd_path: &Option<std::path::PathBuf>,
     handler_addr: &std::net::SocketAddr,
     no_relay: bool,
+    port: u16,
+    min_confirmations: usize,
+    timeout_secs: u64,
 ) -> anyhow::Result<(
     kwaai_p2p_daemon::P2PDaemon,
     kwaai_p2p_daemon::P2PClient,
     Vec<String>,
 )> {
-    info!("No explicit announce address — discovering via IDENTIFY...");
-    let discovered_addrs =
-        collect_observed_addresses(&mut client, 2, Duration::from_secs(10)).await;
+    info!("No explicit announce address — discovering addresses via IDENTIFY...");
+
+    // Give bootstrap peer(s) a moment to complete the IDENTIFY exchange before
+    // polling. The TCP connection is established by the time we're called, but
+    // IDENTIFY runs asynchronously after it.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let discovered_addrs = collect_observed_addresses(
+        &mut client,
+        min_confirmations,
+        Duration::from_secs(timeout_secs),
+        port,
+    )
+    .await;
 
     if discovered_addrs.is_empty() {
         warn!(
-            "⚠️ Could not confirm external address via IDENTIFY \
+            "⚠️ Could not confirm any announce addresses via IDENTIFY \
              — node may appear Unreachable on map.kwaai.ai. \
              Set public_ip or announce_addr in config to override."
         );
         return Ok((daemon, client, discovered_addrs));
     }
 
-    info!("Confirmed external address(es) — restarting p2pd with announce addrs:");
+    info!("Confirmed announce address(es) — restarting p2pd:");
     for addr in &discovered_addrs {
         info!("  - {}", addr);
     }
@@ -1480,10 +1505,11 @@ async fn discover_and_restart_with_announce(
 }
 
 /// Poll `identify_with_addrs()` until `min_confirmations` separate responses
-/// all include the same public multiaddr, or `timeout` elapses.
+/// all include the same multiaddr, or `timeout` elapses.
 ///
-/// Returns the confirmed public addresses as multiaddr strings (e.g.
-/// `/ip4/203.0.113.1/tcp/8080`). Private/loopback addresses are filtered out.
+/// Returns the confirmed addresses as multiaddr strings (e.g.
+/// `/ip4/203.0.113.1/tcp/8080`). Unspecified and link-local addresses are
+/// filtered out; private/loopback addresses are included.
 ///
 /// "Confirmation" here means the address appeared in at least
 /// `min_confirmations` distinct IDENTIFY responses. p2pd refreshes its
@@ -1494,80 +1520,116 @@ async fn collect_observed_addresses(
     client: &mut kwaai_p2p_daemon::P2PClient,
     min_confirmations: usize,
     timeout: Duration,
+    port: u16,
 ) -> Vec<String> {
     use libp2p::Multiaddr;
     use std::collections::HashMap;
 
+    // Poll for the full timeout window so every address has an equal chance
+    // to accumulate confirmations. Returning early as soon as any address hits
+    // the threshold causes addresses that appear later (e.g. the public IP
+    // observed by the second bootstrap peer) to be dropped.
     let deadline = tokio::time::Instant::now() + timeout;
     let mut counts: HashMap<String, usize> = HashMap::new();
 
     loop {
         match client.identify_with_addrs().await {
             Ok((_peer_id, addrs)) => {
+                tracing::debug!("IDENTIFY returned {} addr(s)", addrs.len());
                 for addr_bytes in &addrs {
-                    // Parse as libp2p Multiaddr so we can inspect the components.
                     if let Ok(ma) = Multiaddr::try_from(addr_bytes.clone()) {
                         let s = ma.to_string();
-                        if is_public_multiaddr(&ma) {
-                            *counts.entry(s).or_insert(0) += 1;
+                        if let Some(normalized) = normalize_announce_addr(&ma, port) {
+                            let count = counts.entry(normalized.clone()).or_insert(0);
+                            *count += 1;
+                            tracing::debug!("  addr={} → {} ({}x)", s, normalized, count);
+                        } else {
+                            tracing::debug!("  addr={} → filtered", s);
                         }
                     }
                 }
             }
-            Err(e) => {
-                tracing::debug!("identify_with_addrs error: {}", e);
-            }
-        }
-
-        let confirmed: Vec<String> = counts
-            .iter()
-            .filter(|(_, &c)| c >= min_confirmations)
-            .map(|(addr, _)| addr.clone())
-            .collect();
-
-        if !confirmed.is_empty() {
-            return confirmed;
+            Err(e) => tracing::debug!("identify_with_addrs error: {}", e),
         }
 
         if tokio::time::Instant::now() >= deadline {
-            // Return whatever we have (even unconfirmed) as a best-effort
-            // fallback if we got at least one observation.
-            let best_effort: Vec<String> = counts.into_keys().collect();
-            if !best_effort.is_empty() {
-                tracing::warn!(
-                    "IDENTIFY: could not get {} confirmations within {:?}; \
-                     using best-effort address(es): {:?}",
-                    min_confirmations,
-                    timeout,
-                    best_effort
-                );
-            }
-            return best_effort;
+            break;
         }
 
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+
+    let confirmed: Vec<String> = counts
+        .into_iter()
+        .filter(|(_, c)| *c >= min_confirmations)
+        .map(|(addr, _)| addr)
+        .collect();
+
+    if confirmed.is_empty() {
+        tracing::warn!(
+            "IDENTIFY: no addresses reached {} confirmation(s) within {:?}",
+            min_confirmations,
+            timeout,
+        );
+    }
+
+    confirmed
 }
 
-/// Returns true if the multiaddr represents a publicly routable address.
-/// Filters out loopback, RFC-1918 private ranges, and link-local.
-fn is_public_multiaddr(ma: &libp2p::Multiaddr) -> bool {
+/// Normalise a multiaddr from `host.Addrs()` into an announce address, or
+/// return `None` if it should be filtered.
+///
+/// `host.Addrs()` contains two kinds of entries:
+///   - Our own listen addresses (loopback, LAN) — always on `our_port`.
+///   - Peer-observed addresses from the libp2p IDENTIFY protocol — our IP as
+///     seen by the peer, but with an ephemeral source port because they were
+///     recorded from our outbound TCP connections to those peers.
+///
+/// Private and loopback addresses are accepted as-is — `host.Addrs()` only
+/// ever contains our own interfaces for these ranges, so no port filter is
+/// needed.
+///
+/// Unspecified (`0.0.0.0`/`::`) and link-local addresses are rejected.
+/// Addresses with no TCP component are rejected.
+fn normalize_announce_addr(ma: &libp2p::Multiaddr, our_port: u16) -> Option<String> {
     use libp2p::multiaddr::Protocol;
+    use std::net::IpAddr;
+
+    let mut ip: Option<IpAddr> = None;
+    let mut has_tcp = false;
+
     for proto in ma.iter() {
         match proto {
-            Protocol::Ip4(ip) => {
-                return !ip.is_loopback()
-                    && !ip.is_private()
-                    && !ip.is_link_local()
-                    && !ip.is_unspecified();
+            Protocol::Ip4(a) => {
+                if a.is_unspecified() || a.is_link_local() {
+                    return None;
+                }
+                ip = Some(IpAddr::V4(a));
             }
-            Protocol::Ip6(ip) => {
-                return !ip.is_loopback() && !ip.is_unspecified();
+            Protocol::Ip6(a) => {
+                if a.is_unspecified() {
+                    return None;
+                }
+                ip = Some(IpAddr::V6(a));
             }
+            Protocol::Tcp(_) => has_tcp = true,
             _ => {}
         }
     }
-    false
+
+    let ip = ip?;
+    if !has_tcp {
+        return None;
+    }
+
+    // Always announce on our_port. For peer-observed addresses the port is
+    // ephemeral (outbound NAT mapping) and must be replaced. For listen
+    // addresses our_port is already correct.
+    let normalized = match ip {
+        IpAddr::V4(a) => format!("/ip4/{}/tcp/{}", a, our_port),
+        IpAddr::V6(a) => format!("/ip6/{}/tcp/{}", a, our_port),
+    };
+    Some(normalized)
 }
 
 /// Wait for p2pd's own DHT bootstrap to establish connections.

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -375,6 +375,21 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // to silently fail).
     let trusted_relays = config.trusted_relays.clone();
 
+    // Reachability is decided by libp2p at runtime: AutoNAT probes the
+    // bootstraps, and if dialback fails AutoRelay reserves a circuit on a
+    // trusted relay. The IDENTIFY discover step polls host.Addrs() until
+    // either a verified direct address or a /p2p-circuit address appears,
+    // then announces whatever the daemon reports.
+    //
+    // The DaemonBuilder's dht_server(true) knob (see kwaai-p2p-daemon/src/
+    // daemon.rs) keeps a node in DHT server mode regardless of AutoNAT
+    // verdict — without it p2pd defaults to client mode until reachability
+    // is confirmed, which means the node never gets advertised into peers'
+    // routing tables and FindPeer lookups for it fail. Not used here for
+    // regular nodes (the default `dht(true)` auto-mode is correct), but
+    // available for bootstrap-style deployments that need to be findable
+    // from t=0.
+
     let builder = P2PDaemon::builder()
         .dht(true)
         .bootstrap(!bootstrap_peers.is_empty())
@@ -526,10 +541,22 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // Determine effective throughput using the Petals formula:
     //   effective_tps = min(compute_tps, network_rps × relay_penalty)
     //   network_rps   = download_bps / (hidden_size × 16)
-    // using_relay: true only if we have no explicit address and IDENTIFY
-    // discovery also came up empty. If we have confirmed announce addresses
-    // (directly or via IDENTIFY) we are directly reachable — no relay needed.
-    let using_relay = announce_addr.is_none() && discovered_addrs.is_empty() && !config.no_relay;
+    //
+    // using_relay drives the map's "Direct" vs "Via relay" badge:
+    //   - explicit announce_addr/public_ip  → false (Direct)
+    //   - all discovered addrs are circuits → true  (Via relay)
+    //   - mix of circuit + direct           → false (Direct, relay is fallback)
+    //   - no usable addrs discovered        → true  (intent is relay; the
+    //     node has no public reachability and no relay reservation succeeded
+    //     yet, but treating it as Direct on the map would be misleading
+    //     since libp2p's leaked LAN listen addr is not actually reachable)
+    let using_relay = if announce_addr.is_some() {
+        false
+    } else if discovered_addrs.is_empty() {
+        true
+    } else {
+        all_addrs_are_relay(&discovered_addrs)
+    };
 
     // Measure network bandwidth once at startup (1 MiB Cloudflare probe).
     // Stored so re-announcements can recompute effective_tps without re-probing.
@@ -861,7 +888,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                             warn!("Deferred p2pd restart failed: {}", e);
                         } else {
                             discovered_addrs = new_addrs.clone();
-                            server_info.using_relay = false;
+                            server_info.using_relay = all_addrs_are_relay(&discovered_addrs);
                             pending_restart = None;
                         }
                     }
@@ -1496,10 +1523,17 @@ async fn discover_and_restart_with_announce(
     }
 
     restart_p2pd_with_addrs(
-        &mut daemon, &mut client, &discovered_addrs,
-        host_addr, bootstrap_peers, identity_key_path,
-        p2pd_path, handler_addr, no_relay,
-    ).await?;
+        &mut daemon,
+        &mut client,
+        &discovered_addrs,
+        host_addr,
+        bootstrap_peers,
+        identity_key_path,
+        p2pd_path,
+        handler_addr,
+        no_relay,
+    )
+    .await?;
 
     Ok((daemon, client, discovered_addrs))
 }
@@ -1520,15 +1554,17 @@ async fn collect_observed_addresses(
     client: &mut kwaai_p2p_daemon::P2PClient,
     min_confirmations: usize,
     timeout: Duration,
-    port: u16,
+    _port: u16,
 ) -> Vec<String> {
     use libp2p::Multiaddr;
     use std::collections::HashMap;
 
-    // Poll for the full timeout window so every address has an equal chance
-    // to accumulate confirmations. Returning early as soon as any address hits
-    // the threshold causes addresses that appear later (e.g. the public IP
-    // observed by the second bootstrap peer) to be dropped.
+    // host.Addrs() is libp2p's authoritative set of advertised addresses:
+    //   - AutoNAT-confirmed direct addresses (bootstraps verified inbound dialback)
+    //   - AutoRelay-reserved /p2p-circuit addresses
+    //   - Local listen interfaces (loopback, LAN)
+    // Trust the daemon's filtering — we don't second-guess its port or IP.
+    // We only drop entries that are obviously unusable (loopback/link-local).
     let deadline = tokio::time::Instant::now() + timeout;
     let mut counts: HashMap<String, usize> = HashMap::new();
 
@@ -1539,10 +1575,10 @@ async fn collect_observed_addresses(
                 for addr_bytes in &addrs {
                     if let Ok(ma) = Multiaddr::try_from(addr_bytes.clone()) {
                         let s = ma.to_string();
-                        if let Some(normalized) = normalize_announce_addr(&ma, port) {
-                            let count = counts.entry(normalized.clone()).or_insert(0);
+                        if is_announceable_addr(&ma) {
+                            let count = counts.entry(s.clone()).or_insert(0);
                             *count += 1;
-                            tracing::debug!("  addr={} → {} ({}x)", s, normalized, count);
+                            tracing::debug!("  addr={} ({}x)", s, count);
                         } else {
                             tracing::debug!("  addr={} → filtered", s);
                         }
@@ -1576,60 +1612,90 @@ async fn collect_observed_addresses(
     confirmed
 }
 
-/// Normalise a multiaddr from `host.Addrs()` into an announce address, or
-/// return `None` if it should be filtered.
+/// Decide whether a multiaddr from p2pd's `host.Addrs()` is suitable to
+/// announce.
 ///
-/// `host.Addrs()` contains two kinds of entries:
-///   - Our own listen addresses (loopback, LAN) — always on `our_port`.
-///   - Peer-observed addresses from the libp2p IDENTIFY protocol — our IP as
-///     seen by the peer, but with an ephemeral source port because they were
-///     recorded from our outbound TCP connections to those peers.
+/// Three kinds of entries appear there:
+///   - AutoNAT-confirmed direct: `/ip4/PUB/tcp/PORT` — the bootstraps verified
+///     they can dial us back at this exact address. Announce.
+///   - AutoRelay-reserved circuit: `/.../p2p-circuit` — we hold a reservation
+///     on a relay; peers can reach us through it. Announce.
+///   - Local listen interface: loopback / LAN — only useful inside our box or
+///     LAN, never as a public announce. Drop.
 ///
-/// Private and loopback addresses are accepted as-is — `host.Addrs()` only
-/// ever contains our own interfaces for these ranges, so no port filter is
-/// needed.
+/// We accept any address with a `/p2p-circuit` segment, or one with a
+/// globally-routable IP. RFC1918 / CGNAT / loopback / link-local IPs are
+/// rejected when standalone — they appear in `host.Addrs()` because they are
+/// our local listen interfaces, but they are not reachable from outside the
+/// LAN and announcing them produces Direct-but-unreachable nodes.
 ///
-/// Unspecified (`0.0.0.0`/`::`) and link-local addresses are rejected.
-/// Addresses with no TCP component are rejected.
-fn normalize_announce_addr(ma: &libp2p::Multiaddr, our_port: u16) -> Option<String> {
+/// Operators with unusual topologies (private overlays, port-forwarded
+/// routers, deployments where the public IP genuinely is RFC1918) should set
+/// `public_ip` or `announce_addr` explicitly to bypass IDENTIFY discovery.
+fn is_announceable_addr(ma: &libp2p::Multiaddr) -> bool {
     use libp2p::multiaddr::Protocol;
-    use std::net::IpAddr;
 
-    let mut ip: Option<IpAddr> = None;
-    let mut has_tcp = false;
+    let mut has_circuit = false;
+    let mut routable_ip = false;
+    let mut bad_ip = false;
 
     for proto in ma.iter() {
         match proto {
+            Protocol::P2pCircuit => has_circuit = true,
             Protocol::Ip4(a) => {
-                if a.is_unspecified() || a.is_link_local() {
-                    return None;
+                if !is_globally_routable_v4(a) {
+                    bad_ip = true;
+                } else {
+                    routable_ip = true;
                 }
-                ip = Some(IpAddr::V4(a));
             }
             Protocol::Ip6(a) => {
-                if a.is_unspecified() {
-                    return None;
+                if a.is_unspecified() || a.is_loopback() {
+                    bad_ip = true;
+                } else {
+                    routable_ip = true;
                 }
-                ip = Some(IpAddr::V6(a));
             }
-            Protocol::Tcp(_) => has_tcp = true,
             _ => {}
         }
     }
 
-    let ip = ip?;
-    if !has_tcp {
-        return None;
+    if has_circuit {
+        return true;
     }
+    routable_ip && !bad_ip
+}
 
-    // Always announce on our_port. For peer-observed addresses the port is
-    // ephemeral (outbound NAT mapping) and must be replaced. For listen
-    // addresses our_port is already correct.
-    let normalized = match ip {
-        IpAddr::V4(a) => format!("/ip4/{}/tcp/{}", a, our_port),
-        IpAddr::V6(a) => format!("/ip6/{}/tcp/{}", a, our_port),
-    };
-    Some(normalized)
+/// True iff `a` is plausibly an externally-reachable IPv4 address. Rejects
+/// loopback, link-local, unspecified, broadcast, multicast, and the RFC1918 /
+/// RFC6598 (CGNAT) private ranges.
+///
+/// We deliberately do NOT reject RFC5737 documentation ranges
+/// (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`) here — they are
+/// reserved by IANA but not LAN-private, and our nat-test topology uses
+/// `198.51.100.0/24` as a simulated public network.
+fn is_globally_routable_v4(a: std::net::Ipv4Addr) -> bool {
+    if a.is_unspecified()
+        || a.is_loopback()
+        || a.is_link_local()
+        || a.is_broadcast()
+        || a.is_multicast()
+        || a.is_private()
+    {
+        return false;
+    }
+    let [b0, b1, ..] = a.octets();
+    // RFC6598 carrier-grade NAT: 100.64.0.0/10
+    if b0 == 100 && (64..=127).contains(&b1) {
+        return false;
+    }
+    true
+}
+
+/// Returns true if every confirmed announce address is a relay circuit
+/// (`/p2p-circuit`). Used to set `using_relay` on the DHT record.
+fn all_addrs_are_relay(addrs: &[String]) -> bool {
+    !addrs.is_empty() && addrs.iter().all(|s| s.contains("/p2p-circuit"))
 }
 
 /// Wait for p2pd's own DHT bootstrap to establish connections.

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -439,8 +439,8 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // node's "while we're alive, please answer these" surface area.
     client
         .add_unary_handler(
-            crate::p2p_hello::HELLO_PROTO,
-            crate::p2p_hello::make_handler(),
+            kwaai_p2p_daemon::hello::HELLO_PROTO,
+            kwaai_p2p_daemon::hello::make_handler(),
             false,
         )
         .await

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -361,17 +361,26 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
 
     let identity_key_path = NodeIdentity::key_file_path();
 
+    // Trusted relays: empty means "let AutoRelay discover via DHT". When the
+    // user configures explicit trusted_relays we pass them through; otherwise
+    // we leave the list empty rather than auto-promoting bootstraps to relays
+    // (bootstraps may not run a hop relay service, which causes reservations
+    // to silently fail).
+    let trusted_relays = config.trusted_relays.clone();
+
     let builder = P2PDaemon::builder()
         .dht(true)
         .bootstrap(!bootstrap_peers.is_empty())
         .relay(!config.no_relay)
         .auto_relay(true)
         .auto_nat(true)
-        .force_reachability_private(announce_addr.is_none() && !config.no_relay)
+        // Pre-declaring private blocks AutoNAT from ever promoting the node
+        // to public, even if it actually is. Only honour an explicit opt-in.
+        .force_reachability_private(config.force_private)
         .nat_portmap(true)
         .host_addrs([host_addr])
         .bootstrap_peers(bootstrap_peers.clone())
-        .trusted_relays(bootstrap_peers.clone())
+        .trusted_relays(trusted_relays.clone())
         .with_identity_key(&identity_key_path);
 
     let builder = if let Some(ref addr) = announce_addr {
@@ -1589,11 +1598,11 @@ async fn restart_p2pd(
         .relay(!config.no_relay)
         .auto_relay(true)
         .auto_nat(true)
-        .force_reachability_private(announce_addr.is_none() && !config.no_relay)
+        .force_reachability_private(config.force_private)
         .nat_portmap(true)
         .host_addrs([host_addr])
         .bootstrap_peers(bootstrap_peers.to_vec())
-        .trusted_relays(bootstrap_peers.to_vec())
+        .trusted_relays(config.trusted_relays.clone())
         .with_identity_key(&identity_key_path);
 
     let builder = match announce_addr {

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -356,14 +356,18 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
 
     // Announce address: prefer explicit announce_addr, fall back to public_ip.
     // announce_addr is a raw multiaddr (e.g. /dns/kwaainet/tcp/8080).
-    // public_ip is an IP address formatted as /ip4/<ip>/tcp/<port>.
+    // public_ip is an IP address formatted as /ip4/<ip>/tcp/<port>, where
+    // <port> is `public_port` if set (port-forwarded deployments where the
+    // router maps an external port to the node's internal listen port) or
+    // `port` otherwise.
     // An empty string public_ip is treated as "no public IP".
+    let announce_port = config.public_port.unwrap_or(config.port);
     let announce_addr = config.announce_addr.clone().or_else(|| {
         config
             .public_ip
             .as_deref()
             .filter(|ip| !ip.is_empty())
-            .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port))
+            .map(|ip| format!("/ip4/{}/tcp/{}", ip, announce_port))
     });
 
     let identity_key_path = NodeIdentity::key_file_path();

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -738,6 +738,16 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
         300, 30,
     ))));
 
+    // Tracks the number of RPC stream handler tasks currently in-flight.
+    // Used to gate p2pd restarts: we defer any restart until this reaches zero
+    // so we never tear down the daemon mid-request.
+    let active_rpc_streams: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+
+    // When IDENTIFY detects an address change while RPC streams are active we
+    // store the new addresses here and apply the restart at the next reannounce
+    // tick once the node is idle (active_rpc_streams == 0).
+    let mut pending_restart: Option<Vec<String>> = None;
+
     // Periodic IDENTIFY check — only active when no explicit announce_addr is
     // configured. Every 5 minutes we re-poll our observed addresses; if they
     // differ from what we announced at startup (e.g. after a network change)
@@ -763,10 +773,13 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                     Ok((mut stream, addr)) => {
                         info!("Incoming RPC from {}", addr);
                         let s = storage_clone.clone();
+                        let counter = active_rpc_streams.clone();
+                        counter.fetch_add(1, Ordering::Relaxed);
                         tokio::spawn(async move {
                             if let Err(e) = handle_rpc_stream(&mut stream, s).await {
                                 warn!("RPC handler error: {}", e);
                             }
+                            counter.fetch_sub(1, Ordering::Relaxed);
                         });
                     }
                     Err(e) => warn!("Accept error: {}", e),
@@ -820,6 +833,34 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                     ).await {
                         Ok(()) => info!("✅ p2pd restarted and handlers re-registered"),
                         Err(e) => warn!("p2pd restart failed: {} — will retry in 120s", e),
+                    }
+                }
+
+                // If IDENTIFY detected an address change while RPC streams were
+                // active, apply the deferred p2pd restart now — but only once
+                // all in-flight RPC handler tasks have completed.
+                if let Some(ref new_addrs) = pending_restart.clone() {
+                    if active_rpc_streams.load(Ordering::Relaxed) > 0 {
+                        info!(
+                            "p2pd restart pending ({} active RPC stream(s)) — will retry next tick",
+                            active_rpc_streams.load(Ordering::Relaxed)
+                        );
+                    } else {
+                        info!("Applying deferred p2pd restart with new announce addr(s):");
+                        for addr in new_addrs {
+                            info!("  {}", addr);
+                        }
+                        if let Err(e) = restart_p2pd_with_addrs(
+                            &mut daemon, &mut client, new_addrs,
+                            &host_addr, &bootstrap_peers, &identity_key_path,
+                            &p2pd_path, &handler_addr, config.no_relay,
+                        ).await {
+                            warn!("Deferred p2pd restart failed: {}", e);
+                        } else {
+                            discovered_addrs = new_addrs.clone();
+                            server_info.using_relay = false;
+                            pending_restart = None;
+                        }
                     }
                 }
 
@@ -917,74 +958,19 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             _ = identify_check.tick(), if !explicit_announce => {
                 let fresh = collect_observed_addresses(&mut client, 2, Duration::from_secs(8)).await;
                 if !fresh.is_empty() && fresh != discovered_addrs {
-                    info!("External address changed — restarting p2pd:");
+                    info!("External address changed:");
                     for addr in &discovered_addrs {
                         info!("  old: {}", addr);
                     }
                     for addr in &fresh {
                         info!("  new: {}", addr);
                     }
-                    // Unregister handlers, restart p2pd with new announce addrs.
-                    let _ = client
-                        .remove_stream_handler(
-                            &format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port()),
-                            vec![
-                                "DHTProtocol.rpc_ping".to_string(),
-                                "DHTProtocol.rpc_store".to_string(),
-                                "DHTProtocol.rpc_find".to_string(),
-                            ],
-                        )
-                        .await;
-                    let _ = daemon.shutdown().await;
-
-                    let builder = P2PDaemon::builder()
-                        .dht(true)
-                        .relay(!config.no_relay)
-                        .auto_relay(true)
-                        .auto_nat(true)
-                        .nat_portmap(true)
-                        .host_addrs([host_addr.clone()])
-                        .bootstrap_peers(bootstrap_peers.clone())
-                        .announce_addrs(fresh.iter().map(|s| s.as_str()))
-                        .with_identity_key(&identity_key_path);
-                    let builder = if let Some(ref path) = p2pd_path {
-                        builder.with_binary_path(path)
-                    } else {
-                        builder
-                    };
-                    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
-                        #[cfg(unix)]
-                        let sock_addr = format!("/unix/{}", sock);
-                        #[cfg(not(unix))]
-                        let sock_addr = sock;
-                        builder.with_listen_addr(sock_addr)
-                    } else {
-                        builder
-                    };
-
-                    match builder.spawn().await {
-                        Ok(new_daemon) => {
-                            daemon = new_daemon;
-                            match daemon.client().await {
-                                Ok(new_client) => {
-                                    client = new_client;
-                                    discovered_addrs = fresh;
-                                    server_info.using_relay = false;
-                                    let sb = config.start_block as i32;
-                                    let eb = config.effective_end_block() as i32;
-                                    if let Err(e) = announce(
-                                        &mut client, peer_id, &storage, &bootstrap_peers,
-                                        &prefix, &repository, config.model_total_blocks(),
-                                        sb, eb, &server_info, Some(&mut rep_store),
-                                    ).await {
-                                        warn!("Re-announce after address change failed: {}", e);
-                                    }
-                                }
-                                Err(e) => warn!("p2pd client reconnect failed: {}", e),
-                            }
-                        }
-                        Err(e) => warn!("p2pd restart failed: {}", e),
-                    }
+                    // Don't restart p2pd immediately — doing so mid-inference would
+                    // tear down active relay circuits and orphan in-flight RPC streams.
+                    // Instead record the new addresses and let the reannounce tick
+                    // apply the restart once the node is idle.
+                    pending_restart = Some(fresh);
+                    info!("  p2pd restart deferred until node is idle");
                 }
             }
 
@@ -1366,6 +1352,82 @@ async fn send_to_bootstrap(
     (succeeded > 0, timings)
 }
 
+/// Unregister DHT stream handlers, shut down p2pd, rebuild and spawn it with
+/// the supplied set of announce addresses, reconnect the client, and re-register
+/// handlers. Used by the deferred-restart path (reannounce tick), where new
+/// addresses learned via IDENTIFY need to be promoted to the announce set.
+///
+/// Distinct from the `restart_p2pd` function above (which restarts after a p2pd
+/// crash with the original announce_addr); this one takes an explicit
+/// `announce_addrs` slice. Both share the same daemon-spawning shape.
+///
+/// `remove_stream_handler` failures are non-fatal (daemon may already be
+/// unresponsive). All other failures are returned as `Err` for the caller to
+/// handle at the appropriate severity.
+async fn restart_p2pd_with_addrs(
+    daemon: &mut kwaai_p2p_daemon::P2PDaemon,
+    client: &mut kwaai_p2p_daemon::P2PClient,
+    announce_addrs: &[String],
+    host_addr: &str,
+    bootstrap_peers: &[String],
+    identity_key_path: &std::path::Path,
+    p2pd_path: &Option<std::path::PathBuf>,
+    handler_addr: &std::net::SocketAddr,
+    no_relay: bool,
+) -> anyhow::Result<()> {
+    let handler_addr_str = format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port());
+    let dht_protocols = vec![
+        "DHTProtocol.rpc_ping".to_string(),
+        "DHTProtocol.rpc_store".to_string(),
+        "DHTProtocol.rpc_find".to_string(),
+    ];
+
+    // Unregister handlers before shutdown so the listener port is freed
+    // cleanly before we rebind. Non-fatal if the daemon is already gone.
+    if let Err(e) = client
+        .remove_stream_handler(&handler_addr_str, dht_protocols.clone())
+        .await
+    {
+        warn!("remove_stream_handler before restart: {}", e);
+    }
+    daemon.shutdown().await?;
+
+    let builder = P2PDaemon::builder()
+        .dht(true)
+        .relay(!no_relay)
+        .auto_relay(true)
+        .auto_nat(true)
+        .nat_portmap(true)
+        .host_addrs([host_addr])
+        .bootstrap_peers(bootstrap_peers.to_vec())
+        .announce_addrs(announce_addrs.iter().map(|s| s.as_str()))
+        .with_identity_key(identity_key_path);
+    let builder = if let Some(ref path) = p2pd_path {
+        builder.with_binary_path(path)
+    } else {
+        builder
+    };
+    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
+        #[cfg(unix)]
+        let sock_addr = format!("/unix/{}", sock);
+        #[cfg(not(unix))]
+        let sock_addr = sock;
+        builder.with_listen_addr(sock_addr)
+    } else {
+        builder
+    };
+
+    *daemon = builder.spawn().await.context("restarting p2pd")?;
+    *client = daemon.client().await.context("p2pd client reconnect after restart")?;
+
+    client
+        .register_stream_handler(&handler_addr_str, dht_protocols)
+        .await
+        .context("re-registering stream handlers after restart")?;
+    info!("  p2pd restarted and handlers re-registered");
+
+    Ok(())
+}
 /// Self-discover external address via IDENTIFY and restart p2pd with announce addrs.
 ///
 /// When no explicit `announce_addr` or `public_ip` is configured, we rely on the
@@ -1408,49 +1470,11 @@ async fn discover_and_restart_with_announce(
         info!("  - {}", addr);
     }
 
-    // Unregister stream handlers before shutting down the daemon so
-    // the RPC listener port is freed before we rebind.
-    let _ = client
-        .remove_stream_handler(
-            &format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port()),
-            vec![
-                "DHTProtocol.rpc_ping".to_string(),
-                "DHTProtocol.rpc_store".to_string(),
-                "DHTProtocol.rpc_find".to_string(),
-            ],
-        )
-        .await;
-    daemon.shutdown().await?;
-
-    // Rebuild the builder with the same settings + announce addrs.
-    let builder = P2PDaemon::builder()
-        .dht(true)
-        .relay(!no_relay)
-        .auto_relay(true)
-        .auto_nat(true)
-        .nat_portmap(true)
-        .host_addrs([host_addr])
-        .bootstrap_peers(bootstrap_peers.to_vec())
-        .announce_addrs(discovered_addrs.iter().map(|s| s.as_str()))
-        .with_identity_key(identity_key_path);
-    let builder = if let Some(ref path) = p2pd_path {
-        builder.with_binary_path(path)
-    } else {
-        builder
-    };
-    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
-        #[cfg(unix)]
-        let sock_addr = format!("/unix/{}", sock);
-        #[cfg(not(unix))]
-        let sock_addr = sock;
-        builder.with_listen_addr(sock_addr)
-    } else {
-        builder
-    };
-
-    daemon = builder.spawn().await.context("restarting p2pd with announce addrs")?;
-    client = daemon.client().await.context("p2pd client (restart)")?;
-    info!("  p2pd restarted with announce addr(s)");
+    restart_p2pd_with_addrs(
+        &mut daemon, &mut client, &discovered_addrs,
+        host_addr, bootstrap_peers, identity_key_path,
+        p2pd_path, handler_addr, no_relay,
+    ).await?;
 
     Ok((daemon, client, discovered_addrs))
 }

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -516,9 +516,19 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // IDENTIFY protocol lets peers report our observed addresses. We poll until
     // min_confirmations separate responses agree on the same address, then
     // restart p2pd with those addresses as its announce addrs.
-    // -----------------------------------------------------------------------
+    //
+    // Skipped when:
+    // - `announce_addr` is set: we already know our address; IDENTIFY can only
+    //   confirm what we said.
+    // - `trusted_relays` is non-empty: the node is intentionally NATed and
+    //   uses one or more configured relays. Its only externally-visible
+    //   address is the `/p2p-circuit/` path through those relays; IDENTIFY
+    //   would only "discover" the same circuit address, and the
+    //   discover-then-restart cycle tears down the in-flight relay
+    //   reservation, leaving the node unable to announce. Trust the
+    //   trusted_relays config and let the relay path stand.
     let mut discovered_addrs: Vec<String>;
-    if announce_addr.is_none() {
+    if announce_addr.is_none() && config.trusted_relays.is_empty() {
         (daemon, client, discovered_addrs) = discover_and_restart_with_announce(
             daemon,
             client,

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -434,6 +434,18 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
         .context("registering stream handlers")?;
     info!("RPC handlers ready on {}", handler_addr);
 
+    // Register the /kwaai/p2p/hello/1.0.0 handler so any peer can DM us.
+    // Lives alongside the Hivemind RPC handlers because both belong to the
+    // node's "while we're alive, please answer these" surface area.
+    client
+        .add_unary_handler(
+            crate::p2p_hello::HELLO_PROTO,
+            crate::p2p_hello::make_handler(),
+            false,
+        )
+        .await
+        .context("registering p2p hello handler")?;
+
     // -----------------------------------------------------------------------
     // Step 4: Wait for DHT bootstrap (intelligent polling)
     // -----------------------------------------------------------------------

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -15,7 +15,14 @@ use kwaai_p2p::NetworkConfig;
 use kwaai_p2p_daemon::{stream, P2PDaemon};
 use libp2p::PeerId;
 use sha1::{Digest, Sha1};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 use tokio::{io::AsyncWriteExt, net::TcpListener, signal, sync::RwLock};
 use tracing::{info, warn};
 
@@ -338,7 +345,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // -----------------------------------------------------------------------
     // Step 1: Start p2pd
     // -----------------------------------------------------------------------
-    info!("[1/5] Starting p2p daemon...");
+    info!("[1/6] Starting p2p daemon...");
     let p2pd_path = find_p2pd_binary();
     if p2pd_path.is_none() {
         eprintln!("  ⚠️  p2pd not found — run `kwaainet setup --get-deps` to install it");
@@ -378,7 +385,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
         // to public, even if it actually is. Only honour an explicit opt-in.
         .force_reachability_private(config.force_private)
         .nat_portmap(true)
-        .host_addrs([host_addr])
+        .host_addrs([host_addr.clone()])
         .bootstrap_peers(bootstrap_peers.clone())
         .trusted_relays(trusted_relays.clone())
         .with_identity_key(&identity_key_path);
@@ -418,13 +425,13 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // -----------------------------------------------------------------------
     // Step 2: DHT storage
     // -----------------------------------------------------------------------
-    info!("[2/5] Initialising DHT storage...");
+    info!("[2/6] Initialising DHT storage...");
     let storage: SharedStorage = Arc::new(RwLock::new(DHTStorage::new(peer_id)));
 
     // -----------------------------------------------------------------------
     // Step 3: Register Hivemind RPC stream handlers with p2pd
     // -----------------------------------------------------------------------
-    info!("[3/5] Registering Hivemind RPC handlers...");
+    info!("[3/6] Registering Hivemind RPC handlers...");
     let handler_listener = TcpListener::bind("127.0.0.1:0")
         .await
         .context("binding RPC handler listener")?;
@@ -458,7 +465,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // -----------------------------------------------------------------------
     // Step 4: Wait for DHT bootstrap (intelligent polling)
     // -----------------------------------------------------------------------
-    info!("[4/5] Bootstrapping...");
+    info!("[4/6] Bootstrapping...");
     dial_and_wait_for_bootstrap(&mut client, &bootstrap_peers).await?;
 
     // If p2pd crashed during bootstrap (Kademlia walk goroutine panic in
@@ -485,26 +492,41 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     }
 
     // -----------------------------------------------------------------------
-    // Step 5: Initial DHT announcement
+    // Step 5: Self-discover external address via IDENTIFY (when not manually
+    // configured). After at least one bootstrap peer connects, the libp2p
+    // IDENTIFY protocol lets peers report our observed external address. We
+    // poll until 2 separate responses agree on the same address, then restart
+    // p2pd with that address as its announce addr so map.kwaai.ai can reach us.
     // -----------------------------------------------------------------------
-    info!("[5/5] Announcing to DHT...");
+    let mut discovered_addrs: Vec<String>;
+    if announce_addr.is_none() {
+        (daemon, client, discovered_addrs) = discover_and_restart_with_announce(
+            daemon,
+            client,
+            &host_addr,
+            &bootstrap_peers,
+            &identity_key_path,
+            &p2pd_path,
+            &handler_addr,
+            config.no_relay,
+        )
+        .await?;
+    } else {
+        discovered_addrs = Vec::new();
+    }
 
-    // Install the SIGHUP handler here — before announce() — so that if
-    // `shard serve` calls signal_reannounce() while announce() is still
-    // running (a ~5 s window), tokio captures the signal instead of
-    // applying the default Unix action (terminate process).
-    #[cfg(unix)]
-    let mut sighup = {
-        use tokio::signal::unix::{signal, SignalKind};
-        signal(SignalKind::hangup()).expect("SIGHUP handler")
-    };
+    // -----------------------------------------------------------------------
+    // Step 6: Initial DHT announcement
+    // -----------------------------------------------------------------------
+    info!("[6/6] Announcing to DHT...");
 
     // Determine effective throughput using the Petals formula:
     //   effective_tps = min(compute_tps, network_rps × relay_penalty)
     //   network_rps   = download_bps / (hidden_size × 16)
-    // using_relay: true only if we have no reachable address (behind NAT) and relay is allowed.
-    // announce_addr already encodes both explicit announce_addr and non-empty public_ip.
-    let using_relay = announce_addr.is_none() && !config.no_relay;
+    // using_relay: true only if we have no explicit address and IDENTIFY
+    // discovery also came up empty. If we confirmed an external address
+    // (directly or via IDENTIFY) we are directly reachable — no relay needed.
+    let using_relay = announce_addr.is_none() && discovered_addrs.is_empty() && !config.no_relay;
 
     // Measure network bandwidth once at startup (1 MiB Cloudflare probe).
     // Stored so re-announcements can recompute effective_tps without re-probing.
@@ -716,7 +738,22 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
         300, 30,
     ))));
 
-    // (SIGHUP handler installed above before announce() — see Step 5 setup)
+    // Periodic IDENTIFY check — only active when no explicit announce_addr is
+    // configured. Every 5 minutes we re-poll our observed addresses; if they
+    // differ from what we announced at startup (e.g. after a network change)
+    // we restart p2pd and trigger an immediate re-announcement.
+    let mut identify_check = tokio::time::interval(Duration::from_secs(300));
+    identify_check.tick().await; // skip the immediate first tick
+    let explicit_announce = announce_addr.is_some();
+
+    // SIGHUP handler: shard serve sends SIGHUP after updating config.yaml so
+    // the daemon re-announces the new block range immediately (Unix only).
+    // On non-Unix this future never resolves — the branch is dead code.
+    #[cfg(unix)]
+    let mut sighup = {
+        use tokio::signal::unix::{signal, SignalKind};
+        signal(SignalKind::hangup()).expect("SIGHUP handler")
+    };
 
     loop {
         tokio::select! {
@@ -873,6 +910,82 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                 next_announce
                     .as_mut()
                     .reset(tokio::time::Instant::now() + Duration::from_secs(jitter_secs(300, 30)));
+            }
+
+            // Periodic IDENTIFY address check (every 5 minutes).
+            // Skipped when announce_addr/public_ip was explicitly configured.
+            _ = identify_check.tick(), if !explicit_announce => {
+                let fresh = collect_observed_addresses(&mut client, 2, Duration::from_secs(8)).await;
+                if !fresh.is_empty() && fresh != discovered_addrs {
+                    info!("External address changed — restarting p2pd:");
+                    for addr in &discovered_addrs {
+                        info!("  old: {}", addr);
+                    }
+                    for addr in &fresh {
+                        info!("  new: {}", addr);
+                    }
+                    // Unregister handlers, restart p2pd with new announce addrs.
+                    let _ = client
+                        .remove_stream_handler(
+                            &format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port()),
+                            vec![
+                                "DHTProtocol.rpc_ping".to_string(),
+                                "DHTProtocol.rpc_store".to_string(),
+                                "DHTProtocol.rpc_find".to_string(),
+                            ],
+                        )
+                        .await;
+                    let _ = daemon.shutdown().await;
+
+                    let builder = P2PDaemon::builder()
+                        .dht(true)
+                        .relay(!config.no_relay)
+                        .auto_relay(true)
+                        .auto_nat(true)
+                        .nat_portmap(true)
+                        .host_addrs([host_addr.clone()])
+                        .bootstrap_peers(bootstrap_peers.clone())
+                        .announce_addrs(fresh.iter().map(|s| s.as_str()))
+                        .with_identity_key(&identity_key_path);
+                    let builder = if let Some(ref path) = p2pd_path {
+                        builder.with_binary_path(path)
+                    } else {
+                        builder
+                    };
+                    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
+                        #[cfg(unix)]
+                        let sock_addr = format!("/unix/{}", sock);
+                        #[cfg(not(unix))]
+                        let sock_addr = sock;
+                        builder.with_listen_addr(sock_addr)
+                    } else {
+                        builder
+                    };
+
+                    match builder.spawn().await {
+                        Ok(new_daemon) => {
+                            daemon = new_daemon;
+                            match daemon.client().await {
+                                Ok(new_client) => {
+                                    client = new_client;
+                                    discovered_addrs = fresh;
+                                    server_info.using_relay = false;
+                                    let sb = config.start_block as i32;
+                                    let eb = config.effective_end_block() as i32;
+                                    if let Err(e) = announce(
+                                        &mut client, peer_id, &storage, &bootstrap_peers,
+                                        &prefix, &repository, config.model_total_blocks(),
+                                        sb, eb, &server_info, Some(&mut rep_store),
+                                    ).await {
+                                        warn!("Re-announce after address change failed: {}", e);
+                                    }
+                                }
+                                Err(e) => warn!("p2pd client reconnect failed: {}", e),
+                            }
+                        }
+                        Err(e) => warn!("p2pd restart failed: {}", e),
+                    }
+                }
             }
 
             // Shutdown signal
@@ -1251,6 +1364,186 @@ async fn send_to_bootstrap(
         );
     }
     (succeeded > 0, timings)
+}
+
+/// Self-discover external address via IDENTIFY and restart p2pd with announce addrs.
+///
+/// When no explicit `announce_addr` or `public_ip` is configured, we rely on the
+/// libp2p IDENTIFY protocol: after bootstrap peers connect they report our observed
+/// external address back to us. Once 2 independent responses agree we shut the
+/// initial p2pd down, rebuild it with the confirmed address as its announce addr,
+/// and return the new daemon + client along with the discovered addresses.
+///
+/// If IDENTIFY yields nothing the original daemon is returned unchanged and the
+/// returned address list is empty (the node will fall back to relay mode).
+async fn discover_and_restart_with_announce(
+    mut daemon: kwaai_p2p_daemon::P2PDaemon,
+    mut client: kwaai_p2p_daemon::P2PClient,
+    host_addr: &str,
+    bootstrap_peers: &[String],
+    identity_key_path: &std::path::Path,
+    p2pd_path: &Option<std::path::PathBuf>,
+    handler_addr: &std::net::SocketAddr,
+    no_relay: bool,
+) -> anyhow::Result<(
+    kwaai_p2p_daemon::P2PDaemon,
+    kwaai_p2p_daemon::P2PClient,
+    Vec<String>,
+)> {
+    info!("No explicit announce address — discovering via IDENTIFY...");
+    let discovered_addrs =
+        collect_observed_addresses(&mut client, 2, Duration::from_secs(10)).await;
+
+    if discovered_addrs.is_empty() {
+        warn!(
+            "⚠️ Could not confirm external address via IDENTIFY \
+             — node may appear Unreachable on map.kwaai.ai. \
+             Set public_ip or announce_addr in config to override."
+        );
+        return Ok((daemon, client, discovered_addrs));
+    }
+
+    info!("Confirmed external address(es) — restarting p2pd with announce addrs:");
+    for addr in &discovered_addrs {
+        info!("  - {}", addr);
+    }
+
+    // Unregister stream handlers before shutting down the daemon so
+    // the RPC listener port is freed before we rebind.
+    let _ = client
+        .remove_stream_handler(
+            &format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port()),
+            vec![
+                "DHTProtocol.rpc_ping".to_string(),
+                "DHTProtocol.rpc_store".to_string(),
+                "DHTProtocol.rpc_find".to_string(),
+            ],
+        )
+        .await;
+    daemon.shutdown().await?;
+
+    // Rebuild the builder with the same settings + announce addrs.
+    let builder = P2PDaemon::builder()
+        .dht(true)
+        .relay(!no_relay)
+        .auto_relay(true)
+        .auto_nat(true)
+        .nat_portmap(true)
+        .host_addrs([host_addr])
+        .bootstrap_peers(bootstrap_peers.to_vec())
+        .announce_addrs(discovered_addrs.iter().map(|s| s.as_str()))
+        .with_identity_key(identity_key_path);
+    let builder = if let Some(ref path) = p2pd_path {
+        builder.with_binary_path(path)
+    } else {
+        builder
+    };
+    let builder = if let Ok(sock) = std::env::var("KWAAINET_SOCKET") {
+        #[cfg(unix)]
+        let sock_addr = format!("/unix/{}", sock);
+        #[cfg(not(unix))]
+        let sock_addr = sock;
+        builder.with_listen_addr(sock_addr)
+    } else {
+        builder
+    };
+
+    daemon = builder.spawn().await.context("restarting p2pd with announce addrs")?;
+    client = daemon.client().await.context("p2pd client (restart)")?;
+    info!("  p2pd restarted with announce addr(s)");
+
+    Ok((daemon, client, discovered_addrs))
+}
+
+/// Poll `identify_with_addrs()` until `min_confirmations` separate responses
+/// all include the same public multiaddr, or `timeout` elapses.
+///
+/// Returns the confirmed public addresses as multiaddr strings (e.g.
+/// `/ip4/203.0.113.1/tcp/8080`). Private/loopback addresses are filtered out.
+///
+/// "Confirmation" here means the address appeared in at least
+/// `min_confirmations` distinct IDENTIFY responses. p2pd refreshes its
+/// observed-address list as more bootstrap peers connect and run IDENTIFY, so
+/// polling with a short interval naturally accumulates multiple independent
+/// observations.
+async fn collect_observed_addresses(
+    client: &mut kwaai_p2p_daemon::P2PClient,
+    min_confirmations: usize,
+    timeout: Duration,
+) -> Vec<String> {
+    use libp2p::Multiaddr;
+    use std::collections::HashMap;
+
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut counts: HashMap<String, usize> = HashMap::new();
+
+    loop {
+        match client.identify_with_addrs().await {
+            Ok((_peer_id, addrs)) => {
+                for addr_bytes in &addrs {
+                    // Parse as libp2p Multiaddr so we can inspect the components.
+                    if let Ok(ma) = Multiaddr::try_from(addr_bytes.clone()) {
+                        let s = ma.to_string();
+                        if is_public_multiaddr(&ma) {
+                            *counts.entry(s).or_insert(0) += 1;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::debug!("identify_with_addrs error: {}", e);
+            }
+        }
+
+        let confirmed: Vec<String> = counts
+            .iter()
+            .filter(|(_, &c)| c >= min_confirmations)
+            .map(|(addr, _)| addr.clone())
+            .collect();
+
+        if !confirmed.is_empty() {
+            return confirmed;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            // Return whatever we have (even unconfirmed) as a best-effort
+            // fallback if we got at least one observation.
+            let best_effort: Vec<String> = counts.into_keys().collect();
+            if !best_effort.is_empty() {
+                tracing::warn!(
+                    "IDENTIFY: could not get {} confirmations within {:?}; \
+                     using best-effort address(es): {:?}",
+                    min_confirmations,
+                    timeout,
+                    best_effort
+                );
+            }
+            return best_effort;
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+/// Returns true if the multiaddr represents a publicly routable address.
+/// Filters out loopback, RFC-1918 private ranges, and link-local.
+fn is_public_multiaddr(ma: &libp2p::Multiaddr) -> bool {
+    use libp2p::multiaddr::Protocol;
+    for proto in ma.iter() {
+        match proto {
+            Protocol::Ip4(ip) => {
+                return !ip.is_loopback()
+                    && !ip.is_private()
+                    && !ip.is_link_local()
+                    && !ip.is_unspecified();
+            }
+            Protocol::Ip6(ip) => {
+                return !ip.is_loopback() && !ip.is_unspecified();
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 /// Wait for p2pd's own DHT bootstrap to establish connections.

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -798,7 +798,17 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // we restart p2pd and trigger an immediate re-announcement.
     let mut identify_check = tokio::time::interval(Duration::from_secs(300));
     identify_check.tick().await; // skip the immediate first tick
-    let explicit_announce = announce_addr.is_some();
+                                 // Skip the periodic IDENTIFY-discover-and-restart loop when:
+                                 // - announce_addr is set: we already know our address; IDENTIFY can only
+                                 //   confirm what we said.
+                                 // - trusted_relays is non-empty: this is an intentionally-NATed node
+                                 //   whose only externally-visible address is the /p2p-circuit/ path
+                                 //   through its configured relay(s). The periodic check would "discover"
+                                 //   that circuit address, see it differs from the empty discovered_addrs
+                                 //   (we skip the initial discover for the same reason), set
+                                 //   pending_restart, and the subsequent restart would tear down the
+                                 //   relay reservation that makes the node reachable in the first place.
+    let explicit_announce = announce_addr.is_some() || !config.trusted_relays.is_empty();
 
     // SIGHUP handler: shard serve sends SIGHUP after updating config.yaml so
     // the daemon re-announces the new block range immediately (Unix only).

--- a/core/crates/kwaai-cli/src/p2p_cmd.rs
+++ b/core/crates/kwaai-cli/src/p2p_cmd.rs
@@ -377,7 +377,7 @@ async fn peers_connect(
         match client
             .call_unary_handler(
                 &dest_peer.to_bytes(),
-                crate::p2p_hello::HELLO_PROTO,
+                kwaai_p2p_daemon::hello::HELLO_PROTO,
                 msg.as_bytes(),
             )
             .await

--- a/core/crates/kwaai-cli/src/p2p_cmd.rs
+++ b/core/crates/kwaai-cli/src/p2p_cmd.rs
@@ -60,11 +60,38 @@ fn fmt_addr(bytes: &[u8]) -> String {
         .unwrap_or_else(|_| format!("0x{} (unparseable)", hex::encode(bytes)))
 }
 
-/// Classify a multiaddr for the dcutr signal we care about most: is this
-/// connection going through a relay circuit, or directly?
-fn is_relayed(m: &Multiaddr) -> bool {
-    m.iter()
+/// Connection classification. `LIST_PEERS` only gives us `(id, addrs)` so this
+/// is derived from the multiaddr alone.
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum ConnKind {
+    /// Plain `/ip4/.../tcp/...` — directly dialable.
+    Direct,
+    /// Path includes `/p2p-circuit/` — going through a relay.
+    Relay,
+}
+
+fn classify_addr(m: &Multiaddr) -> ConnKind {
+    if m.iter()
         .any(|p| matches!(p, libp2p::multiaddr::Protocol::P2pCircuit))
+    {
+        ConnKind::Relay
+    } else {
+        ConnKind::Direct
+    }
+}
+
+/// Backwards-compat shim retained so `info` keeps working unchanged.
+fn is_relayed(m: &Multiaddr) -> bool {
+    classify_addr(m) == ConnKind::Relay
+}
+
+/// Inline ANSI label for a `ConnKind`. Green for direct, yellow for relay.
+/// Keeping ANSI inline avoids pulling in a colour crate for two strings.
+fn fmt_kind(k: ConnKind) -> &'static str {
+    match k {
+        ConnKind::Direct => "\x1b[32m[direct]\x1b[0m",
+        ConnKind::Relay => "\x1b[33m[ relay]\x1b[0m",
+    }
 }
 
 /// Build the set of bootstrap peer IDs the local node was configured to use.
@@ -77,6 +104,20 @@ fn bootstrap_peer_ids() -> HashSet<PeerId> {
     };
 
     bootstraps
+        .iter()
+        .filter_map(|addr| addr.split("/p2p/").nth(1))
+        .filter_map(|id| id.parse::<PeerId>().ok())
+        .collect()
+}
+
+/// Build the set of trusted-relay peer IDs the local node was configured with.
+/// Empty when the user hasn't configured any (the production default).
+fn trusted_relay_peer_ids() -> HashSet<PeerId> {
+    let relays = KwaaiNetConfig::load_or_create()
+        .map(|cfg| cfg.trusted_relays)
+        .unwrap_or_default();
+
+    relays
         .iter()
         .filter_map(|addr| addr.split("/p2p/").nth(1))
         .filter_map(|id| id.parse::<PeerId>().ok())
@@ -171,64 +212,126 @@ async fn peers_list() -> Result<()> {
     }
 
     let bootstraps = bootstrap_peer_ids();
+    let trusted_relays = trusted_relay_peer_ids();
+
+    // Group ordering for the sort: bootstrap first (regardless of conn kind),
+    // then trusted relay, then plain direct, then via-relay. Within each
+    // group, sort by peer ID so output is stable across polls — useful when
+    // watching the list change as peers come and go.
+    fn group_index(is_bootstrap: bool, is_trusted_relay: bool, kind: ConnKind) -> u8 {
+        if is_bootstrap {
+            return 0;
+        }
+        if is_trusted_relay {
+            return 1;
+        }
+        match kind {
+            ConnKind::Direct => 2,
+            ConnKind::Relay => 3,
+        }
+    }
+
+    struct Row {
+        group: u8,
+        id_str: String,
+        kind: ConnKind,
+        is_bootstrap: bool,
+        is_trusted_relay: bool,
+        preview: String,
+        extra_count: usize,
+    }
+
+    let mut rows: Vec<Row> = peers
+        .iter()
+        .map(|p| {
+            let parsed_id = PeerId::from_bytes(&p.id).ok();
+            let id_str = parsed_id
+                .map(|p| p.to_base58())
+                .unwrap_or_else(|| format!("0x{}", hex::encode(&p.id)));
+            let is_bootstrap = parsed_id.map_or(false, |pid| bootstraps.contains(&pid));
+            let is_trusted_relay = parsed_id.map_or(false, |pid| trusted_relays.contains(&pid));
+
+            // Classify by the primary (first) addr. p2pd returns one PeerInfo
+            // per connection; multiple PeerInfos for the same peer ID indicate
+            // multiple simultaneous connections (e.g. relay path + direct path
+            // during a hole-punch upgrade).
+            let kind = p
+                .addrs
+                .first()
+                .and_then(|a| Multiaddr::try_from(a.clone()).ok())
+                .map(|m| classify_addr(&m))
+                .unwrap_or(ConnKind::Direct);
+
+            let preview = p
+                .addrs
+                .first()
+                .map(|a| fmt_addr(a))
+                .unwrap_or_else(|| "(no addrs)".to_string());
+            let extra_count = p.addrs.len().saturating_sub(1);
+
+            Row {
+                group: group_index(is_bootstrap, is_trusted_relay, kind),
+                id_str,
+                kind,
+                is_bootstrap,
+                is_trusted_relay,
+                preview,
+                extra_count,
+            }
+        })
+        .collect();
+
+    rows.sort_by(|a, b| a.group.cmp(&b.group).then_with(|| a.id_str.cmp(&b.id_str)));
 
     let mut direct = 0usize;
     let mut relayed = 0usize;
     let mut bootstrap_hits = 0usize;
-    for p in &peers {
-        let parsed_id = PeerId::from_bytes(&p.id).ok();
-        let id_str = parsed_id
-            .map(|p| p.to_base58())
-            .unwrap_or_else(|| format!("0x{}", hex::encode(&p.id)));
-        let is_bootstrap = parsed_id.map_or(false, |pid| bootstraps.contains(&pid));
-        if is_bootstrap {
+    let mut trusted_relay_hits = 0usize;
+    for r in &rows {
+        match r.kind {
+            ConnKind::Direct => direct += 1,
+            ConnKind::Relay => relayed += 1,
+        }
+        if r.is_bootstrap {
             bootstrap_hits += 1;
         }
-
-        let any_relay = p
-            .addrs
-            .iter()
-            .filter_map(|a| Multiaddr::try_from(a.clone()).ok())
-            .any(|m| is_relayed(&m));
-        if any_relay {
-            relayed += 1;
-        } else {
-            direct += 1;
+        if r.is_trusted_relay {
+            trusted_relay_hits += 1;
         }
-        let kind = if any_relay { "relay" } else { "direct" };
-        let preview = p
-            .addrs
-            .first()
-            .map(|a| fmt_addr(a))
-            .unwrap_or_else(|| "(no addrs)".to_string());
-        let extra = if p.addrs.len() > 1 {
-            format!(" (+{} more)", p.addrs.len() - 1)
+
+        let extra = if r.extra_count > 0 {
+            format!(" (+{} more)", r.extra_count)
         } else {
             String::new()
         };
-        // Cyan for bootstrap so the label stands out at a glance without
-        // being garish. Inline ANSI keeps us off the dep treadmill for a
-        // single annotation; revisit if color use spreads.
-        let label = if is_bootstrap {
+        // Cyan for bootstrap, gold (256-color 220) for trusted relay — both
+        // surface configuration that the user explicitly chose. Inline ANSI
+        // avoids a colour-crate dep for two strings; if colour use spreads,
+        // revisit.
+        let label = if r.is_bootstrap {
             "  \x1b[36m(bootstrap)\x1b[0m"
+        } else if r.is_trusted_relay {
+            "  \x1b[38;5;220m(trusted relay)\x1b[0m"
         } else {
             ""
         };
-        println!("  [{:>6}] {}{}", kind, id_str, label);
-        println!("           {}{}", preview, extra);
+        println!("  {} {}{}", fmt_kind(r.kind), r.id_str, label);
+        println!("           {}{}", r.preview, extra);
     }
 
     println!();
     print_info(&format!(
-        "Total {} connection(s): {} direct, {} via relay; {} to bootstrap peer(s)",
+        "Total {} connection(s): {} direct, {} via relay; \
+         {} to bootstrap peer(s), {} to trusted relay(s)",
         peers.len(),
         direct,
         relayed,
-        bootstrap_hits
+        bootstrap_hits,
+        trusted_relay_hits
     ));
     print_info(
         "Each row is one live connection — a peer with both a direct and a \
-         relay path (e.g. during a dcutr upgrade) appears twice.",
+         relay path (e.g. during a hole-punch upgrade) appears twice.",
     );
     print_separator();
     Ok(())

--- a/core/crates/kwaai-cli/src/p2p_cmd.rs
+++ b/core/crates/kwaai-cli/src/p2p_cmd.rs
@@ -32,7 +32,26 @@ async fn peers(args: PeersArgs) -> Result<()> {
             peer,
             message,
         } => peers_connect(addr, peer, message).await,
-        PeersAction::Send { peer_id, message } => peers_send(peer_id, message).await,
+        PeersAction::Send {
+            peer,
+            proto,
+            message,
+            payload_hex,
+            payload_bin,
+            stdin,
+            timeout,
+        } => {
+            peers_send(
+                peer,
+                proto,
+                message,
+                payload_hex,
+                payload_bin,
+                stdin,
+                timeout,
+            )
+            .await
+        }
     }
 }
 
@@ -355,9 +374,18 @@ async fn peers_connect(
     print_success("Connected.");
 
     if let Some(msg) = message {
-        let from_peer = local_peer_id(&mut client).await?;
-        match crate::p2p_hello::send(&client, &dest_peer, &from_peer, &msg).await {
-            Ok(()) => print_success(&format!("Sent hello to {} — see their logs.", dest_peer)),
+        match client
+            .call_unary_handler(
+                &dest_peer.to_bytes(),
+                crate::p2p_hello::HELLO_PROTO,
+                msg.as_bytes(),
+            )
+            .await
+        {
+            Ok(resp) => {
+                print_success(&format!("Sent hello to {} — see their logs.", dest_peer));
+                print_response(&resp);
+            }
             Err(e) => print_error(&format!("hello send failed: {}", e)),
         }
     } else {
@@ -461,35 +489,145 @@ async fn resolve_peer(
 }
 
 // ---------------------------------------------------------------------------
-// peers send — hello DM to an already-connected peer
+// peers send — invoke a unary RPC on a connected peer
 // ---------------------------------------------------------------------------
 
-async fn peers_send(peer_id: String, message: String) -> Result<()> {
+async fn peers_send(
+    peer: String,
+    proto: String,
+    message: Option<String>,
+    payload_hex: Option<String>,
+    payload_bin: Option<std::path::PathBuf>,
+    stdin: bool,
+    timeout_secs: u64,
+) -> Result<()> {
+    let payload = match resolve_payload(message, payload_hex, payload_bin, stdin) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            print_error(&format!("payload: {}", e));
+            print_separator();
+            return Ok(());
+        }
+    };
+
+    let dest_peer: PeerId = match peer.parse() {
+        Ok(p) => p,
+        Err(e) => {
+            print_error(&format!("invalid recipient peer ID: {}", e));
+            print_separator();
+            return Ok(());
+        }
+    };
+
     let Some(mut client) = connect_p2pd().await? else {
         return Ok(());
     };
 
-    let dest_peer: PeerId = peer_id.parse().context("invalid recipient peer ID")?;
-    let from_peer = local_peer_id(&mut client).await?;
-
-    print_box_header("🛰  KwaaiNet P2P — Hello DM");
+    print_box_header("🛰  KwaaiNet P2P — Unary RPC");
     println!("  To:      {}", dest_peer);
-    println!("  From:    {}", from_peer);
-    println!("  Message: {}", message);
+    println!("  Proto:   {}", proto);
+    println!("  Payload: {} bytes", payload.len());
+    println!("  Timeout: {}s", timeout_secs);
     println!();
 
-    match crate::p2p_hello::send(&client, &dest_peer, &from_peer, &message).await {
-        Ok(()) => print_success("Sent — see the recipient's logs for the message."),
-        Err(e) => print_error(&format!("hello send failed: {}", e)),
+    let dest_bytes = dest_peer.to_bytes();
+    let call = client.call_unary_handler(&dest_bytes, &proto, &payload);
+    match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), call).await {
+        Ok(Ok(resp)) => {
+            print_success("Sent.");
+            print_response(&resp);
+        }
+        Ok(Err(e)) => print_error(&format!("call_unary_handler failed: {}", e)),
+        Err(_) => {
+            print_error(&format!(
+                "no response within {}s — recipient may not handle this protocol, \
+                 or the handler hung on the payload. Try a longer --timeout.",
+                timeout_secs
+            ));
+        }
     }
     print_separator();
     Ok(())
 }
 
-/// Ask the local p2pd for our own peer ID. Used so the recipient knows who
-/// sent them the hello.
-async fn local_peer_id(client: &mut P2PClient) -> Result<PeerId> {
-    let id_hex = client.identify().await.context("identify local peer ID")?;
-    let id_bytes = hex::decode(&id_hex).context("decode identify hex")?;
-    PeerId::from_bytes(&id_bytes).map_err(|e| anyhow::anyhow!("invalid local peer ID: {}", e))
+/// Resolve the user's payload-source flags to the concrete bytes that go on
+/// the wire. Exactly one source must be set; clap groups them but doesn't
+/// enforce one-and-only-one across the whole set, so we validate here.
+fn resolve_payload(
+    message: Option<String>,
+    payload_hex: Option<String>,
+    payload_bin: Option<std::path::PathBuf>,
+    stdin: bool,
+) -> Result<Vec<u8>> {
+    let sources: Vec<&str> = [
+        message.as_ref().map(|_| "--message"),
+        payload_hex.as_ref().map(|_| "--payload-hex"),
+        payload_bin.as_ref().map(|_| "--payload-bin"),
+        stdin.then_some("--stdin"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    match sources.len() {
+        0 => anyhow::bail!(
+            "no payload — pass exactly one of --message, --payload-hex, \
+             --payload-bin, or --stdin"
+        ),
+        1 => {}
+        _ => anyhow::bail!(
+            "multiple payload sources given ({}); pass exactly one",
+            sources.join(", ")
+        ),
+    }
+
+    if let Some(text) = message {
+        return Ok(text.into_bytes());
+    }
+    if let Some(hex_str) = payload_hex {
+        let stripped: String = hex_str.chars().filter(|c| !c.is_whitespace()).collect();
+        return hex::decode(&stripped).context("decode --payload-hex");
+    }
+    if let Some(path) = payload_bin {
+        return std::fs::read(&path)
+            .with_context(|| format!("read --payload-bin {}", path.display()));
+    }
+    if stdin {
+        use std::io::Read;
+        let mut buf = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buf)
+            .context("read --stdin")?;
+        return Ok(buf);
+    }
+    unreachable!("payload source validation above ensures one is set")
+}
+
+/// Display response bytes uniformly: short summary, then either UTF-8 text
+/// (if the bytes are printable) or hex. Mirrors what curl-style tools do
+/// and avoids guessing the wire format the protocol owns.
+fn print_response(resp: &[u8]) {
+    if resp.is_empty() {
+        print_info("Response: (empty)");
+        return;
+    }
+    match std::str::from_utf8(resp) {
+        Ok(s) if s.chars().all(|c| !c.is_control() || c == '\n' || c == '\t') => {
+            print_info(&format!("Response ({} bytes): {}", resp.len(), s));
+        }
+        _ => {
+            let preview: String = resp
+                .iter()
+                .take(64)
+                .map(|b| format!("{:02x}", b))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let suffix = if resp.len() > 64 { " …" } else { "" };
+            print_info(&format!(
+                "Response ({} bytes): {}{}",
+                resp.len(),
+                preview,
+                suffix
+            ));
+        }
+    }
 }

--- a/core/crates/kwaai-cli/src/p2p_cmd.rs
+++ b/core/crates/kwaai-cli/src/p2p_cmd.rs
@@ -27,6 +27,8 @@ async fn peers(args: PeersArgs) -> Result<()> {
     match args.action {
         PeersAction::List => peers_list().await,
         PeersAction::Find { peer_id, timeout } => peers_find(peer_id, timeout).await,
+        PeersAction::Connect { multiaddr, message } => peers_connect(multiaddr, message).await,
+        PeersAction::Send { peer_id, message } => peers_send(peer_id, message).await,
     }
 }
 
@@ -277,4 +279,85 @@ async fn peers_find(peer_id_str: String, timeout: i64) -> Result<()> {
     }
     print_separator();
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// peers connect — manual dial + optional hello DM
+// ---------------------------------------------------------------------------
+
+async fn peers_connect(multiaddr: String, message: Option<String>) -> Result<()> {
+    let Some(mut client) = connect_p2pd().await? else {
+        return Ok(());
+    };
+
+    print_box_header("🛰  KwaaiNet P2P — Manual Dial");
+    println!("  Target: {}", multiaddr);
+    println!();
+
+    if let Err(e) = client.connect_peer(&multiaddr).await {
+        print_error(&format!("connect_peer failed: {}", e));
+        print_separator();
+        return Ok(());
+    }
+    print_success("Connected.");
+
+    if let Some(msg) = message {
+        // Pull the destination peer ID out of the multiaddr — for a relay'd
+        // address (`…/p2p/<RELAY>/p2p-circuit/p2p/<DEST>`) the destination is
+        // the LAST /p2p/ component, not the first.
+        let maddr: Multiaddr = multiaddr.parse().context("parse multiaddr for hello")?;
+        let mut last_p2p = None;
+        for proto in maddr.iter() {
+            if let libp2p::multiaddr::Protocol::P2p(hash) = proto {
+                last_p2p = Some(hash);
+            }
+        }
+        let dest = last_p2p.context("multiaddr has no /p2p/<peer-id> component")?;
+        let dest_peer = PeerId::from_multihash(dest.into())
+            .map_err(|e| anyhow::anyhow!("invalid peer multihash: {:?}", e))?;
+
+        let from_peer = local_peer_id(&mut client).await?;
+        match crate::p2p_hello::send(&client, &dest_peer, &from_peer, &msg).await {
+            Ok(()) => print_success(&format!("Sent hello to {} — see their logs.", dest_peer)),
+            Err(e) => print_error(&format!("hello send failed: {}", e)),
+        }
+    } else {
+        print_info("Pass --message <text> to send a hello DM that the peer logs.");
+    }
+    print_separator();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// peers send — hello DM to an already-connected peer
+// ---------------------------------------------------------------------------
+
+async fn peers_send(peer_id: String, message: String) -> Result<()> {
+    let Some(mut client) = connect_p2pd().await? else {
+        return Ok(());
+    };
+
+    let dest_peer: PeerId = peer_id.parse().context("invalid recipient peer ID")?;
+    let from_peer = local_peer_id(&mut client).await?;
+
+    print_box_header("🛰  KwaaiNet P2P — Hello DM");
+    println!("  To:      {}", dest_peer);
+    println!("  From:    {}", from_peer);
+    println!("  Message: {}", message);
+    println!();
+
+    match crate::p2p_hello::send(&client, &dest_peer, &from_peer, &message).await {
+        Ok(()) => print_success("Sent — see the recipient's logs for the message."),
+        Err(e) => print_error(&format!("hello send failed: {}", e)),
+    }
+    print_separator();
+    Ok(())
+}
+
+/// Ask the local p2pd for our own peer ID. Used so the recipient knows who
+/// sent them the hello.
+async fn local_peer_id(client: &mut P2PClient) -> Result<PeerId> {
+    let id_hex = client.identify().await.context("identify local peer ID")?;
+    let id_bytes = hex::decode(&id_hex).context("decode identify hex")?;
+    PeerId::from_bytes(&id_bytes).map_err(|e| anyhow::anyhow!("invalid local peer ID: {}", e))
 }

--- a/core/crates/kwaai-cli/src/p2p_cmd.rs
+++ b/core/crates/kwaai-cli/src/p2p_cmd.rs
@@ -27,7 +27,11 @@ async fn peers(args: PeersArgs) -> Result<()> {
     match args.action {
         PeersAction::List => peers_list().await,
         PeersAction::Find { peer_id, timeout } => peers_find(peer_id, timeout).await,
-        PeersAction::Connect { multiaddr, message } => peers_connect(multiaddr, message).await,
+        PeersAction::Connect {
+            addr,
+            peer,
+            message,
+        } => peers_connect(addr, peer, message).await,
         PeersAction::Send { peer_id, message } => peers_send(peer_id, message).await,
     }
 }
@@ -256,11 +260,17 @@ async fn peers_find(peer_id_str: String, timeout: i64) -> Result<()> {
                 println!("  Found in DHT, but no addresses advertised.");
             } else {
                 println!("  Addresses advertised in DHT ({}):", info.addrs.len());
+                // Append `/p2p/<peer-id>` to each address so the printed
+                // form is directly usable as `peers connect --addr …`.
+                // p2pd / Kademlia returns addresses without the trailing
+                // `/p2p/<self>` because the DHT entry is keyed on the peer
+                // ID anyway, but the CLI consumer needs the full form.
                 for a in &info.addrs {
                     match Multiaddr::try_from(a.clone()) {
                         Ok(m) => {
                             let kind = if is_relayed(&m) { "relay" } else { "direct" };
-                            println!("    [{:>6}] {}", kind, m);
+                            let with_dest = m.with(libp2p::multiaddr::Protocol::P2p(target.into()));
+                            println!("    [{:>6}] {}", kind, with_dest);
                         }
                         Err(_) => {
                             println!("    [   ?   ] 0x{} (unparseable)", hex::encode(a))
@@ -285,13 +295,56 @@ async fn peers_find(peer_id_str: String, timeout: i64) -> Result<()> {
 // peers connect — manual dial + optional hello DM
 // ---------------------------------------------------------------------------
 
-async fn peers_connect(multiaddr: String, message: Option<String>) -> Result<()> {
+async fn peers_connect(
+    addr: Option<String>,
+    peer: Option<String>,
+    message: Option<String>,
+) -> Result<()> {
     let Some(mut client) = connect_p2pd().await? else {
         return Ok(());
     };
 
+    // Resolve the input form (--addr | --peer) to a (multiaddr_to_dial,
+    // dest_peer_id) pair. clap's `required_unless_present` enforces that
+    // exactly one of the two is set.
+    let (multiaddr, dest_peer) = match (addr, peer) {
+        (Some(a), None) => match resolve_addr(&a) {
+            Ok(pair) => pair,
+            Err(e) => {
+                print_error(&format!("--addr rejected: {}", e));
+                print_separator();
+                return Ok(());
+            }
+        },
+        (None, Some(p)) => {
+            let target: PeerId = match p.parse() {
+                Ok(p) => p,
+                Err(e) => {
+                    print_error(&format!("--peer is not a valid base58 peer ID: {}", e));
+                    print_separator();
+                    return Ok(());
+                }
+            };
+            match resolve_peer(&mut client, target).await {
+                Ok(pair) => pair,
+                Err(e) => {
+                    print_error(&format!("--peer DHT lookup failed: {}", e));
+                    print_separator();
+                    return Ok(());
+                }
+            }
+        }
+        // clap should make these unreachable, but be explicit.
+        (Some(_), Some(_)) | (None, None) => {
+            print_error("specify exactly one of --addr or --peer");
+            print_separator();
+            return Ok(());
+        }
+    };
+
     print_box_header("🛰  KwaaiNet P2P — Manual Dial");
-    println!("  Target: {}", multiaddr);
+    println!("  Target peer: {}", dest_peer);
+    println!("  Multiaddr:   {}", multiaddr);
     println!();
 
     if let Err(e) = client.connect_peer(&multiaddr).await {
@@ -302,20 +355,6 @@ async fn peers_connect(multiaddr: String, message: Option<String>) -> Result<()>
     print_success("Connected.");
 
     if let Some(msg) = message {
-        // Pull the destination peer ID out of the multiaddr — for a relay'd
-        // address (`…/p2p/<RELAY>/p2p-circuit/p2p/<DEST>`) the destination is
-        // the LAST /p2p/ component, not the first.
-        let maddr: Multiaddr = multiaddr.parse().context("parse multiaddr for hello")?;
-        let mut last_p2p = None;
-        for proto in maddr.iter() {
-            if let libp2p::multiaddr::Protocol::P2p(hash) = proto {
-                last_p2p = Some(hash);
-            }
-        }
-        let dest = last_p2p.context("multiaddr has no /p2p/<peer-id> component")?;
-        let dest_peer = PeerId::from_multihash(dest.into())
-            .map_err(|e| anyhow::anyhow!("invalid peer multihash: {:?}", e))?;
-
         let from_peer = local_peer_id(&mut client).await?;
         match crate::p2p_hello::send(&client, &dest_peer, &from_peer, &msg).await {
             Ok(()) => print_success(&format!("Sent hello to {} — see their logs.", dest_peer)),
@@ -326,6 +365,99 @@ async fn peers_connect(multiaddr: String, message: Option<String>) -> Result<()>
     }
     print_separator();
     Ok(())
+}
+
+/// Parse an `--addr` multiaddr and identify the destination peer ID.
+///
+/// For a relay'd address (`…/p2p/<RELAY>/p2p-circuit/p2p/<DEST>`) the
+/// destination is the LAST `/p2p/` component. We refuse multiaddrs where
+/// `/p2p-circuit` is present but no `/p2p/<peer>` follows it — those addresses
+/// (as returned by p2pd's DHT layer) name only the relay, not the destination,
+/// and dialing them is almost certainly a copy-paste mistake. The user wanted
+/// to reach the peer, not the relay.
+fn resolve_addr(addr: &str) -> Result<(String, PeerId)> {
+    let maddr: Multiaddr = addr.parse().context("parse --addr as multiaddr")?;
+
+    let mut last_p2p_was_after_circuit = !is_relayed(&maddr);
+    let mut saw_circuit = false;
+    let mut last_p2p = None;
+    for proto in maddr.iter() {
+        match proto {
+            libp2p::multiaddr::Protocol::P2pCircuit => {
+                saw_circuit = true;
+                // Reset: only `/p2p/` components AFTER the circuit hop name
+                // the destination. A `/p2p/` before the circuit names the
+                // relay.
+                last_p2p = None;
+            }
+            libp2p::multiaddr::Protocol::P2p(hash) => {
+                last_p2p = Some(hash);
+                if saw_circuit {
+                    last_p2p_was_after_circuit = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let dest_hash = last_p2p.context(
+        "multiaddr has no /p2p/<peer-id> component — pass a complete address \
+         like /ip4/<IP>/tcp/<PORT>/p2p/<PEER-ID> or use --peer to look it up \
+         in the DHT",
+    )?;
+
+    if saw_circuit && !last_p2p_was_after_circuit {
+        anyhow::bail!(
+            "multiaddr ends with /p2p-circuit but has no /p2p/<destination> \
+             after it — this names only the relay, not the peer you want to \
+             reach. Append /p2p/<destination-peer-id> to the multiaddr, or \
+             use --peer <peer-id> to let the CLI do the DHT lookup for you."
+        );
+    }
+
+    let dest_peer = PeerId::from_multihash(dest_hash.into())
+        .map_err(|e| anyhow::anyhow!("invalid peer multihash in /p2p/: {:?}", e))?;
+    Ok((maddr.to_string(), dest_peer))
+}
+
+/// Look up `target` in the DHT and pick a multiaddr to dial. Prefers a direct
+/// address; falls back to the first relay'd address. Always appends
+/// `/p2p/<target>` so the returned multiaddr names the destination
+/// (p2pd / Kademlia returns addresses without the trailing `/p2p/<self>` since
+/// the DHT entry is keyed on the peer ID anyway).
+async fn resolve_peer(
+    client: &mut kwaai_p2p_daemon::P2PClient,
+    target: PeerId,
+) -> Result<(String, PeerId)> {
+    let info = client
+        .dht_find_peer(target.to_bytes(), Some(10))
+        .await
+        .context("dht_find_peer")?;
+    if info.addrs.is_empty() {
+        anyhow::bail!("peer found in DHT but no addresses advertised");
+    }
+
+    let parsed: Vec<Multiaddr> = info
+        .addrs
+        .iter()
+        .filter_map(|a| Multiaddr::try_from(a.clone()).ok())
+        .collect();
+    if parsed.is_empty() {
+        anyhow::bail!("DHT returned addresses but none parsed as a multiaddr");
+    }
+
+    // Prefer direct over relay'd. If both kinds are present a direct dial is
+    // always faster and gives hole-punching nothing to work on.
+    let pick = parsed
+        .iter()
+        .find(|m| !is_relayed(m))
+        .or_else(|| parsed.first())
+        .expect("parsed is non-empty");
+
+    let with_dest = pick
+        .clone()
+        .with(libp2p::multiaddr::Protocol::P2p(target.into()));
+    Ok((with_dest.to_string(), target))
 }
 
 // ---------------------------------------------------------------------------

--- a/core/crates/kwaai-cli/src/p2p_hello.rs
+++ b/core/crates/kwaai-cli/src/p2p_hello.rs
@@ -1,67 +1,35 @@
-//! Direct-message ("hello") protocol over the libp2p fabric.
+//! Plain-text messaging protocol over the libp2p fabric.
 //!
 //! Protocol ID: `/kwaai/p2p/hello/1.0.0`
 //!
-//! A minimal request/response RPC that lets one node send a short message to
-//! another and surfaces the message in the recipient's logs. Doubles as the
-//! example we point at when explaining how to plug a custom protocol into the
-//! KwaaiNet p2p fabric — see [`make_handler`] for the server side and
-//! [`send`] for the client side.
+//! A trivial unary RPC: the request payload is a UTF-8 string, the recipient
+//! logs it, and replies with `b"ok"`. No wrapper, no schema. Doubles as the
+//! canonical example of how to plug a custom protocol into the KwaaiNet p2p
+//! fabric — see [`make_handler`] for the server side.
 //!
-//! Wire format: [`HelloRequest`] / [`HelloResponse`] serialised with msgpack
-//! (matches the convention established by `/kwaai/inference/1.0.0` in
-//! `block_rpc.rs`).
+//! Sending side has no helper here on purpose: callers go through
+//! [`P2PClient::call_unary_handler`] directly with the bytes they want to
+//! send. `peers send --message <text>` and `peers send --payload-hex <hex>`
+//! produce identical wire output for the same bytes — that's the no-magic
+//! property we want from a diagnostic tool.
 
-use anyhow::{Context, Result};
-use kwaai_p2p_daemon::{error::Result as DaemonResult, P2PClient};
-use libp2p::PeerId;
-use serde::{Deserialize, Serialize};
+use kwaai_p2p_daemon::error::Result as DaemonResult;
 use std::pin::Pin;
 use tracing::info;
 
 /// libp2p protocol string registered with the p2p daemon.
 pub const HELLO_PROTO: &str = "/kwaai/p2p/hello/1.0.0";
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HelloRequest {
-    /// Sender's peer ID, base58-encoded (e.g. `12D3KooW…`). Filled in by the
-    /// caller from the local node's identity.
-    pub from: String,
-    /// The message body. Plain UTF-8 — no length cap is enforced here, but
-    /// the unary-RPC wire imposes its own framing limits.
-    pub msg: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HelloResponse {
-    /// Always `true` for now — kept as a struct (rather than a unit type) so
-    /// future versions can add fields without breaking the wire format.
-    pub ok: bool,
-}
-
-/// Send a hello message to `peer_id` over an already-established connection.
-///
-/// Returns `Ok(())` once the recipient has acknowledged the message.
-pub async fn send(client: &P2PClient, peer_id: &PeerId, from: &PeerId, msg: &str) -> Result<()> {
-    let req = HelloRequest {
-        from: from.to_base58(),
-        msg: msg.to_string(),
-    };
-    let req_bytes = rmp_serde::to_vec_named(&req).context("serialise HelloRequest")?;
-    let resp_bytes = client
-        .call_unary_handler(&peer_id.to_bytes(), HELLO_PROTO, &req_bytes)
-        .await
-        .context("call_unary_handler")?;
-    let _resp: HelloResponse =
-        rmp_serde::from_slice(&resp_bytes).context("deserialise HelloResponse")?;
-    Ok(())
-}
-
 /// Build a unary handler suitable for [`P2PClient::add_unary_handler`].
 ///
-/// On every inbound message, prints the message to stdout (so it's visible in
-/// `docker logs` even with default tracing filters) and emits a `tracing::info!`
-/// event for structured-log consumers.
+/// Decodes the request payload as UTF-8, prints it to stdout (so it's
+/// visible in `docker logs` even with default tracing filters), and emits a
+/// `tracing::info!` event for structured-log consumers. Replies with
+/// `b"ok"`.
+///
+/// Non-UTF-8 payloads are decoded with `String::from_utf8_lossy` (replacement
+/// chars for invalid sequences) and logged with a leading marker so the
+/// operator can see the protocol was misused.
 #[allow(clippy::type_complexity)]
 pub fn make_handler(
 ) -> impl Fn(Vec<u8>) -> Pin<Box<dyn std::future::Future<Output = DaemonResult<Vec<u8>>> + Send>>
@@ -70,26 +38,18 @@ pub fn make_handler(
        + 'static {
     |data: Vec<u8>| {
         Box::pin(async move {
-            let req: HelloRequest = match rmp_serde::from_slice(&data) {
-                Ok(req) => req,
-                Err(e) => {
-                    let err = format!("hello: bad msgpack: {e}");
-                    println!("⚠️  {err}");
-                    return Err(kwaai_p2p_daemon::error::Error::Protocol(err));
+            match std::str::from_utf8(&data) {
+                Ok(msg) => {
+                    println!("💬 [p2p hello] {}", msg);
+                    info!(msg = %msg, "p2p hello received");
                 }
-            };
-            // Belt-and-braces: stdout for demo visibility, tracing for structured
-            // log consumers. The leading emoji makes the line easy to spot in a
-            // wall of debug output.
-            println!("💬 [p2p hello] from {}: {}", req.from, req.msg);
-            info!(from = %req.from, msg = %req.msg, "p2p hello received");
-
-            let resp = HelloResponse { ok: true };
-            rmp_serde::to_vec_named(&resp).map_err(|e| {
-                kwaai_p2p_daemon::error::Error::Protocol(format!(
-                    "hello: serialise HelloResponse: {e}"
-                ))
-            })
+                Err(_) => {
+                    let lossy = String::from_utf8_lossy(&data);
+                    println!("💬 [p2p hello, non-utf8] {}", lossy);
+                    info!(msg = %lossy, "p2p hello received (non-utf8 payload)");
+                }
+            }
+            Ok(b"ok".to_vec())
         })
     }
 }

--- a/core/crates/kwaai-cli/src/p2p_hello.rs
+++ b/core/crates/kwaai-cli/src/p2p_hello.rs
@@ -1,0 +1,95 @@
+//! Direct-message ("hello") protocol over the libp2p fabric.
+//!
+//! Protocol ID: `/kwaai/p2p/hello/1.0.0`
+//!
+//! A minimal request/response RPC that lets one node send a short message to
+//! another and surfaces the message in the recipient's logs. Doubles as the
+//! example we point at when explaining how to plug a custom protocol into the
+//! KwaaiNet p2p fabric — see [`make_handler`] for the server side and
+//! [`send`] for the client side.
+//!
+//! Wire format: [`HelloRequest`] / [`HelloResponse`] serialised with msgpack
+//! (matches the convention established by `/kwaai/inference/1.0.0` in
+//! `block_rpc.rs`).
+
+use anyhow::{Context, Result};
+use kwaai_p2p_daemon::{error::Result as DaemonResult, P2PClient};
+use libp2p::PeerId;
+use serde::{Deserialize, Serialize};
+use std::pin::Pin;
+use tracing::info;
+
+/// libp2p protocol string registered with the p2p daemon.
+pub const HELLO_PROTO: &str = "/kwaai/p2p/hello/1.0.0";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HelloRequest {
+    /// Sender's peer ID, base58-encoded (e.g. `12D3KooW…`). Filled in by the
+    /// caller from the local node's identity.
+    pub from: String,
+    /// The message body. Plain UTF-8 — no length cap is enforced here, but
+    /// the unary-RPC wire imposes its own framing limits.
+    pub msg: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HelloResponse {
+    /// Always `true` for now — kept as a struct (rather than a unit type) so
+    /// future versions can add fields without breaking the wire format.
+    pub ok: bool,
+}
+
+/// Send a hello message to `peer_id` over an already-established connection.
+///
+/// Returns `Ok(())` once the recipient has acknowledged the message.
+pub async fn send(client: &P2PClient, peer_id: &PeerId, from: &PeerId, msg: &str) -> Result<()> {
+    let req = HelloRequest {
+        from: from.to_base58(),
+        msg: msg.to_string(),
+    };
+    let req_bytes = rmp_serde::to_vec_named(&req).context("serialise HelloRequest")?;
+    let resp_bytes = client
+        .call_unary_handler(&peer_id.to_bytes(), HELLO_PROTO, &req_bytes)
+        .await
+        .context("call_unary_handler")?;
+    let _resp: HelloResponse =
+        rmp_serde::from_slice(&resp_bytes).context("deserialise HelloResponse")?;
+    Ok(())
+}
+
+/// Build a unary handler suitable for [`P2PClient::add_unary_handler`].
+///
+/// On every inbound message, prints the message to stdout (so it's visible in
+/// `docker logs` even with default tracing filters) and emits a `tracing::info!`
+/// event for structured-log consumers.
+#[allow(clippy::type_complexity)]
+pub fn make_handler(
+) -> impl Fn(Vec<u8>) -> Pin<Box<dyn std::future::Future<Output = DaemonResult<Vec<u8>>> + Send>>
+       + Send
+       + Sync
+       + 'static {
+    |data: Vec<u8>| {
+        Box::pin(async move {
+            let req: HelloRequest = match rmp_serde::from_slice(&data) {
+                Ok(req) => req,
+                Err(e) => {
+                    let err = format!("hello: bad msgpack: {e}");
+                    println!("⚠️  {err}");
+                    return Err(kwaai_p2p_daemon::error::Error::Protocol(err));
+                }
+            };
+            // Belt-and-braces: stdout for demo visibility, tracing for structured
+            // log consumers. The leading emoji makes the line easy to spot in a
+            // wall of debug output.
+            println!("💬 [p2p hello] from {}: {}", req.from, req.msg);
+            info!(from = %req.from, msg = %req.msg, "p2p hello received");
+
+            let resp = HelloResponse { ok: true };
+            rmp_serde::to_vec_named(&resp).map_err(|e| {
+                kwaai_p2p_daemon::error::Error::Protocol(format!(
+                    "hello: serialise HelloResponse: {e}"
+                ))
+            })
+        })
+    }
+}

--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -331,12 +331,13 @@ impl P2PClient {
             .parse()
             .map_err(|e| Error::Connection(format!("Invalid multiaddr: {}", e)))?;
 
-        // Extract the peer ID from the multiaddr
+        // Extract the destination peer ID from the multiaddr.
+        // For a relay'd address like /ip4/.../p2p/<RELAY>/p2p-circuit/p2p/<DEST>,
+        // the destination is the LAST /p2p/ component, not the first.
         let mut peer_id_bytes = None;
         for component in maddr.iter() {
             if let libp2p::multiaddr::Protocol::P2p(hash) = component {
                 peer_id_bytes = Some(hash.to_bytes());
-                break;
             }
         }
 

--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -263,6 +263,16 @@ impl P2PClient {
     ///
     /// Returns the peer ID as hex-encoded string
     pub async fn identify(&mut self) -> Result<String> {
+        let (peer_id, _) = self.identify_with_addrs().await?;
+        Ok(peer_id)
+    }
+
+    /// Send an IDENTIFY request and return both the peer ID and observed multiaddrs.
+    ///
+    /// Returns `(peer_id_hex, addrs)` where `addrs` is the list of multiaddr bytes
+    /// that p2pd has observed for itself (populated by the libp2p IDENTIFY protocol
+    /// as peers connect and report our external address).
+    pub async fn identify_with_addrs(&mut self) -> Result<(String, Vec<Vec<u8>>)> {
         let request = Request {
             r#type: request::Type::Identify as i32,
             connect: None,
@@ -278,9 +288,8 @@ impl P2PClient {
         let response = self.send_request(request).await?;
 
         if let Some(id) = response.identify {
-            // Peer ID is binary data, encode as hex for display
             let peer_id = hex::encode(&id.id);
-            Ok(peer_id)
+            Ok((peer_id, id.addrs))
         } else {
             Err(Error::InvalidResponse(
                 "Expected IDENTIFY response".to_string(),

--- a/core/crates/kwaai-p2p-daemon/src/daemon.rs
+++ b/core/crates/kwaai-p2p-daemon/src/daemon.rs
@@ -20,6 +20,7 @@ pub struct DaemonBuilder {
     bootstrap_peers: Vec<String>,
     bootstrap: bool,
     dht: bool,
+    dht_server: bool,
     relay: bool,
     auto_relay: bool,
     auto_nat: bool,
@@ -58,9 +59,30 @@ impl DaemonBuilder {
         self
     }
 
-    /// Enable DHT support
+    /// Enable DHT support.
+    ///
+    /// Maps to p2pd's `-dht` flag, which uses libp2p's `dht.ModeAuto`: the
+    /// node starts in client mode and only switches to server mode if AutoNAT
+    /// confirms it is publicly reachable. Client-mode peers do not advertise
+    /// themselves into other nodes' routing tables and are not findable via
+    /// FindPeer. For private deployments where every node should be findable
+    /// without depending on AutoNAT, prefer `dht_server(true)`.
     pub fn dht(mut self, enable: bool) -> Self {
         self.dht = enable;
+        self
+    }
+
+    /// Force DHT server mode (`-dhtServer`).
+    ///
+    /// Server mode means the node always advertises itself into peers' routing
+    /// tables and answers DHT queries. Use this when the node should be
+    /// findable regardless of AutoNAT verdict — e.g. on a private network
+    /// where AutoNAT's "public reachability" definition does not apply, or
+    /// when running behind a port-forwarded router that AutoNAT cannot probe.
+    ///
+    /// When set, takes precedence over `dht()` (the `-dht` flag is omitted).
+    pub fn dht_server(mut self, enable: bool) -> Self {
+        self.dht_server = enable;
         self
     }
 
@@ -227,8 +249,12 @@ impl DaemonBuilder {
         // Set listen address
         cmd.arg("-listen").arg(&listen_addr);
 
-        // DHT mode
-        if self.dht {
+        // DHT mode. -dhtServer takes precedence over -dht: server mode forces
+        // the node into the routing table regardless of AutoNAT verdict, while
+        // -dht (auto mode) leaves it as a client until proven reachable.
+        if self.dht_server {
+            cmd.arg("-dhtServer");
+        } else if self.dht {
             cmd.arg("-dht");
         }
 

--- a/core/crates/kwaai-p2p-daemon/src/hello.rs
+++ b/core/crates/kwaai-p2p-daemon/src/hello.rs
@@ -8,19 +8,28 @@
 //! fabric — see [`make_handler`] for the server side.
 //!
 //! Sending side has no helper here on purpose: callers go through
-//! [`P2PClient::call_unary_handler`] directly with the bytes they want to
-//! send. `peers send --message <text>` and `peers send --payload-hex <hex>`
-//! produce identical wire output for the same bytes — that's the no-magic
-//! property we want from a diagnostic tool.
+//! [`crate::P2PClient::call_unary_handler`] directly with the bytes they
+//! want to send. `peers send --message <text>` and
+//! `peers send --payload-hex <hex>` (in `kwaainet`) produce identical wire
+//! output for the same bytes — that's the no-magic property we want from a
+//! diagnostic tool.
+//!
+//! Lives in `kwaai-p2p-daemon` rather than `kwaai-cli` because the protocol
+//! is daemon-shaped infrastructure (handler registered via
+//! [`crate::P2PClient::add_unary_handler`], called via
+//! [`crate::P2PClient::call_unary_handler`]) and the CLI is just one
+//! caller. Future code that wants to participate in the hello protocol —
+//! whether to register the handler, to invoke it, or to reference its
+//! protocol ID — imports from here.
 
-use kwaai_p2p_daemon::error::Result as DaemonResult;
+use crate::error::Result;
 use std::pin::Pin;
 use tracing::info;
 
 /// libp2p protocol string registered with the p2p daemon.
 pub const HELLO_PROTO: &str = "/kwaai/p2p/hello/1.0.0";
 
-/// Build a unary handler suitable for [`P2PClient::add_unary_handler`].
+/// Build a unary handler suitable for [`crate::P2PClient::add_unary_handler`].
 ///
 /// Decodes the request payload as UTF-8, prints it to stdout (so it's
 /// visible in `docker logs` even with default tracing filters), and emits a
@@ -32,7 +41,7 @@ pub const HELLO_PROTO: &str = "/kwaai/p2p/hello/1.0.0";
 /// operator can see the protocol was misused.
 #[allow(clippy::type_complexity)]
 pub fn make_handler(
-) -> impl Fn(Vec<u8>) -> Pin<Box<dyn std::future::Future<Output = DaemonResult<Vec<u8>>> + Send>>
+) -> impl Fn(Vec<u8>) -> Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>>> + Send>>
        + Send
        + Sync
        + 'static {

--- a/core/crates/kwaai-p2p-daemon/src/lib.rs
+++ b/core/crates/kwaai-p2p-daemon/src/lib.rs
@@ -41,6 +41,7 @@ pub mod client;
 pub mod daemon;
 pub mod dht;
 pub mod error;
+pub mod hello;
 pub mod persistent;
 pub mod protocol;
 pub mod stream;

--- a/docs/IP_DISCOVERY.md
+++ b/docs/IP_DISCOVERY.md
@@ -1,0 +1,164 @@
+# IP Address Discovery and p2pd Restart Safety
+
+This document explains how a KwaaiNet node discovers its public IP address, how
+that address propagates to `map.kwaai.ai`, and the safety mechanism that
+prevents p2pd restarts from disrupting in-flight inference.
+
+---
+
+## Overview
+
+For a node to appear **Online** on the map and be reachable for PING/FIND
+operations, the Hivemind DHT record for that node must contain a publicly
+routable multiaddr. There are three ways this address can be established,
+in priority order:
+
+| Priority | Source | Config field | Behaviour |
+|----------|--------|--------------|-----------|
+| 1 | Manual multiaddr | `announce_addr` | Passed directly to p2pd at startup; no discovery needed |
+| 2 | Manual IP | `public_ip` | Formatted as `/ip4/<ip>/tcp/<port>` and passed to p2pd |
+| 3 | **IDENTIFY (default)** | _(neither set)_ | p2pd starts with no announce addr; address discovered dynamically |
+
+When neither `announce_addr` nor `public_ip` is set the node relies entirely
+on the IDENTIFY-based discovery path described below.
+
+---
+
+## Phase 1 — p2pd starts without an announce address
+
+p2pd is spawned with only a host listen address (`/ip4/0.0.0.0/tcp/<port>`).
+At this point the daemon has no knowledge of its public address and will not
+advertise one in DHT records.
+
+## Phase 2 — DHT bootstrap
+
+The node dials each configured bootstrap peer and waits until at least one
+connection is confirmed. Bootstrap peers are the entry point into the Hivemind
+DHT and are also the peers that will run the IDENTIFY protocol with us.
+
+## Phase 3 — IDENTIFY polling (external address discovery)
+
+Once a bootstrap peer is connected, the libp2p
+[IDENTIFY protocol](https://github.com/libp2p/specs/blob/master/identify/README.md)
+fires automatically. Each peer that connects reports back what address it
+_observed_ us connecting from — i.e., our public IP and port as seen from the
+internet.
+
+`collect_observed_addresses()` polls `identify_with_addrs()` in a loop,
+filtering out private/loopback addresses. It requires **two independent
+confirmations** from distinct peers before accepting an address as authoritative.
+This guards against a single rogue or misconfigured peer reporting a wrong
+address.
+
+```
+Bootstrap peer A  ──identify──▶  "I see you at /ip4/203.0.113.1/tcp/8080"
+Bootstrap peer B  ──identify──▶  "I see you at /ip4/203.0.113.1/tcp/8080"
+                                                          ↓
+                                              2 confirmations → accepted
+```
+
+Polling runs for up to 10 seconds. If no confirmed address is found within that
+window a warning is logged and the node falls back to relay mode.
+
+## Phase 4 — p2pd restart with announce address
+
+Once the address is confirmed, p2pd is restarted with the discovered multiaddr
+passed as its `--announceAddr` flag. This causes p2pd to include the address in
+all DHT advertisements and IDENTIFY responses going forward.
+
+Before shutdown, DHT stream handlers (`DHTProtocol.rpc_ping/store/find`) are
+explicitly unregistered so the listener port is freed cleanly. After the new
+p2pd starts the handlers are re-registered with the new client.
+
+**The startup restart (Step 5)** happens before the event loop begins, so no
+inference traffic can be in-flight at this point.
+
+## Phase 5 — DHT announcement
+
+With p2pd now advertising the correct address, the node announces itself to the
+DHT. `map.kwaai.ai` reads these records and marks the node **Online**. PING and
+FIND operations from other peers now route to the correct address.
+
+---
+
+## Periodic address refresh
+
+Network conditions change — DHCP leases expire, NAT mappings shift, the node
+moves between networks. Every 5 minutes (when running without an explicit
+`announce_addr`) the node re-runs IDENTIFY polling with the same 2-confirmation
+requirement.
+
+If the observed address has changed a **deferred restart** is scheduled (see
+below). If the address is unchanged nothing happens.
+
+---
+
+## Deferred restart safety mechanism
+
+### The problem
+
+Restarting p2pd tears down:
+
+- All active peer connections and relay circuits
+- DHT handler registrations (these must be re-registered after restart)
+- Any libp2p streams currently being forwarded
+
+If a p2pd restart fires during an in-flight inference request the stream
+carrying that request is torn down. The coordinator's retry logic handles
+this, but the disruption is unnecessary and wastes KV-cache state on the
+downstream shard.
+
+### The solution
+
+When IDENTIFY detects an address change inside the event loop, the new
+addresses are stored in `pending_restart` rather than triggering an immediate
+restart:
+
+```
+IDENTIFY tick  →  address changed  →  pending_restart = Some(new_addrs)
+                                       (log: "restart deferred until idle")
+```
+
+At the next **reannounce tick** (every 120 seconds), before the regular DHT
+announcement, the event loop checks two conditions:
+
+1. `pending_restart` is `Some(_)` — there is a restart waiting
+2. `active_rpc_streams == 0` — no DHT RPC handler tasks are currently running
+
+If both are true the restart proceeds. If streams are still active the tick logs
+the count and tries again at the next tick.
+
+```
+Reannounce tick
+  ├─ pending_restart? yes
+  ├─ active_rpc_streams? 0  ──▶  restart p2pd now
+  │                               re-register handlers
+  │                               pending_restart = None
+  │                               continue with normal re-announce
+  └─ active_rpc_streams? N  ──▶  log "N stream(s) active, retrying next tick"
+```
+
+`active_rpc_streams` is an `Arc<AtomicUsize>` incremented when `accept()`
+returns a new stream and decremented when the spawned handler task completes.
+
+### What this guarantees
+
+- A restart will never fire while a DHT RPC (ping/store/find) is in progress.
+- Restarts are applied within at most `120 + 300 = 420 seconds` of an address
+  change in the worst case (IDENTIFY fires at the end of its 5-minute window,
+  all streams happen to be active for the next full 120-second reannounce
+  interval).
+- Handler re-registration always happens as part of the restart, eliminating
+  the previous bug where handlers were lost after a periodic restart.
+
+---
+
+## Remaining risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `shard serve` inference stream torn down by startup restart (Step 5) | Low — startup precedes inference | `shard serve` is a separate process; its handler survives p2pd restart. The coordinator retries on stream error. |
+| Relay circuit torn down mid-inference (relay-mode nodes only) | Low — only affects nodes with no confirmed public address | Direct-reachable nodes are unaffected. Relay nodes already tolerate circuit loss. |
+| Address change goes undetected if IDENTIFY peers are slow | Medium | 10-second timeout at startup; 8-second timeout on periodic checks. Bootstrap peers are expected to be stable. |
+| Node stays on stale address longer than expected if always busy | Low | In practice DHT RPC streams complete in milliseconds. Sustained load would need to span multiple 120-second ticks. |
+| `announce_addr` or `public_ip` set but wrong (manual misconfiguration) | User error | IDENTIFY path is bypassed entirely when either field is set. The node relies on the user-provided value. |


### PR DESCRIPTION
## Summary

A bundle of public-address-handling improvements for kwaainet nodes. Three threads converge on the same plumbing — kwaainet correctly publishing its address, regardless of how that address was determined.

### What's in scope

1. **IDENTIFY-based public-IP detection.** When neither `announce_addr` nor `public_ip` is set in config, poll libp2p IDENTIFY responses from bootstrap peers until at least N (default 2) independent peers report the same observed address. Restart p2pd with that address as `-announceAddrs`. Configurable via new `identify_min_confirmations` and `identify_timeout_secs` config keys (defaults 2 / 45s).

2. **`public_port` config field** (new). Adjacent to `public_ip`. Lets a port-forwarded node announce a different external port than the one it listens on — common when ISPs block the listen port (80, 25) or when one router forwards distinct external ports to multiple kwaainet instances each on internal :8080. When unset, falls back to `port`. Has no effect when `announce_addr` is set explicitly (that's a full multiaddr).

3. **Deferred p2pd restarts.** Address changes detected mid-flight no longer immediately tear down active circuits and orphan in-flight RPC streams. The restart waits until `active_rpc_streams` drops to zero (checked on the periodic re-announce tick).

4. **`P2PDaemon::builder().dht_server(true)` knob** (in `kwaai-p2p-daemon`). Pre-promotes a node to DHT server mode regardless of AutoNAT verdict. Not used by regular nodes (default `dht(true)` auto-mode is correct), but available for bootstrap-style deployments that need to be findable from t=0 without waiting for AutoNAT.

5. **`using_relay` derived from actual address set**, not config-time intent. True only when the discovery set is empty AND no `announce_addr` AND `!no_relay`. Matches what the map's Direct/Via-relay badge should mean. (Was config-time intent, which gave wrong results when actual reachability diverged.)

### Why one PR

All five share the same code surface in `node.rs`'s startup sequence and the daemon builder. Splitting them would mean overlapping diffs that conflict and need careful re-stacking.

## Approach (per architectural constraint)

The user is exploring rust-libp2p / shimming go-libp2p separately, so **no p2pd source changes**. The "relaunch p2pd on change" approach (vs. patching p2pd to expose `add_external_address` over IPC) is the right plumbing for today's daemon-driven architecture, even though it's disruptive to active connections — hence #3's deferred-restart wrapper to minimize the disruption.

## Files

- `core/crates/kwaai-cli/src/config.rs` — `public_port`, `identify_min_confirmations`, `identify_timeout_secs` config keys + `config set` arms.
- `core/crates/kwaai-cli/src/node.rs` — `discover_and_restart_with_announce`, `restart_p2pd_with_addrs`, deferred-restart logic, gating, `using_relay` rework.
- `core/crates/kwaai-p2p-daemon/src/{client.rs,daemon.rs}` — small client tweaks + new `dht_server(true)` builder knob.
- `docs/IP_DISCOVERY.md` — new docs explaining the IDENTIFY-detection lifecycle.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] End-to-end verified in the local nat-test topology: all 8 nodes (a-h) appear on the health map, including the 3 NATed nodes (f/g/h) using their trusted relay.
- [x] Regression caught + fixed during testing: NATed nodes failed to announce when the discover-and-restart loop tore down their in-flight relay reservation. Resolved by the final commit (gating: skip discover when `trusted_relays` is configured) — full justification in that commit's message.

## Known gaps (separate work, not this PR)

- Even with announce_addr correctly passed via `-announceAddrs`, NATed/port-forwarded nodes still publish only `/p2p-circuit/` addresses to the DHT (verified). Either p2pd's `-announceAddrs` flag isn't reaching the DHT-record path, or the nodes need another nudge to advertise the direct addr alongside the relay one. Tracked separately.
- The deferred-restart logic on the periodic-tick arm is wired up but the trigger path (IDENTIFY discovery sees an address change) hasn't been exercised end-to-end yet — needs a test scenario where a node's public IP genuinely changes mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Note on CI

The Format check fails on 5 files this PR doesn't touch (`crates/kwaai-cli/src/rag_api.rs`, `crates/kwaai-cli/src/rag_cmd.rs`, `crates/kwaai-rag/src/{bm25,prompt,query_understanding}.rs`). Those are pre-existing rustfmt debt introduced by the 5 rag commits merged to upstream/main since this PR branched (`30afd12` through `3849a22`). Local `cargo fmt --all -- --check` on this branch alone reports 0 diffs; the failures only appear after the implicit rebase against current upstream/main. Cleanup belongs in a separate rag-owned commit.