### PR TITLE
fix(updater): move self-delete after respawn in Windows update batch

### DIFF
--- a/core/crates/kwaai-cli/src/updater.rs
+++ b/core/crates/kwaai-cli/src/updater.rs
@@ -303,8 +303,8 @@ impl UpdateChecker {
                     "{kill_header}\
                      powershell -ExecutionPolicy Bypass -File \"{ps1_str}\" >> \"{log_path}\" 2>&1\r\n\
                      del /f \"{ps1_str}\"\r\n\
-                     del /f \"%~f0\"\r\n\
-                     {respawn}"
+                     {respawn}\
+                     del /f \"%~f0\"\r\n"
                 )
             } else {
                 // Full path: use the cargo-dist PS1 installer (handles first-time
@@ -318,8 +318,8 @@ impl UpdateChecker {
                     "{kill_header}\
                      powershell -ExecutionPolicy Bypass -File \"{ps_path}\" >> \"{log_path}\" 2>&1\r\n\
                      del /f \"{ps_path}\"\r\n\
-                     del /f \"%~f0\"\r\n\
-                     {respawn}"
+                     {respawn}\
+                     del /f \"%~f0\"\r\n"
                 )
             };
 


### PR DESCRIPTION
## Summary

- The Windows update batch script ran `del /f "%~f0"` (self-deletion) **before** the restart block (`ping` + `start "" kwaainet.exe start --daemon`)
- cmd.exe doesn't guarantee that commands following a self-deleted batch file will execute — the daemon was silently never restarted after `kwaainet update`
- Fix: move `del /f "%~f0"` to the very last line in both the CUDA fast-path and full-installer batch scripts

## Root cause

Generated batch order was:
```
install/swap
del installer.ps1
del %~f0          ← self-delete here
ping delay
start kwaainet    ← this never ran
```
After the fix:
```
install/swap
del installer.ps1
ping delay
start kwaainet    ← always runs now
del %~f0          ← self-delete last
```

## Test plan

- [ ] Run `kwaainet update` on a Windows machine with an older version
- [ ] Confirm daemon is running automatically after the update completes (check `kwaainet status`)
- [ ] Inspect `%TEMP%\kwaainet-update.log` to confirm installer and restart both completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)