### PR TITLE
chore: local lint setup (Makefile targets, pre-push hook, VS Code)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+cd "$(git rev-parse --show-toplevel)/core"
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,9 @@ yarn-error.log*
 /build/
 
 # IDE
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 .idea/
 *.swp
 *.swo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "rust-lang.rust-analyzer"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.extraArgs": ["--all-targets", "--", "-D", "warnings"],
+  "rust-analyzer.linkedProjects": ["core/Cargo.toml"],
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer",
+    "editor.formatOnSave": true
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# KwaaiNet Nix build targets
+# KwaaiNet build targets
 #
 # Each target writes its output to a dedicated result-<name> symlink,
 # so builds don't overwrite each other.
@@ -13,7 +13,8 @@
         containers kwaainet-container map-server-container kwaainet-all-container \
         cross cross-aarch64-gnu cross-aarch64-musl cross-x86_64-musl cross-riscv64-gnu \
         cross-containers cross-containers-aarch64-gnu cross-containers-aarch64-musl cross-containers-x86_64-musl cross-containers-riscv64-gnu \
-        check test test-containers test-cross fmt develop clean
+        check test test-containers test-cross fmt develop clean \
+        ci-check ci-fmt ci-lint ci-test githooks
 
 all: kwaainet map-server
 
@@ -108,6 +109,33 @@ test-cross:
 	nix build .#test-cross-smoke-aarch64-linux-musl -o result-test-cross-aarch64-musl
 	nix build .#test-cross-smoke-x86_64-linux-musl -o result-test-cross-x86_64-musl
 	nix build .#test-cross-smoke-riscv64-linux-gnu -o result-test-cross-riscv64-gnu
+
+# --- Native cargo checks (mirror CI; work without Nix) ---
+#
+# `make check` above runs the Nix-based gate (smoke test + clippy + tests).
+# These targets are the cargo-direct equivalent — faster, no Nix required,
+# matching the exact flags CI uses in .github/workflows/ci.yml.
+
+ci-check: ci-fmt ci-lint ci-test
+
+ci-fmt:
+	cd core && cargo fmt --all -- --check
+
+ci-lint:
+	cd core && cargo clippy --all-targets -- -D warnings
+
+ci-test:
+	cd core && cargo test --all
+
+# --- Git hooks ---
+#
+# Run `make githooks` once per clone to enable the tracked hooks under
+# .githooks/. Sets core.hooksPath, so any later updates to the hook
+# scripts ship with the repo — no need to re-run install.
+
+githooks:
+	git config core.hooksPath .githooks
+	@echo "Enabled tracked git hooks → .githooks/"
 
 # --- Utilities ---
 


### PR DESCRIPTION
## Summary

Adds a Nix-free path for running the same checks CI runs, plus an opt-in git hook and editor settings so most clippy/fmt errors get caught before they reach a PR.

- **Makefile** — `ci-check` umbrella target running `ci-fmt` + `ci-lint` + `ci-test`, each invoking the exact cargo commands from [.github/workflows/ci.yml](.github/workflows/ci.yml). Sub-targets are individually runnable so `make ci-fmt ci-lint` is a fast pre-push manual check that skips the slow test suite. Named `ci-lint` rather than `ci-clippy` to stay language-agnostic (the recipe still runs cargo clippy). `make githooks` sets `core.hooksPath` to enable the tracked hook below.
- **`.githooks/pre-push`** — runs `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` on each push. Tracked in the repo (so future hook changes ship with the repo, no per-clone install) and activated via `make githooks` once per clone. Calls cargo directly rather than going through `make` so the script is self-explanatory when someone opens it to debug a blocked push. Tests deliberately skipped — too slow for a hook gate; `make ci-check` is the full-parity command for those who want it.
- **`.vscode/settings.json`** — tells rust-analyzer to use clippy (with CI's exact `-D warnings` flag) for its on-save check. Format-on-save scoped to `[rust]` only — fmt changes are whitespace-only and benign, but other file types keep their existing behaviour.
- **`.vscode/extensions.json`** — recommends `rust-lang.rust-analyzer` so a fresh-clone VS Code prompts for install.
- **`.gitignore`** — narrows `.vscode/` to `.vscode/*` with `!`-exceptions for the two tracked files, so other `.vscode/` content (per-user launch configs, history, etc.) stays ignored.

The existing `make check` (`nix flake check`) still works for Nix users and covers strictly more (it also runs the cross-platform smoke test); this PR just adds a parallel cargo-direct path for everyone else.

## Test plan

- [x] `make ci-fmt` invokes the right command (verified — fails on the unrelated pre-existing rag fmt drift, which is a separate issue and presumed in flight under PR #50)
- [x] `make ci-lint` runs `cargo clippy --all-targets -- -D warnings`
- [x] `make ci-test` runs `cargo test --all`
- [x] `make githooks` sets `core.hooksPath` (run once per clone)
- [x] `.githooks/pre-push` is executable, valid POSIX shell, and runs cargo fmt+clippy directly
- [x] `.vscode/settings.json` and `.vscode/extensions.json` are valid JSON; `git check-ignore` confirms they're tracked while other `.vscode/` files stay ignored
- [ ] Reviewer to confirm they're happy with the `ci-lint` naming (alternative: `ci-clippy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)