### PR TITLE
feat(kwaai-rpc): report daemon version in StatusReply

### DIFF
--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -233,6 +233,10 @@ impl KwaaiNet for KwaaiNetService {
                             shard_ready: shard_ready_path_exists(),
                             peer_count: 0, // TODO: thread through DHT routing-table size
                             uptime_secs: started_at.elapsed().as_secs(),
+                            // Same constant the updater compares against, so
+                            // the version reported over the wire can never
+                            // drift from the one used for update checks.
+                            version: crate::updater::CURRENT_VERSION.to_string(),
                         };
                         let _ = out_tx
                             .send(Ok(ServerFrame {

--- a/core/crates/kwaai-network-tests/tests/03_unit_rpc.rs
+++ b/core/crates/kwaai-network-tests/tests/03_unit_rpc.rs
@@ -171,12 +171,46 @@ fn server_frame_status_roundtrip() {
         shard_ready: true,
         peer_count: 12,
         uptime_secs: 3600,
+        // Arbitrary round-trip fixture, deliberately not a real release
+        // number: this asserts the field survives encode/decode, not what the
+        // daemon reports. Nothing here tracks CARGO_PKG_VERSION, so a version
+        // bump never needs to touch this test.
+        version: "9.9.9-test".to_string(),
     };
     let decoded = encode_decode_server_frame(server_frame::Body::Status(reply));
     if let Some(server_frame::Body::Status(s)) = decoded.body {
         assert_eq!(s.model, "llama3.2:3b");
         assert!(s.shard_ready);
         assert_eq!(s.peer_count, 12);
+        assert_eq!(s.uptime_secs, 3600);
+        assert_eq!(s.version, "9.9.9-test");
+    } else {
+        panic!("wrong variant");
+    }
+    rec.finish(true);
+}
+
+/// A daemon built before `version` existed sends no field 6; proto3 decodes
+/// the absent field as "". Clients must be able to distinguish that from a
+/// real version, so pin the behaviour rather than leaving it implied.
+#[test]
+fn server_frame_status_version_defaults_empty_for_old_daemons() {
+    let rec = MetricsRecorder::start(
+        "unit::rpc::server_frame_status_version_defaults_empty_for_old_daemons",
+        "unit",
+    );
+    let reply = StatusReply {
+        server_time: "2026-05-23T18:32:00Z".to_string(),
+        model: "llama3.2:3b".to_string(),
+        shard_ready: true,
+        peer_count: 12,
+        uptime_secs: 3600,
+        ..Default::default()
+    };
+    let decoded = encode_decode_server_frame(server_frame::Body::Status(reply));
+    if let Some(server_frame::Body::Status(s)) = decoded.body {
+        assert_eq!(s.version, "");
+        // The pre-existing fields must still decode alongside the new one.
         assert_eq!(s.uptime_secs, 3600);
     } else {
         panic!("wrong variant");

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -223,6 +223,16 @@ message StatusReply {
 
     // Daemon process uptime in seconds.
     uint64 uptime_secs = 5;
+
+    // Version of the running daemon binary (CARGO_PKG_VERSION), e.g.
+    // "0.5.4" — no leading "v". Lets a client report the version of the
+    // process it is actually talking to, which can differ from whatever
+    // binary is on disk after an upgrade or a config change that has not
+    // been restarted into yet.
+    //
+    // Empty when talking to a daemon built before this field existed;
+    // clients should treat "" as unknown rather than as a version.
+    string version = 6;
 }
 
 // =====================================================================


### PR DESCRIPTION
## What

Adds `StatusReply.version` (field 6) to the `kwaai.v1` gRPC surface, populated from the daemon's `CARGO_PKG_VERSION`.

## Why

A client holding an RPC channel can learn the daemon's uptime, model and peer count, but not which version of the binary is actually serving. Today the only way to get a version is to exec `kwaainet --version`, which has two problems:

- It reports the version of the binary **on disk**, which diverges from the running process after an in-place upgrade, or when a client's configured binary path changes without a restart.
- It's unavailable to a client that only holds an RPC channel and cannot exec anything.

The motivating consumer is [KwaaiNetGUI](https://github.com/dazwin/KwaaiNetGUI), which displays the running daemon's version in its settings page. It talks to the daemon purely over gRPC, so before this change it could only shell out and report the on-disk binary — which is a different thing from what is running, and misleading precisely when the two disagree. With this field it can report the running process's own answer, and show nothing when the daemon can't supply one.

## Implementation

`version` is sourced from `updater::CURRENT_VERSION` — the same constant the updater compares against — so the version reported over the wire can never drift from the one used for update checks.

## Compatibility

Additive on a new field number, so it is wire-compatible in both directions:

- Existing clients ignore field 6.
- A new client reading an older daemon decodes the proto3 default `""`. This is documented in the proto as "unknown", explicitly not a version, so clients can distinguish "daemon predates this field" from a real answer rather than rendering an empty string.

## Tests

`core/crates/kwaai-network-tests/tests/03_unit_rpc.rs`:

- `server_frame_status_roundtrip` — extended to assert `version` survives encode/decode.
- `server_frame_status_version_defaults_empty_for_old_daemons` — new; pins the proto3 default-empty behaviour that clients rely on to detect a pre-field daemon.

`cargo test -p kwaai-network-tests --test 03_unit_rpc` → 16 passed. `cargo fmt --all -- --check` and `cargo clippy` clean.

Verified end to end against a running daemon: a gRPC client issuing `Status` over the Unix socket receives `0.5.4`, and the same client against a pre-field daemon receives `""` and correctly treats it as unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)