### PR TITLE
fix(ci): install gh CLI in manylinux container for CUDA artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,6 +342,10 @@ jobs:
           dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
           dnf install -y -q cuda-toolkit-12-6 openssl-devel perl-IPC-Cmd
           echo "/usr/local/cuda-12.6/bin" >> $GITHUB_PATH
+          # gh CLI — needed by the "Upload CUDA artifact to GitHub Release" step
+          # (manylinux container doesn't include gh; install from the official RPM repo)
+          curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo
+          dnf install -y -q gh
           # sccache for faster incremental Rust compilation
           SCCACHE_VERSION="v0.8.1"
           curl -sSfL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \


### PR DESCRIPTION
## Problem

Every Linux release since the 3-tier CI pipeline shipped has been missing the CUDA binary (`kwaainet-x86_64-unknown-linux-gnu-cuda.tar.xz`). The binary was built successfully but never uploaded.

**Root cause:** The `build-cuda-artifacts` job runs inside the `quay.io/pypa/manylinux_2_28_x86_64` container. The \"Upload CUDA artifact to GitHub Release\" step calls `gh release upload`, but `gh` is not installed in that container. The step polls for 30 minutes waiting for the release to exist, reaches attempt 60/60, then fails with:

```
gh: command not found
exit code 127
```

**Impact:** The patched installer (`kwaainet-installer.sh`) correctly detects NVIDIA GPUs via `nvidia-smi` and tries to fetch the CUDA archive — but since the archive was never uploaded, it falls back to the CPU-only binary. Every `kwaainet` install or `kwaainet update` on a Linux GPU machine has been running inference on CPU.

## Fix

Add two lines to the existing `Install build deps (manylinux container)` step to install `gh` from the official GitHub CLI RPM repo before the build runs:

```bash
curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo
dnf install -y -q gh
```

## Testing

Verified locally inside the exact container image:

```
$ docker run --rm quay.io/pypa/manylinux_2_28_x86_64 bash -c     "curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos.d/gh-cli.repo &&      dnf install -y -q gh && gh --version"
gh version 2.92.0 (2026-04-28)
```

Also verified `gh release view` works from inside the container with `GH_TOKEN` set (the poll loop will exit on the first attempt instead of timing out).

## Test plan

- [ ] Trigger a release and confirm `kwaainet-x86_64-unknown-linux-gnu-cuda.tar.xz` appears as a release asset
- [ ] Run `kwaainet-installer.sh` on a machine with `nvidia-smi` and confirm it selects the CUDA archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)