### PR TITLE
fix(updater): retry Move-Item after Stop-Process on Windows update

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-compression"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "bincode",
  "candle-core",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-core"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-distributed"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-hivemind-dht"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-inference"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-network-tests"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-p2p"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-rag"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-rpc"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-trust"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-wasm"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "kwaainet"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "map-server"
-version = "0.4.90"
+version = "0.4.92"
 dependencies = [
  "anyhow",
  "axum",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ default-members = ["crates/kwaai-cli"]
 # Root package for examples
 [package]
 name = "kwaai-core"
-version = "0.4.91"
+version = "0.4.92"
 edition = "2021"
 publish = false
 
@@ -127,7 +127,7 @@ name = "query_dht_state"
 path = "examples/query_dht_state.rs"
 
 [workspace.package]
-version = "0.4.91"
+version = "0.4.92"
 
 edition = "2021"
 authors = ["Kwaai AI Lab <dev@kwaai.ai>"]

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -974,6 +974,11 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                             discovered_addrs = new_addrs.clone();
                             server_info.using_relay = all_addrs_are_relay(&discovered_addrs);
                             pending_restart = None;
+                            // p2pd's routing table is empty immediately after restart;
+                            // delay re-announcement so bootstrap peers can populate it first.
+                            next_announce
+                                .as_mut()
+                                .reset(tokio::time::Instant::now() + Duration::from_secs(30));
                         }
                     }
                 }

--- a/core/crates/kwaai-cli/src/updater.rs
+++ b/core/crates/kwaai-cli/src/updater.rs
@@ -260,7 +260,7 @@ impl UpdateChecker {
             let ps1_content = format!(
                 "Start-Sleep -Seconds 3\r\n\
                  Get-Process kwaainet,p2pd -ErrorAction SilentlyContinue | Stop-Process -Force\r\n\
-                 Start-Sleep -Seconds 2\r\n\
+                 Start-Sleep -Seconds 5\r\n\
                  $ErrorActionPreference = 'Stop'\r\n\
                  $zip  = '{zip_str}'\r\n\
                  $dest = '{dir_str}'\r\n\
@@ -269,7 +269,16 @@ impl UpdateChecker {
                  Expand-Archive -LiteralPath $zip -DestinationPath $tmp -Force\r\n\
                  Get-ChildItem -Path $tmp -Recurse -Include {file_include} | ForEach-Object {{\r\n\
                    $target = Join-Path $dest $_.Name\r\n\
-                   Move-Item -Path $_.FullName -Destination $target -Force\r\n\
+                   $retries = 0\r\n\
+                   while ($retries -lt 5) {{\r\n\
+                     try {{\r\n\
+                       Move-Item -Path $_.FullName -Destination $target -Force -ErrorAction Stop\r\n\
+                       break\r\n\
+                     }} catch {{\r\n\
+                       $retries++\r\n\
+                       Start-Sleep -Seconds 2\r\n\
+                     }}\r\n\
+                   }}\r\n\
                    Add-Content -Path '{log_str}' -Value ('Installed ' + $_.Name)\r\n\
                  }}\r\n\
                  Remove-Item $zip -Force -ErrorAction SilentlyContinue\r\n\


### PR DESCRIPTION
﻿## Summary

- `kwaainet update` silently failed to install the new binary when the daemon was running at update time
- Root cause: Windows holds a memory-mapped handle on a running EXE; `Stop-Process -Force` terminates the process but the OS may not release the file handle within the old 2-second sleep window
- `Move-Item -Force` on a still-locked `kwaainet.exe` throws "Access is denied" — with `$ErrorActionPreference = 'Stop'` this silently aborts the PS1 before any log entry is written, leaving the old binary in place

## Fix

Two changes to the generated PS1 installer script:
1. Post-kill sleep: 2 s → 5 s (gives OS more time to release the handle)
2. `Move-Item` now retries up to 5× with 2 s gaps before giving up

## How this was diagnosed

- Log file timestamp was 2 days old — the PS1 never wrote any entries for the current update
- Zip and extracted tmp dir were still present (PS1 aborted before cleanup)  
- Manual `Move-Item` succeeded immediately once no process held the file
- Daemon **was** running when `kwaainet update` fired, confirming the lock timing race

## Test plan

- [ ] Start daemon, run `kwaainet update`, confirm new binary is installed and `kwaainet --version` reflects the new version
- [ ] Verify log shows `Installed kwaainet.exe` with a fresh timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Additional fix (f722f9d)

- **Map drop after p2pd restart**: DHT re-announcement now delayed 30s after p2pd restart — routing table was empty causing all STORE RPCs to fail immediately, dropping the node from the map until the next 5-minute cycle.
- Bumped to **v0.4.92**
