### PR TITLE
fix(shard): prefer self as tiebreaker in chain forwarding

### DIFF
--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -2203,18 +2203,34 @@ pub async fn forward_through_chain(
         // All nodes whose range covers `pos`.
         // Primary sort: widest coverage first (largest end_block).
         // Secondary sort: highest local trust score first.
+        // Tertiary sort: prefer self when we can dispatch locally — avoids
+        // routing through libp2p when our own shard serve already has the
+        // block range loaded, which is the cheapest possible hop. Gated on
+        // `local_port.is_some()` so we don't pick self and then fail the
+        // dispatch with "shard serve is not running on this machine".
         // Skip peers that already failed with protocol errors in this session.
         let mut candidates: Vec<&BlockServerEntry> = chain
             .iter()
             .filter(|e| e.start_block <= pos && e.end_block > pos)
             .filter(|e| !failed_peers.contains(&e.peer_id))
             .collect();
+        let self_dispatchable = local_port.is_some();
         candidates.sort_by(|a, b| {
-            b.end_block.cmp(&a.end_block).then_with(|| {
-                b.trust_score
-                    .partial_cmp(&a.trust_score)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
+            b.end_block
+                .cmp(&a.end_block)
+                .then_with(|| {
+                    b.trust_score
+                        .partial_cmp(&a.trust_score)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+                .then_with(|| {
+                    if !self_dispatchable {
+                        return std::cmp::Ordering::Equal;
+                    }
+                    let a_self = our_peer_id == Some(&a.peer_id);
+                    let b_self = our_peer_id == Some(&b.peer_id);
+                    b_self.cmp(&a_self)
+                })
         });
 
         if candidates.is_empty() {


### PR DESCRIPTION
## Summary

- In `forward_through_chain`, when two candidates tie on coverage *and* trust score, prefer the local node. Avoids a libp2p round-trip when our own `shard serve` already has the block range loaded.
- Gated on `local_port.is_some()` so we don't pick self and then fail the hop with "shard serve is not running on this machine".

## Why

Hit this in a sharded run: another peer had all blocks, we had all blocks, same trust, and the remote peer won. The remote dispatch was the slowest hop in the chain. Today the sort key is `(coverage DESC, trust DESC)`; ties between a remote peer and self are decided by `BlockServerEntry` iteration order, which is non-deterministic.

## Out of scope

Self sometimes isn't in the DHT-derived chain at all (a publishing-side problem upstream of `forward_through_chain`). When that happens this tiebreaker is a no-op — self isn't a candidate. Worth tracking separately.

## Test plan

- [ ] Two nodes, each running `shard serve` covering the full block range; run `shard run` from one and confirm hop log shows self instead of the remote peer
- [ ] Node *not* running `shard serve` (no port file): confirm sort behavior is unchanged — tiebreaker is a no-op via `self_dispatchable` gate
- [ ] Only remote peers cover the range: confirm selection still picks widest coverage / highest trust as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)