### PR TITLE
fix(updater): gate second install_update call to non-Windows only

### DIFF
--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -946,13 +946,10 @@ async fn main() -> Result<()> {
                             println!("  {label}");
                         };
 
+                        #[cfg(not(windows))]
                         match checker.install_update(&info.version).await {
                             Ok(()) => {
                                 println!();
-                                #[cfg(windows)]
-                                print_success(&format!(
-                                    "Installer launched in background — daemon will restart automatically."
-                                ));
                                 #[cfg(not(windows))]
                                 if daemon_was_running {
                                     restart_daemon(&format!(


### PR DESCRIPTION
fix(updater): gate second install_update call to non-Windows only

The Windows install block already calls install_update() and handles
success/failure. The trailing match was ungated, so on Windows it ran
a second time -- the new binary was in place, the old .exe.bak was gone,
and the rename step failed with "another process holding it."

Fix: add #[cfg(not(windows))] before the second match and remove the
now-dead #[cfg(windows)] success message inside it.

Verified locally: kwaainet update runs exactly once, installs cleanly,
prints success, and exits without a second download or error.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
