### PR TITLE
chore(cargo): default to kwaai-cli for bare cargo commands

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/kwaai-storage",
     "crates/kwaai-rag",
 ]
+default-members = ["crates/kwaai-cli"]
 
 # Root package for examples
 [package]


### PR DESCRIPTION
## Summary
- Add `default-members = [\"crates/kwaai-cli\"]` to `core/Cargo.toml`.
- Bare `cargo build` / `cargo run` / `cargo test` now target the CLI binary instead of attempting the full workspace, avoiding accidental builds of heavy crates (e.g. inference) for ad-hoc runs.

## Test plan
- [ ] `cd core && cargo build` builds only the CLI by default
- [ ] `cd core && cargo build --workspace` still builds everything
- [ ] `cd core && cargo test -p kwaai-p2p` still scopes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)