### PR TITLE
fix(updater): fast Windows CUDA updates — lean/full zip split

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,7 +461,19 @@ jobs:
           Copy-Item "target\release\kwaainet.exe" "$label\"
           $p2pd = Get-ChildItem "target\release\p2pd.exe" -ErrorAction SilentlyContinue
           if ($p2pd) { Copy-Item $p2pd.FullName "$label\"; Write-Host "Included p2pd.exe" }
-          # Bundle CUDA 12.6 runtime DLLs so end users don't need the toolkit
+
+          # Lean zip — binary only, used for fast incremental updates when CUDA
+          # runtime DLLs are already present on the machine (~30 MB).
+          Compress-Archive -Path "$label\*" -DestinationPath "$label.zip" -Force
+          $hash = (Get-FileHash "$label.zip" -Algorithm SHA256).Hash.ToLower()
+          "$hash  $label.zip" | Set-Content "$label.zip.sha256"
+          Write-Host "Lean CUDA archive: $((Get-Item ""$label.zip"").Length) bytes"
+
+          # Full zip — binary + CUDA 12.6 runtime DLLs, used on first install when
+          # the runtime is not already present (~978 MB, one-time download).
+          $labelFull = "$label-full"
+          New-Item -ItemType Directory -Path $labelFull -Force | Out-Null
+          Copy-Item "$label\*" "$labelFull\"
           $cudaBin = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin"
           if (Test-Path $cudaBin) {
             $dlls = @(
@@ -470,19 +482,17 @@ jobs:
             )
             foreach ($dll in $dlls) {
               $src = Join-Path $cudaBin $dll
-              if (Test-Path $src) { Copy-Item $src "$label\"; Write-Host "  Bundled: $dll" }
+              if (Test-Path $src) { Copy-Item $src "$labelFull\"; Write-Host "  Bundled: $dll" }
             }
-            Get-ChildItem $cudaBin "nvrtc*.dll"          -ErrorAction SilentlyContinue | ForEach-Object { Copy-Item $_.FullName "$label\"; Write-Host "  Bundled: $($_.Name)" }
-            Get-ChildItem $cudaBin "nvrtc-builtins*.dll" -ErrorAction SilentlyContinue | ForEach-Object { Copy-Item $_.FullName "$label\"; Write-Host "  Bundled: $($_.Name)" }
+            Get-ChildItem $cudaBin "nvrtc*.dll"          -ErrorAction SilentlyContinue | ForEach-Object { Copy-Item $_.FullName "$labelFull\"; Write-Host "  Bundled: $($_.Name)" }
+            Get-ChildItem $cudaBin "nvrtc-builtins*.dll" -ErrorAction SilentlyContinue | ForEach-Object { Copy-Item $_.FullName "$labelFull\"; Write-Host "  Bundled: $($_.Name)" }
           } else {
-            Write-Warning "CUDA bin dir not found: $cudaBin"
+            Write-Warning "CUDA bin dir not found: $cudaBin — full zip will not contain DLLs"
           }
-          $dllCount = (Get-ChildItem "$label\*.dll" -ErrorAction SilentlyContinue).Count
-          Write-Host "CUDA DLLs bundled: $dllCount"
-          Compress-Archive -Path "$label\*" -DestinationPath "$label.zip" -Force
-          $hash = (Get-FileHash "$label.zip" -Algorithm SHA256).Hash.ToLower()
-          "$hash  $label.zip" | Set-Content "$label.zip.sha256"
-          Write-Host "CUDA archive: $((Get-Item ""$label.zip"").Length) bytes"
+          Compress-Archive -Path "$labelFull\*" -DestinationPath "$labelFull.zip" -Force
+          $hashFull = (Get-FileHash "$labelFull.zip" -Algorithm SHA256).Hash.ToLower()
+          "$hashFull  $labelFull.zip" | Set-Content "$labelFull.zip.sha256"
+          Write-Host "Full CUDA archive: $((Get-Item ""$labelFull.zip"").Length) bytes"
       - name: Build kwaainet with CUDA (Linux)
         if: runner.os == 'Linux'
         working-directory: core
@@ -520,6 +530,8 @@ jobs:
           path: |
             core/${{ matrix.label }}.${{ matrix.ext }}
             core/${{ matrix.label }}.${{ matrix.ext }}.sha256
+            core/${{ matrix.label }}-full.${{ matrix.ext }}
+            core/${{ matrix.label }}-full.${{ matrix.ext }}.sha256
           retention-days: 3
 
   # Upload the pre-built CUDA archive to the GitHub Release once it exists.
@@ -551,9 +563,13 @@ jobs:
       - name: Upload to GitHub Release
         run: |
           TAG="${{ needs.plan.outputs.tag }}"
+          # Upload lean zip (binary only) + full zip (binary + DLLs) for Windows.
+          # Linux only has the one archive so the glob safely finds nothing extra.
           gh release upload "$TAG" \
             cuda-dist/${{ matrix.label }}.${{ matrix.ext }} \
             cuda-dist/${{ matrix.label }}.${{ matrix.ext }}.sha256 \
+            $(ls cuda-dist/${{ matrix.label }}-full.${{ matrix.ext }} 2>/dev/null || true) \
+            $(ls cuda-dist/${{ matrix.label }}-full.${{ matrix.ext }}.sha256 2>/dev/null || true) \
             --repo "${{ github.repository }}" \
             --clobber
 

--- a/core/crates/kwaai-cli/src/updater.rs
+++ b/core/crates/kwaai-cli/src/updater.rs
@@ -180,9 +180,18 @@ impl UpdateChecker {
                 "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v{version}/kwaainet-x86_64-pc-windows-msvc.zip"
             );
             let archive_url = if nvidia_smi_windows().await {
-                let cuda_url = format!(
-                    "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v{version}/kwaainet-x86_64-pc-windows-msvc-cuda.zip"
-                );
+                // DLLs already present → use the lean binary-only zip (~30 MB, fast).
+                // DLLs missing       → use the full zip with bundled CUDA runtime (~978 MB, one-time).
+                let dlls_present = install_dir.join("cublas64_12.dll").exists();
+                let cuda_url = if dlls_present {
+                    format!(
+                        "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v{version}/kwaainet-x86_64-pc-windows-msvc-cuda.zip"
+                    )
+                } else {
+                    format!(
+                        "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v{version}/kwaainet-x86_64-pc-windows-msvc-cuda-full.zip"
+                    )
+                };
                 let client = reqwest::Client::builder()
                     .user_agent(format!("kwaainet/{}", CURRENT_VERSION))
                     .timeout(std::time::Duration::from_secs(10))
@@ -210,10 +219,15 @@ impl UpdateChecker {
                 cpu_url
             };
 
-            let is_cuda = archive_url.contains("-cuda.zip");
+            let is_cuda = archive_url.contains("-cuda");
             let zip_path = canonical_temp.join("kwaainet-update.zip");
             if is_cuda {
-                print!("  NVIDIA GPU detected — downloading CUDA build for v{version}…");
+                let dlls_present = install_dir.join("cublas64_12.dll").exists();
+                if dlls_present {
+                    print!("  NVIDIA GPU detected — downloading CUDA update for v{version} (binary only)…");
+                } else {
+                    print!("  NVIDIA GPU detected — downloading CUDA build for v{version} (first install, includes runtime DLLs)…");
+                }
             } else {
                 print!("  Downloading v{version} for Windows…");
             }
@@ -228,14 +242,10 @@ impl UpdateChecker {
             let exe_str = kwaainet_exe.to_string_lossy().replace('\'', "''");
             let log_str = log_path.replace('\'', "''");
 
-            // CUDA zips include bundled DLLs alongside the executables; include
-            // *.dll in the file glob so they land in the install directory too.
-            // p2pd.exe is already matched by *.exe so no separate entry needed.
-            let file_include = if is_cuda {
-                "'*.exe','*.dll'"
-            } else {
-                "'*.exe'"
-            };
+            // Include *.dll so the full CUDA zip's bundled runtime DLLs land in
+            // the install dir.  Safe for lean zips and CPU zips — no DLLs found,
+            // nothing extra installed.
+            let file_include = if is_cuda { "'*.exe','*.dll'" } else { "'*.exe'" };
 
             // Single PS1 script handles the full update: waits for kwaainet to
             // exit, kills kwaainet.exe AND p2pd.exe (both may hold file locks),
@@ -572,20 +582,16 @@ mod tests {
         println!("nvidia_smi_windows() = {has_gpu}");
     }
 
-    /// Verify that the CUDA archive URL contains the -cuda.zip suffix so that
-    /// is_cuda detection and file_include selection work correctly.
+    /// Verify that the CUDA archive URLs contain "-cuda" so is_cuda detection
+    /// and file_include selection work correctly for both lean and full zips.
     #[test]
     fn cuda_url_suffix_detection() {
-        let cuda_url = "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v0.4.79/kwaainet-x86_64-pc-windows-msvc-cuda.zip";
-        let cpu_url  = "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v0.4.79/kwaainet-x86_64-pc-windows-msvc.zip";
-        assert!(
-            cuda_url.contains("-cuda.zip"),
-            "CUDA URL must contain -cuda.zip"
-        );
-        assert!(
-            !cpu_url.contains("-cuda.zip"),
-            "CPU URL must not contain -cuda.zip"
-        );
+        let cuda_lean = "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v0.4.79/kwaainet-x86_64-pc-windows-msvc-cuda.zip";
+        let cuda_full = "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v0.4.79/kwaainet-x86_64-pc-windows-msvc-cuda-full.zip";
+        let cpu_url   = "https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/download/v0.4.79/kwaainet-x86_64-pc-windows-msvc.zip";
+        assert!(cuda_lean.contains("-cuda"), "Lean CUDA URL must contain -cuda");
+        assert!(cuda_full.contains("-cuda"), "Full CUDA URL must contain -cuda");
+        assert!(!cpu_url.contains("-cuda"),  "CPU URL must not contain -cuda");
     }
 
     /// Verify the file_include string for CUDA zips contains '*.dll' so bundled


### PR DESCRIPTION
## Summary

- Updates on NVIDIA GPU machines were downloading ~978 MB on every `kwaainet update` because CUDA runtime DLLs were bundled in the release zip
- DLLs (cublas, cufft, cusparse, etc.) don't change between minor kwaainet releases — no reason to re-download them every time
- Fix: CI now publishes **two** Windows CUDA zips per release:
  - `kwaainet-x86_64-pc-windows-msvc-cuda.zip` (~30 MB, binary only) — fast incremental updates
  - `kwaainet-x86_64-pc-windows-msvc-cuda-full.zip` (~978 MB, binary + DLLs) — one-time first install
- Updater checks if `cublas64_12.dll` is already in the install dir and picks the right zip automatically

## Result

| Scenario | Before | After |
|---|---|---|
| First CUDA install | ~978 MB | ~978 MB (one-time) |
| Every subsequent update | ~978 MB (~10 min) | ~30 MB (seconds) |

## Test plan

- [ ] Verify CI publishes both `...-cuda.zip` and `...-cuda-full.zip` for Windows in next release
- [ ] On machine with DLLs already present: `kwaainet update` downloads lean zip and logs only `.exe` installs
- [ ] On fresh machine without DLLs: `kwaainet update` downloads full zip and logs DLLs + exes

🤖 Generated with [Claude Code](https://claude.com/claude-code)