### PR TITLE
chore(fmt): rustfmt rag_api / rag_cmd / bm25 / prompt / query_understanding

### DIFF
--- a/core/crates/kwaai-cli/src/rag_api.rs
+++ b/core/crates/kwaai-cli/src/rag_api.rs
@@ -58,10 +58,9 @@ pub async fn run(port: u16, inference_url: String, top_k: usize, kb: String) -> 
         use crate::rag_cmd::*;
 
         let cfg = KwaaiNetConfig::load_or_create()?;
-        let rag = cfg
-            .get_rag_kb(&kb)
-            .cloned()
-            .with_context(|| format!("KB '{kb}' not initialised. Run: kwaainet rag init --name {kb}"))?;
+        let rag = cfg.get_rag_kb(&kb).cloned().with_context(|| {
+            format!("KB '{kb}' not initialised. Run: kwaainet rag init --name {kb}")
+        })?;
 
         let tenant_id: Uuid = rag.tenant_id.as_deref().context("no tenant_id")?.parse()?;
         let storage_url = rag.storage_url.clone();

--- a/core/crates/kwaai-cli/src/rag_cmd.rs
+++ b/core/crates/kwaai-cli/src/rag_cmd.rs
@@ -132,7 +132,11 @@ async fn cmd_init(
                         false
                     };
                     if tenant_in_db {
-                        print_info(&format!("Knowledge base '{}':  {}", name, data_dir.display()));
+                        print_info(&format!(
+                            "Knowledge base '{}':  {}",
+                            name,
+                            data_dir.display()
+                        ));
                         print_success(&format!(
                             "Already initialised (tenant {tenant_id}) — embedding model updated."
                         ));
@@ -147,7 +151,9 @@ async fn cmd_init(
                         println!("  Next:  kwaainet rag ingest <file> --kb {name}");
                         return Ok(());
                     }
-                    print_warning("Tenant record missing from local DB — recreating knowledge base.");
+                    print_warning(
+                        "Tenant record missing from local DB — recreating knowledge base.",
+                    );
                 }
             }
         }
@@ -157,13 +163,22 @@ async fn cmd_init(
         let tm = kwaai_storage::TenantManager::new(db);
         let local_peer_id = crate::identity::NodeIdentity::load_or_create()?.peer_id;
         let info = tm
-            .create(&local_peer_id.to_base58(), 0, Some(&format!("kwaai-rag/{name}")), 768)
+            .create(
+                &local_peer_id.to_base58(),
+                0,
+                Some(&format!("kwaai-rag/{name}")),
+                768,
+            )
             .await
             .context("creating local tenant")?;
         let tenant_id = info.tenant_id;
 
         MetaStore::open(&data_dir, tenant_id)?;
-        print_info(&format!("Knowledge base '{}':  {}", name, data_dir.display()));
+        print_info(&format!(
+            "Knowledge base '{}':  {}",
+            name,
+            data_dir.display()
+        ));
 
         let mut cfg = KwaaiNetConfig::load_or_create()?;
         cfg.set_rag_kb(
@@ -180,7 +195,10 @@ async fn cmd_init(
         );
         cfg.save()?;
 
-        print_success(&format!("Knowledge base '{}' initialised  (tenant {tenant_id})", name));
+        print_success(&format!(
+            "Knowledge base '{}' initialised  (tenant {tenant_id})",
+            name
+        ));
         if name == "default" {
             println!("  Next:  kwaainet rag ingest <file>");
         } else {
@@ -228,8 +246,14 @@ async fn cmd_connect_eve(peer_id: String, url: Option<String>, kb: String) -> Re
     let rag = cfg
         .rag_kbs
         .get_mut(&kb)
-        .or(if kb == "default" { cfg.rag.as_mut() } else { None })
-        .with_context(|| format!("KB '{kb}' not initialised. Run: kwaainet rag init --name {kb}"))?;
+        .or(if kb == "default" {
+            cfg.rag.as_mut()
+        } else {
+            None
+        })
+        .with_context(|| {
+            format!("KB '{kb}' not initialised. Run: kwaainet rag init --name {kb}")
+        })?;
 
     rag.eve_peer_id = Some(peer_id);
     // url = Some("http://...") for HTTP transport, None for P2P RPC.
@@ -437,7 +461,9 @@ async fn cmd_query(
             if let Some(rag_cfg) = global_cfg.get_rag_kb(&kb_names[0]) {
                 if rag_cfg.storage_url.as_deref() == Some("local") {
                     match try_serve_query(&query, top_k, min_score, 9090).await {
-                        Ok(Some(results)) => return render_query_results(&query, &results, json_out),
+                        Ok(Some(results)) => {
+                            return render_query_results(&query, &results, json_out)
+                        }
                         Ok(None) => {}
                         Err(e) => return Err(e),
                     }
@@ -445,54 +471,94 @@ async fn cmd_query(
             }
         }
 
-        let retrieve_cfg = RetrieveConfig { top_k, min_score, use_sentence_window: false };
-        let spinner = if json_out { None } else { Some(crate::progress::Spinner::start("Retrieving…")) };
+        let retrieve_cfg = RetrieveConfig {
+            top_k,
+            min_score,
+            use_sentence_window: false,
+        };
+        let spinner = if json_out {
+            None
+        } else {
+            Some(crate::progress::Spinner::start("Retrieving…"))
+        };
 
         let mut all_results: Vec<kwaai_rag::retriever::RetrievedChunk> = vec![];
 
         for kb_name in &kb_names {
             let (rag_cfg, tenant_id) = match load_rag_config_for(kb_name) {
                 Ok(v) => v,
-                Err(e) => { tracing::warn!("skipping KB '{kb_name}': {e}"); continue; }
+                Err(e) => {
+                    tracing::warn!("skipping KB '{kb_name}': {e}");
+                    continue;
+                }
             };
             let embed = EmbedClient::new(None, Some(rag_cfg.embed_model.clone()));
             let meta = MetaStore::open(&rag_cfg.data_dir(), tenant_id)?;
-            let infer_url = inference_url.clone().unwrap_or_else(|| rag_cfg.inference_url.clone());
+            let infer_url = inference_url
+                .clone()
+                .unwrap_or_else(|| rag_cfg.inference_url.clone());
 
             let mut chunks = match rag_cfg.storage_url.as_deref() {
                 Some("local") => {
                     let vs = Arc::new(open_local_vs(&rag_cfg.data_dir())?);
                     if understand {
                         kwaai_rag::query_understanding::retrieve_with_understanding(
-                            &query, &retrieve_cfg, &embed, &meta, &infer_url,
+                            &query,
+                            &retrieve_cfg,
+                            &embed,
+                            &meta,
+                            &infer_url,
                             move |emb, k| {
                                 let vs = vs.clone();
                                 Box::pin(async move {
                                     let raw = vs.search(tenant_id, &emb, k).await?;
                                     Ok(raw.into_iter().map(|r| (r.id, r.score)).collect())
-                                }) as Pin<Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>>
+                                })
+                                    as Pin<
+                                        Box<
+                                            dyn std::future::Future<
+                                                    Output = Result<Vec<(i64, f64)>>,
+                                                > + Send,
+                                        >,
+                                    >
                             },
-                        ).await?
+                        )
+                        .await?
                     } else {
                         retrieve_hybrid(&query, &retrieve_cfg, &embed, &meta, move |emb, k| {
                             let vs = vs.clone();
                             Box::pin(async move {
                                 let raw = vs.search(tenant_id, &emb, k).await?;
                                 Ok(raw.into_iter().map(|r| (r.id, r.score)).collect())
-                            }) as Pin<Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>>
-                        }).await?
+                            })
+                                as Pin<
+                                    Box<
+                                        dyn std::future::Future<Output = Result<Vec<(i64, f64)>>>
+                                            + Send,
+                                    >,
+                                >
+                        })
+                        .await?
                     }
                 }
                 Some(url) => {
                     let http = reqwest::Client::new();
                     let url = url.to_string();
                     retrieve_hybrid(&query, &retrieve_cfg, &embed, &meta, move |emb, k| {
-                        let http = http.clone(); let url = url.clone();
+                        let http = http.clone();
+                        let url = url.clone();
                         Box::pin(async move {
                             let raw = http_search_vectors(&http, &url, tenant_id, emb, k).await?;
                             Ok(raw.into_iter().map(|r| (r.id, r.score)).collect())
-                        }) as Pin<Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>>
-                    }).await?
+                        })
+                            as Pin<
+                                Box<
+                                    dyn std::future::Future<Output = Result<Vec<(i64, f64)>>>
+                                        + Send,
+                                >,
+                            >
+                    })
+                    .await?
                 }
                 None => {
                     let ep = eve_peer_id(&rag_cfg)?;
@@ -504,20 +570,35 @@ async fn cmd_query(
                             let guard = client.lock().await;
                             let raw = rpc_search_vectors(&*guard, &ep, tenant_id, emb, k).await?;
                             Ok(raw.into_iter().map(|r| (r.id, r.score)).collect())
-                        }) as Pin<Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>>
-                    }).await?
+                        })
+                            as Pin<
+                                Box<
+                                    dyn std::future::Future<Output = Result<Vec<(i64, f64)>>>
+                                        + Send,
+                                >,
+                            >
+                    })
+                    .await?
                 }
             };
             if kb_names.len() > 1 {
-                for c in &mut chunks { c.source_kb = Some(kb_name.clone()); }
+                for c in &mut chunks {
+                    c.source_kb = Some(kb_name.clone());
+                }
             }
             all_results.append(&mut chunks);
         }
 
-        all_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        all_results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         all_results.truncate(top_k);
 
-        if let Some(s) = spinner { s.finish("").await; }
+        if let Some(s) = spinner {
+            s.finish("").await;
+        }
 
         let arr: Vec<serde_json::Value> = all_results
             .iter()
@@ -628,12 +709,21 @@ async fn cmd_chat(top_k: usize, inference_url: String, kb: String, understand: b
                     Box::pin(async move {
                         let raw = vs.search(tenant_id, &emb, k).await?;
                         Ok(raw.into_iter().map(|r| (r.id, r.score)).collect())
-                    }) as Pin<Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>>
+                    })
+                        as Pin<
+                            Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>,
+                        >
                 };
                 if understand {
                     kwaai_rag::query_understanding::retrieve_with_understanding(
-                        &query, &retrieve_cfg, &embed, &meta, &inference_url, search_fn,
-                    ).await?
+                        &query,
+                        &retrieve_cfg,
+                        &embed,
+                        &meta,
+                        &inference_url,
+                        search_fn,
+                    )
+                    .await?
                 } else {
                     retrieve_hybrid(&query, &retrieve_cfg, &embed, &meta, search_fn).await?
                 }
@@ -646,8 +736,12 @@ async fn cmd_chat(top_k: usize, inference_url: String, kb: String, understand: b
                     Box::pin(async move {
                         let raw = http_search_vectors(&h, &u, tenant_id, embedding, k).await?;
                         Ok(raw.into_iter().map(|r| (r.id, r.score)).collect())
-                    }) as Pin<Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>>
-                }).await?
+                    })
+                        as Pin<
+                            Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>,
+                        >
+                })
+                .await?
             } else {
                 let (client2, eve) = p2p_client.as_ref().unwrap();
                 let client2 = client2.clone();
@@ -656,10 +750,16 @@ async fn cmd_chat(top_k: usize, inference_url: String, kb: String, understand: b
                     let c = client2.clone();
                     Box::pin(async move {
                         let guard = c.lock().await;
-                        let raw = rpc_search_vectors(&*guard, &eve_peer_id, tenant_id, embedding, k).await?;
+                        let raw =
+                            rpc_search_vectors(&*guard, &eve_peer_id, tenant_id, embedding, k)
+                                .await?;
                         Ok(raw.into_iter().map(|r| (r.id, r.score)).collect())
-                    }) as Pin<Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>>
-                }).await?
+                    })
+                        as Pin<
+                            Box<dyn std::future::Future<Output = Result<Vec<(i64, f64)>>> + Send>,
+                        >
+                })
+                .await?
             };
 
             let messages = build_chat_messages(&query, &chunks, &history, 8192);
@@ -709,7 +809,9 @@ async fn cmd_docs(kb: String) -> Result<()> {
 
     let docs = meta.list_docs()?;
     if docs.is_empty() {
-        print_info(&format!("No documents ingested yet. Run: kwaainet rag ingest <file> --kb {kb}"));
+        print_info(&format!(
+            "No documents ingested yet. Run: kwaainet rag ingest <file> --kb {kb}"
+        ));
     } else {
         print_box_header(&format!("{} document(s)", docs.len()));
         for d in &docs {
@@ -778,10 +880,9 @@ async fn cmd_delete_doc(name: String, yes: bool, kb: String) -> Result<()> {
 
 fn load_rag_config_for(kb: &str) -> Result<(RagConfig, Uuid)> {
     let cfg = KwaaiNetConfig::load_or_create()?;
-    let rag = cfg
-        .get_rag_kb(kb)
-        .cloned()
-        .with_context(|| format!("KB '{kb}' not initialised. Run: kwaainet rag init --name {kb}"))?;
+    let rag = cfg.get_rag_kb(kb).cloned().with_context(|| {
+        format!("KB '{kb}' not initialised. Run: kwaainet rag init --name {kb}")
+    })?;
 
     let tenant_id: Uuid = rag
         .tenant_id

--- a/core/crates/kwaai-rag/src/bm25.rs
+++ b/core/crates/kwaai-rag/src/bm25.rs
@@ -183,7 +183,13 @@ impl BM25Index {
                 // Fall back to individual term union if parse fails (e.g. special chars)
                 let safe: String = query_text
                     .chars()
-                    .map(|c| if c.is_alphanumeric() || c == ' ' { c } else { ' ' })
+                    .map(|c| {
+                        if c.is_alphanumeric() || c == ' ' {
+                            c
+                        } else {
+                            ' '
+                        }
+                    })
                     .collect();
                 match parser.parse_query(&safe) {
                     Ok(q) => q,
@@ -226,11 +232,7 @@ impl BM25Index {
 
 /// Reciprocal Rank Fusion: merge two ranked lists into one combined ranking.
 /// k=60 is the standard value (Cormack et al. 2009).
-pub fn rrf_merge(
-    semantic: &[(i64, f64)],
-    keyword: &[(i64, f64)],
-    top_k: usize,
-) -> Vec<(i64, f64)> {
+pub fn rrf_merge(semantic: &[(i64, f64)], keyword: &[(i64, f64)], top_k: usize) -> Vec<(i64, f64)> {
     const K: f64 = 60.0;
     let mut rrf: HashMap<i64, f64> = HashMap::new();
 
@@ -281,7 +283,10 @@ mod tests {
         idx.build_from_chunks(&chunks).unwrap();
         let results = idx.search("TLSA teacher league south africa", 3);
         assert!(!results.is_empty(), "should find at least one result");
-        assert_eq!(results[0].0, 1, "Chapter 14 should rank first for TLSA query");
+        assert_eq!(
+            results[0].0, 1,
+            "Chapter 14 should rank first for TLSA query"
+        );
     }
 
     #[test]
@@ -297,7 +302,8 @@ mod tests {
         // Delete doc_b
         idx.delete_doc("doc_b.docx").unwrap();
         // Add a new chunk to doc_b replacement
-        idx.add_chunks(&[(12i64, "doc_c.docx", "cricket sport bat wicket")]).unwrap();
+        idx.add_chunks(&[(12i64, "doc_c.docx", "cricket sport bat wicket")])
+            .unwrap();
 
         let res = idx.search("apartheid", 5);
         // doc_b deleted — should no longer appear

--- a/core/crates/kwaai-rag/src/prompt.rs
+++ b/core/crates/kwaai-rag/src/prompt.rs
@@ -71,10 +71,7 @@ fn build_context_block(chunks: &[RetrievedChunk], max_chars: usize) -> String {
 }
 
 fn reorder_for_context(chunks: &[RetrievedChunk]) -> Vec<&RetrievedChunk> {
-    let (evens, odds): (Vec<_>, Vec<_>) = chunks
-        .iter()
-        .enumerate()
-        .partition(|(i, _)| i % 2 == 0);
+    let (evens, odds): (Vec<_>, Vec<_>) = chunks.iter().enumerate().partition(|(i, _)| i % 2 == 0);
     let mut result: Vec<&RetrievedChunk> = evens.into_iter().map(|(_, c)| c).collect();
     result.extend(odds.into_iter().rev().map(|(_, c)| c));
     result

--- a/core/crates/kwaai-rag/src/query_understanding.rs
+++ b/core/crates/kwaai-rag/src/query_understanding.rs
@@ -21,11 +21,7 @@ use crate::retriever::{retrieve_hybrid, RetrieveConfig, RetrievedChunk};
 ///
 /// Returns the original query plus the generated variants (deduplicated).
 /// Falls back to `[query]` if the LLM call fails, so callers are always safe.
-pub async fn decompose_query(
-    query: &str,
-    n_variants: usize,
-    inference_url: &str,
-) -> Vec<String> {
+pub async fn decompose_query(query: &str, n_variants: usize, inference_url: &str) -> Vec<String> {
     match decompose_inner(query, n_variants, inference_url).await {
         Ok(mut qs) => {
             // Always include the original in case decomposition is lossy.
@@ -59,7 +55,10 @@ async fn decompose_inner(
          Question: {query}"
     );
 
-    let url = format!("{}/v1/chat/completions", inference_url.trim_end_matches('/'));
+    let url = format!(
+        "{}/v1/chat/completions",
+        inference_url.trim_end_matches('/')
+    );
     let body = json!({
         "model": "default",
         "messages": [{"role": "user", "content": prompt}],
@@ -130,12 +129,14 @@ where
     );
 
     // Retrieve for each sub-query, collect all chunks.
-    let mut best_by_id: std::collections::HashMap<i64, RetrievedChunk> = std::collections::HashMap::new();
+    let mut best_by_id: std::collections::HashMap<i64, RetrievedChunk> =
+        std::collections::HashMap::new();
 
     for sq in &sub_queries {
         let results = retrieve_hybrid(sq, cfg, embed, meta, search_fn.clone()).await?;
         for chunk in results {
-            let stable_key = stable_chunk_key(&chunk.chunk_meta.doc_name, chunk.chunk_meta.chunk_index);
+            let stable_key =
+                stable_chunk_key(&chunk.chunk_meta.doc_name, chunk.chunk_meta.chunk_index);
             best_by_id
                 .entry(stable_key)
                 .and_modify(|existing| {


### PR DESCRIPTION
## Summary

Pre-existing rustfmt debt on upstream/main. CI's Format job reports 34 diffs across these 5 files (the rag CLI surface and 3 files in kwaai-rag). Applying \`cargo fmt\` cleanly.

No semantic changes. Same shape as PR #41 from the previous round of fmt cleanup; this catches what's crept in since.

## Why now

Spotted because [PR #49](https://github.com/Kwaai-AI-Lab/KwaaiNet/pull/49) (and any other PR opened against the current upstream/main) fails the Format check on these unrelated files. Landing this lets future PRs pass CI without conflating fmt cleanup with their actual changes.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)