### PR TITLE
feat(node): --identity-key flag to load a pre-existing key file

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -151,7 +151,9 @@ futures = "0.3"
 async-trait = "0.1"
 
 # P2P networking
-libp2p = { version = "0.53", features = ["tokio", "kad", "identify", "noise", "tcp", "yamux", "macros", "request-response", "relay"] }
+# `rsa` feature lets Keypair::from_protobuf_encoding decode RSA keys (e.g. the
+# bootstrap_key{N}.bin files used by kwaaiai bootstrap servers).
+libp2p = { version = "0.53", features = ["tokio", "kad", "identify", "noise", "tcp", "yamux", "macros", "request-response", "relay", "rsa"] }
 
 # ML/Inference
 candle-core = "0.10"

--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -201,6 +201,12 @@ pub struct StartArgs {
     #[arg(long)]
     pub announce_addr: Option<String>,
 
+    /// Path to a libp2p-protobuf-encoded identity key file.
+    /// Overrides the default `~/.kwaainet/identity.key`. Used by bootstrap
+    /// deployments to keep their existing RSA peer IDs across restarts.
+    #[arg(long)]
+    pub identity_key: Option<std::path::PathBuf>,
+
     /// Disable automatic relay
     #[arg(long)]
     pub no_relay: bool,

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -75,6 +75,14 @@ pub struct KwaaiNetConfig {
     #[serde(default)]
     pub announce_addr: Option<String>,
 
+    /// Override path to the persistent identity key file. When set, this
+    /// libp2p-protobuf-encoded key is used instead of the default one at
+    /// `~/.kwaainet/identity.key` (which is auto-generated as Ed25519).
+    /// Used by bootstrap deployments to keep their existing RSA peer IDs.
+    /// CLI: `--identity-key <path>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_key: Option<std::path::PathBuf>,
+
     #[serde(default)]
     pub no_relay: bool,
 
@@ -515,6 +523,7 @@ impl Default for KwaaiNetConfig {
             )),
             public_ip: None,
             announce_addr: None,
+            identity_key: None,
             no_relay: false,
             initial_peers: default_peers(),
             health_monitoring: HealthConfig::default(),

--- a/core/crates/kwaai-cli/src/identity.rs
+++ b/core/crates/kwaai-cli/src/identity.rs
@@ -40,16 +40,29 @@ impl NodeIdentity {
     pub fn load_or_create() -> Result<Self> {
         let path = Self::key_file_path();
         if path.exists() {
-            let bytes = std::fs::read(&path)
-                .with_context(|| format!("reading identity key: {}", path.display()))?;
-            let keypair = Keypair::from_protobuf_encoding(&bytes)
-                .context("decoding identity key — file may be corrupted")?;
-            let peer_id = keypair.public().to_peer_id();
-            info!("Loaded persistent identity: {}", peer_id.to_base58());
-            Ok(Self { keypair, peer_id })
+            Self::load_from(&path)
         } else {
             Self::generate_and_save()
         }
+    }
+
+    /// Load an identity from an explicit libp2p-protobuf-encoded key file.
+    /// Unlike `load_or_create`, this does not fall back to generating a new
+    /// key — used for bootstrap deployments that mount a pre-existing key
+    /// (e.g. an RSA `bootstrap_keyN.bin`).
+    pub fn load_from(path: &Path) -> Result<Self> {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("reading identity key: {}", path.display()))?;
+        let keypair = Keypair::from_protobuf_encoding(&bytes).context(
+            "decoding identity key — file may be corrupted or use an unsupported key type",
+        )?;
+        let peer_id = keypair.public().to_peer_id();
+        info!(
+            "Loaded identity from {}: {}",
+            path.display(),
+            peer_id.to_base58()
+        );
+        Ok(Self { keypair, peer_id })
     }
 
     /// Generate a fresh Ed25519 keypair, save it, and return the identity

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -156,6 +156,9 @@ async fn main() -> Result<()> {
             if let Some(a) = args.announce_addr {
                 cfg.announce_addr = Some(a);
             }
+            if let Some(p) = args.identity_key {
+                cfg.identity_key = Some(p);
+            }
             if args.no_relay {
                 cfg.no_relay = true;
             }

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -274,10 +274,19 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     info!("KwaaiNet node starting (PID {})", std::process::id());
 
     // -----------------------------------------------------------------------
-    // Persistent identity — load or generate the Ed25519 keypair so the
-    // PeerId is stable across restarts. Credentials are bound to this DID.
+    // Persistent identity — load or generate the keypair so the PeerId is
+    // stable across restarts. Credentials are bound to this DID.
+    // `config.identity_key` (CLI: `--identity-key`) overrides the default
+    // path, which lets bootstrap deployments mount a pre-existing key
+    // (e.g. an RSA `bootstrap_keyN.bin`) without it living under
+    // `~/.kwaainet/`.
     // -----------------------------------------------------------------------
-    let node_identity = NodeIdentity::load_or_create().context("loading node identity")?;
+    let node_identity = if let Some(ref key_path) = config.identity_key {
+        NodeIdentity::load_from(key_path)
+            .with_context(|| format!("loading node identity from {}", key_path.display()))?
+    } else {
+        NodeIdentity::load_or_create().context("loading node identity")?
+    };
     let node_did = node_identity.did();
     info!("Node DID: {}", node_did);
 
@@ -359,7 +368,10 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             .map(|ip| format!("/ip4/{}/tcp/{}", ip, config.port))
     });
 
-    let identity_key_path = NodeIdentity::key_file_path();
+    let identity_key_path = config
+        .identity_key
+        .clone()
+        .unwrap_or_else(NodeIdentity::key_file_path);
 
     let builder = P2PDaemon::builder()
         .dht(true)
@@ -1581,7 +1593,10 @@ async fn restart_p2pd(
     let _ = daemon.shutdown().await;
 
     let host_addr = format!("/ip4/0.0.0.0/tcp/{}", config.port);
-    let identity_key_path = crate::identity::NodeIdentity::key_file_path();
+    let identity_key_path = config
+        .identity_key
+        .clone()
+        .unwrap_or_else(crate::identity::NodeIdentity::key_file_path);
 
     let builder = P2PDaemon::builder()
         .dht(true)


### PR DESCRIPTION
## Summary

- Adds `--identity-key <PATH>` CLI flag (and matching `identity_key:` config field) on `kwaainet start`. When set, the node loads the libp2p-protobuf-encoded private key from that path instead of the auto-generated Ed25519 at `~/.kwaainet/identity.key`.
- Adds the `rsa` libp2p feature so `Keypair::from_protobuf_encoding` accepts RSA-typed keys; without it the Rust loader rejects them even though p2pd accepts them via `crypto.UnmarshalPrivateKey`.
- The path is forwarded to p2pd's `-id` flag (key-type-agnostic) and to the Rust-side `NodeIdentity` loader so the PeerId/DID match. Both the initial daemon spawn and the watchdog `restart_p2pd` honour the override.

## Why

Any deployment that wants a stable PeerId derived from a mounted secret needs this: bootstrap servers (so existing peer IDs baked into clients keep working), test rigs that pre-provision identities, anything driven by a secrets manager. The new flag is type-agnostic — it works with the existing `bootstrap_keyN.bin` RSA files in this repo and any Ed25519 key generated elsewhere.

The motivating use case is running `kwaainet start` as a docker-compose bootstrap service alongside the existing Petals bootstraps, mounting `config/bootstrap_keyN.bin` and forwarding via the new flag. Verified end-to-end: kwaainet bootstraps come up healthy, get the same `Qm…` peer IDs as the matching `BOOTSTRAP_PEER_IDN` in `.env`, and NATed test nodes successfully obtain relay reservations through them.

## Test plan

- [x] `cargo check --package kwaainet --bin kwaainet` clean
- [x] `cargo fmt --check` on changed files clean (pre-existing drift in `rag_api.rs` / `rag_cmd.rs` left alone)
- [x] Loaded an existing `bootstrap_key3.bin` (RSA) via `--identity-key /app/identity.bin`; logged identity matches the expected `Qm…` peer ID
- [x] Verified the watchdog restart path picks up the override (manually killed p2pd; respawn used the same key path → same peer ID)
- [x] Default behaviour unchanged when the flag/field is absent (still auto-generates Ed25519 at `~/.kwaainet/identity.key`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)