### PR TITLE
fix(node): delay DHT re-announce 30s after watchdog p2pd restart

### DIFF
--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -953,8 +953,23 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                         &mut daemon, &mut client, &p2pd_path, &config,
                         &bootstrap_peers, &announce_addr, handler_addr,
                     ).await {
-                        Ok(()) => info!("✅ p2pd restarted and handlers re-registered"),
-                        Err(e) => warn!("p2pd restart failed: {} — will retry in 120s", e),
+                        Ok(()) => {
+                            info!("✅ p2pd restarted and handlers re-registered");
+                            // Routing table is empty right after restart; announcing now
+                            // fails with "no peer in table". Delay 30 s so bootstrap
+                            // peers can populate the routing table first.
+                            next_announce
+                                .as_mut()
+                                .reset(tokio::time::Instant::now() + Duration::from_secs(30));
+                            continue;
+                        }
+                        Err(e) => {
+                            warn!("p2pd restart failed: {} — will retry in 120s", e);
+                            next_announce
+                                .as_mut()
+                                .reset(tokio::time::Instant::now() + Duration::from_secs(120));
+                            continue;
+                        }
                     }
                 }
 


### PR DESCRIPTION
fix(node): delay DHT re-announce 30s after watchdog p2pd restart

When next_announce fires and the watchdog finds p2pd dead, it restarts
the daemon and then immediately falls through to the DHT announcement in
the same timer tick -- ~1 second after restart. The routing table is
still empty at that point, so every STORE RPC fails with "failed to find
any peer in table" and the node does not appear on the map.

The fix: after a successful watchdog restart, reset next_announce to
T+30s and continue, skipping the announcement. After a failed restart,
reset to T+120s and continue (matching the "will retry in 120s" message).

The same 30s delay already existed for the pending_restart (deferred
address-change) path at line 987. This brings the watchdog path in line
with that behavior.

Confirmed on metro-win: log showed p2pd restarted at 17:06:03, announce
fired at 17:06:04, all STORE RPCs failed, node absent from map.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
