### PR TITLE
fix(ci): add MSVC dev env before Windows CUDA build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,6 +439,9 @@ jobs:
           if ($dir) {
             echo "OPENSSL_DIR=$dir" >> $env:GITHUB_ENV
           }
+      - name: Set up MSVC developer environment (nvcc needs cl.exe in PATH)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
       - name: Build kwaainet with CUDA (Windows)
         if: runner.os == 'Windows'
         working-directory: core


### PR DESCRIPTION
## Summary

- The v0.4.80 Windows CUDA build failed with `nvcc fatal: Cannot find compiler 'cl.exe' in PATH`
- nvcc requires the MSVC host compiler to compile `.cu` files on Windows; the GitHub Actions `windows-2022` runner has MSVC installed but does not add it to PATH by default
- Fix: add `ilammy/msvc-dev-cmd@v1` before the cargo build step — this runs `vcvars64.bat` and exports the full MSVC toolchain environment including `cl.exe`

## Local proof

Reproduced the exact failure and fix locally:

```
=== WITHOUT vcvars ===
nvcc fatal   : Cannot find compiler 'cl.exe' in PATH
Exit code: 1

=== AFTER vcvars64.bat (what ilammy/msvc-dev-cmd does) ===
nvcc: using host compiler …\MSVC\14.44.35207\bin\Hostx64\x64\cl.exe
Exit code: 0
```

`cl.exe` confirmed at `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64\cl.exe` — present on the machine, just not on PATH until vcvars runs.

## Change

3 lines added to `build-cuda-artifacts` in `release.yml`, immediately before the `cargo build --features cuda-windows` step:

```yaml
- name: Set up MSVC developer environment (nvcc needs cl.exe in PATH)
  if: runner.os == 'Windows'
  uses: ilammy/msvc-dev-cmd@v1
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)