### PR TITLE
chore: bump version to v0.4.105

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-compression"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "bincode",
  "candle-core",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-core"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-distributed"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-hivemind-dht"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-inference"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-network-tests"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-p2p"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-rpc"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-trust"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-wasm"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "kwaainet"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "map-server"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "anyhow",
  "axum",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ default-members = ["crates/kwaai-cli"]
 # Root package for examples
 [package]
 name = "kwaai-core"
-version = "0.4.104"
+version = "0.4.105"
 edition = "2021"
 publish = false
 
@@ -127,7 +127,7 @@ name = "query_dht_state"
 path = "examples/query_dht_state.rs"
 
 [workspace.package]
-version = "0.4.104"
+version = "0.4.105"
 
 edition = "2021"
 authors = ["Kwaai AI Lab <dev@kwaai.ai>"]


### PR DESCRIPTION
Releases the Windows updater double-call fix (#71) and the p2pd watchdog premature-announce fix (#72) that missed the v0.4.104 tag.

## Changes included
- **fix(updater) #71**: Windows kwaainet update was calling install_update() twice — first call succeeded and restarted the daemon, second call failed with a misleading rename error. Node was correctly updated but users saw a false failure.
- **fix(node) #72**: After a watchdog p2pd restart, DHT re-announcement fired ~1s later with an empty routing table, causing all STORE RPCs to fail and the node to drop off the map. Fix delays 30s before announcing.

## Test
Verified on metro-win: \kwaainet update\ now runs exactly once and exits cleanly.