### PR TITLE
feat(rpc): block-coverage fetch/subscribe over the Session stream

### DIFF
--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -653,6 +653,50 @@ async fn spawn_session_shard_run(
 /// doesn't ask for a specific interval. Mirrors the map-server crawler.
 const DEFAULT_COVERAGE_INTERVAL_SECS: u64 = 5;
 
+/// How long a subscription may stay silent while coverage is unchanged.
+///
+/// Unchanged snapshots are suppressed, so without this a stable network
+/// and a wedged daemon look identical from the client's side. Sending an
+/// otherwise-redundant update this often bounds that ambiguity while
+/// still dropping the vast majority of duplicate frames — at the default
+/// 5 s cadence this keeps roughly one tick in twelve.
+const HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// The parts of a [`BlockCoverageUpdate`] that decide whether it tells the
+/// client anything new.
+///
+/// Deliberately excludes `server_time`: it changes every tick by
+/// construction, so comparing whole updates would report every snapshot as
+/// changed and suppress nothing. Peers are compared as a *set* — the DHT
+/// returns them in whatever order responders answered in, and a pure
+/// reordering is not a change worth waking the UI for.
+type CoverageIdentity = (u32, u32, bool, std::collections::BTreeSet<String>);
+
+fn coverage_identity(u: &BlockCoverageUpdate) -> CoverageIdentity {
+    let peers = u
+        .peers
+        .iter()
+        .map(|p| {
+            // Every field a client renders per row, so a peer changing its
+            // range, name, throughput or trust still counts as a change.
+            // Floats are formatted rather than compared bitwise: the DHT
+            // round-trips them through msgpack, and a stable rendering is
+            // what the client actually sees.
+            format!(
+                "{}|{}|{}|{}|{:.3}|{:.3}|{}",
+                p.peer_id,
+                p.start_block,
+                p.end_block,
+                p.public_name,
+                p.throughput,
+                p.trust_score,
+                p.trust_tier,
+            )
+        })
+        .collect();
+    (u.total_blocks, u.covered_blocks, u.full_coverage, peers)
+}
+
 /// Serve a `block_coverage` op within a Session: query the DHT for the
 /// model's block servers and emit one BlockCoverageUpdate (one-shot) or
 /// one per refresh interval until cancelled (subscribe).
@@ -693,6 +737,11 @@ async fn spawn_session_block_coverage(
         let mut discovery: Option<(kwaai_p2p_daemon::P2PClient, libp2p::PeerId, Vec<String>)> =
             None;
 
+        // Identity of the last snapshot actually sent, and when it went
+        // out — together these drive the change/heartbeat decision below.
+        let mut last_sent: Option<CoverageIdentity> = None;
+        let mut last_send_at: Option<std::time::Instant> = None;
+
         loop {
             if discovery.is_none() {
                 match crate::shard_cmd::connect_for_discovery(&cfg).await {
@@ -724,12 +773,37 @@ async fn spawn_session_block_coverage(
                 .await;
 
                 let update = build_coverage_update(&cfg, &dht_prefix, total_blocks, &chain);
-                let frame = ServerFrame {
-                    id,
-                    body: Some(server_frame::Body::BlockCoverage(update)),
-                };
-                if out_tx.send(Ok(frame)).await.is_err() {
-                    break; // client went away
+
+                // Suppress updates that would tell the client nothing new.
+                //
+                // Coverage is derived from DHT records with a 360 s TTL that
+                // peers re-announce every ~300 s, so at a 5 s cadence the
+                // overwhelming majority of ticks produce a byte-identical
+                // snapshot. Sending them anyway costs a frame and a client
+                // rebuild per tick to convey nothing.
+                //
+                // The heartbeat is what keeps that safe: silence alone is
+                // ambiguous — a client cannot distinguish "nothing changed"
+                // from "the daemon wedged" — so an unchanged snapshot is
+                // still sent every HEARTBEAT interval. That preserves a
+                // liveness signal and keeps any client-side "last updated"
+                // display honest.
+                let changed = last_sent.as_ref() != Some(&coverage_identity(&update));
+                let heartbeat_due = last_send_at
+                    .map(|t: std::time::Instant| t.elapsed() >= HEARTBEAT)
+                    .unwrap_or(true);
+
+                if changed || heartbeat_due || !req.subscribe {
+                    last_sent = Some(coverage_identity(&update));
+                    last_send_at = Some(std::time::Instant::now());
+
+                    let frame = ServerFrame {
+                        id,
+                        body: Some(server_frame::Body::BlockCoverage(update)),
+                    };
+                    if out_tx.send(Ok(frame)).await.is_err() {
+                        break; // client went away
+                    }
                 }
 
                 if !req.subscribe {
@@ -1406,5 +1480,65 @@ mod tests {
         assert_eq!(update.covered_blocks, 8);
         assert!(update.full_coverage);
         assert_eq!(update.peers[1].end_block, 12);
+    }
+
+    #[test]
+    fn coverage_identity_ignores_time_and_peer_order() {
+        let peer = |id: &str, start, end| BlockPeer {
+            peer_id: id.to_string(),
+            start_block: start,
+            end_block: end,
+            public_name: "peer".into(),
+            throughput: 1.0,
+            trust_score: 0.5,
+            trust_tier: String::new(),
+        };
+        let update = |time: &str, peers: Vec<BlockPeer>| BlockCoverageUpdate {
+            server_time: time.to_string(),
+            model: "m".into(),
+            dht_prefix: "Model-X".into(),
+            total_blocks: 8,
+            covered_blocks: 8,
+            full_coverage: true,
+            peers,
+        };
+
+        let a = update(
+            "2026-01-01T00:00:00Z",
+            vec![peer("A", 0, 4), peer("B", 4, 8)],
+        );
+
+        // server_time advances every tick by construction; if it counted,
+        // nothing would ever be suppressed and the diff would be useless.
+        let later = update(
+            "2026-01-01T00:00:05Z",
+            vec![peer("A", 0, 4), peer("B", 4, 8)],
+        );
+        assert_eq!(coverage_identity(&a), coverage_identity(&later));
+
+        // Responder order is not information — the same peers arriving in
+        // a different order must not wake the client.
+        let reordered = update(
+            "2026-01-01T00:00:05Z",
+            vec![peer("B", 4, 8), peer("A", 0, 4)],
+        );
+        assert_eq!(coverage_identity(&a), coverage_identity(&reordered));
+
+        // A peer leaving is the change the subscription exists to report.
+        let departed = update("2026-01-01T00:00:05Z", vec![peer("A", 0, 4)]);
+        assert_ne!(coverage_identity(&a), coverage_identity(&departed));
+
+        // So is one silently changing the range it serves.
+        let reranged = update(
+            "2026-01-01T00:00:05Z",
+            vec![peer("A", 0, 4), peer("B", 4, 6)],
+        );
+        assert_ne!(coverage_identity(&a), coverage_identity(&reranged));
+
+        // And so is a trust re-tiering, which the client renders per row.
+        let mut retiered_peer = peer("B", 4, 8);
+        retiered_peer.trust_tier = "TRUSTED".into();
+        let retiered = update("2026-01-01T00:00:05Z", vec![peer("A", 0, 4), retiered_peer]);
+        assert_ne!(coverage_identity(&a), coverage_identity(&retiered));
     }
 }

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -40,8 +40,9 @@ use kwaai_rpc::v1::{
     client_frame,
     error::Code as ErrorCode,
     kwaai_net_server::{KwaaiNet, KwaaiNetServer},
-    server_frame, Cancel, ChatMessage, ChatToken, ClientFrame, Done, Error as RpcError,
-    GenerateRequest, PingReply, PingRequest, ServerFrame, ShardRunRequest, StatusReply,
+    server_frame, BlockCoverageRequest, BlockCoverageUpdate, BlockPeer, Cancel, ChatMessage,
+    ChatToken, ClientFrame, Done, Error as RpcError, GenerateRequest, PingReply, PingRequest,
+    ServerFrame, ShardRunRequest, StatusReply,
 };
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -257,6 +258,17 @@ impl KwaaiNet for KwaaiNetService {
 
                     client_frame::Body::ShardRun(req) => {
                         spawn_session_shard_run(id, req, out_tx.clone(), cancels.clone()).await;
+                    }
+
+                    client_frame::Body::BlockCoverage(req) => {
+                        spawn_session_block_coverage(
+                            id,
+                            req,
+                            cfg.clone(),
+                            out_tx.clone(),
+                            cancels.clone(),
+                        )
+                        .await;
                     }
 
                     client_frame::Body::Cancel(Cancel { target_id }) => {
@@ -635,6 +647,169 @@ async fn spawn_session_shard_run(
 
         cancels_for_cleanup.lock().await.remove(&id);
     });
+}
+
+/// Refresh cadence for block-coverage subscriptions when the client
+/// doesn't ask for a specific interval. Mirrors the map-server crawler.
+const DEFAULT_COVERAGE_INTERVAL_SECS: u64 = 5;
+
+/// Serve a `block_coverage` op within a Session: query the DHT for the
+/// model's block servers and emit one BlockCoverageUpdate (one-shot) or
+/// one per refresh interval until cancelled (subscribe).
+async fn spawn_session_block_coverage(
+    id: u64,
+    req: BlockCoverageRequest,
+    cfg: Arc<KwaaiNetConfig>,
+    out_tx: mpsc::Sender<Result<ServerFrame, Status>>,
+    cancels: Arc<Mutex<HashMap<u64, oneshot::Sender<()>>>>,
+) {
+    // Register the cancel channel up-front so a Cancel arriving immediately
+    // after this frame still finds an entry to fire.
+    let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+    cancels.lock().await.insert(id, cancel_tx);
+
+    let cancels_for_cleanup = cancels.clone();
+    tokio::spawn(async move {
+        use std::time::Duration;
+
+        let dht_prefix = req
+            .dht_prefix
+            .clone()
+            .filter(|p| !p.is_empty())
+            .unwrap_or_else(|| cfg.effective_dht_prefix());
+        let total_blocks = match req.total_blocks {
+            Some(n) if n > 0 => n as usize,
+            _ => cfg.model_total_blocks().max(1) as usize,
+        };
+        let interval = if req.interval_secs > 0 {
+            req.interval_secs as u64
+        } else {
+            DEFAULT_COVERAGE_INTERVAL_SECS
+        };
+
+        // The gRPC server binds before p2pd is up during daemon startup,
+        // so the p2pd connection is (re)established lazily: a one-shot
+        // fetch fails fast, a subscription just retries next tick.
+        let mut discovery: Option<(kwaai_p2p_daemon::P2PClient, libp2p::PeerId, Vec<String>)> =
+            None;
+
+        loop {
+            if discovery.is_none() {
+                match crate::shard_cmd::connect_for_discovery(&cfg).await {
+                    Ok(conn) => discovery = Some(conn),
+                    Err(e) if !req.subscribe => {
+                        let _ = out_tx
+                            .send(Ok(error_frame(
+                                id,
+                                ErrorCode::Unavailable,
+                                &format!("{e:#}"),
+                            )))
+                            .await;
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::debug!(id, "block coverage: p2pd not reachable yet: {e:#}");
+                    }
+                }
+            }
+
+            if let Some((client, our_peer_id, bootstrap_peers)) = discovery.as_mut() {
+                let chain = crate::shard_cmd::discover_chain(
+                    client,
+                    our_peer_id,
+                    &dht_prefix,
+                    total_blocks,
+                    bootstrap_peers,
+                )
+                .await;
+
+                let update = build_coverage_update(&cfg, &dht_prefix, total_blocks, &chain);
+                let frame = ServerFrame {
+                    id,
+                    body: Some(server_frame::Body::BlockCoverage(update)),
+                };
+                if out_tx.send(Ok(frame)).await.is_err() {
+                    break; // client went away
+                }
+
+                if !req.subscribe {
+                    let _ = out_tx.send(Ok(done_frame(id))).await;
+                    break;
+                }
+            }
+
+            tokio::select! {
+                _ = &mut cancel_rx => {
+                    let _ = out_tx
+                        .send(Ok(error_frame(
+                            id,
+                            ErrorCode::Cancelled,
+                            "cancelled by client",
+                        )))
+                        .await;
+                    break;
+                }
+                _ = tokio::time::sleep(Duration::from_secs(interval)) => {}
+            }
+        }
+
+        cancels_for_cleanup.lock().await.remove(&id);
+    });
+}
+
+/// Assemble a [`BlockCoverageUpdate`] from a discovered chain, enriching
+/// each peer with its local reputation score/tier when enabled.
+fn build_coverage_update(
+    cfg: &KwaaiNetConfig,
+    dht_prefix: &str,
+    total_blocks: usize,
+    chain: &[crate::shard_cmd::BlockServerEntry],
+) -> BlockCoverageUpdate {
+    let rep_store = if cfg.reputation.enabled {
+        Some(crate::reputation::ReputationStore::load())
+    } else {
+        None
+    };
+
+    let mut covered = vec![false; total_blocks];
+    let peers: Vec<BlockPeer> = chain
+        .iter()
+        .map(|e| {
+            let start = e.start_block.min(total_blocks);
+            let end = e.end_block.min(total_blocks);
+            if start < end {
+                covered[start..end].fill(true);
+            }
+            let peer_b58 = e.peer_id.to_base58();
+            let (trust_score, trust_tier) = match rep_store.as_ref() {
+                Some(store) => {
+                    let s = store.score(&peer_b58);
+                    (s.score, s.tier.as_str().to_string())
+                }
+                None => (0.0, String::new()),
+            };
+            BlockPeer {
+                peer_id: peer_b58,
+                start_block: e.start_block as u32,
+                end_block: e.end_block as u32,
+                public_name: e.public_name.clone(),
+                throughput: e.throughput,
+                trust_score,
+                trust_tier,
+            }
+        })
+        .collect();
+    let covered_blocks = covered.iter().filter(|&&c| c).count();
+
+    BlockCoverageUpdate {
+        server_time: now_rfc3339(),
+        model: cfg.model.clone(),
+        dht_prefix: dht_prefix.to_string(),
+        total_blocks: total_blocks as u32,
+        covered_blocks: covered_blocks as u32,
+        full_coverage: covered_blocks == total_blocks,
+        peers,
+    }
 }
 
 /// Free-function variant of `KwaaiNetService::get_or_init_inference` so

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1374,4 +1374,37 @@ mod tests {
         let down = wait_for(Duration::from_secs(2), tcp_refused).await;
         assert!(down, "TCP listener did not close after handle drop");
     }
+
+    #[test]
+    fn coverage_update_counts_blocks_and_clamps_ranges() {
+        let mut cfg = KwaaiNetConfig::default();
+        // Keep the test hermetic: enabled reputation would read the real
+        // user's on-disk ReputationStore.
+        cfg.reputation.enabled = false;
+
+        let entry = |start, end| crate::shard_cmd::BlockServerEntry {
+            peer_id: libp2p::PeerId::random(),
+            start_block: start,
+            end_block: end,
+            public_name: "peer".into(),
+            throughput: 1.0,
+            trust_score: None,
+        };
+
+        // Gap at block 3: [0,3) + [4,8).
+        let update = build_coverage_update(&cfg, "Model-X", 8, &[entry(0, 3), entry(4, 8)]);
+        assert_eq!(update.dht_prefix, "Model-X");
+        assert_eq!(update.total_blocks, 8);
+        assert_eq!(update.covered_blocks, 7);
+        assert!(!update.full_coverage);
+        assert_eq!(update.peers.len(), 2);
+        assert!(update.peers[0].trust_tier.is_empty());
+
+        // Overlapping ranges cover fully, and an end past total_blocks
+        // must clamp for the bitmap while surviving verbatim on the peer.
+        let update = build_coverage_update(&cfg, "Model-X", 8, &[entry(0, 5), entry(3, 12)]);
+        assert_eq!(update.covered_blocks, 8);
+        assert!(update.full_coverage);
+        assert_eq!(update.peers[1].end_block, 12);
+    }
 }

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -2031,6 +2031,26 @@ pub async fn discover_chain(
     chain
 }
 
+/// Connect to the local p2pd and resolve everything [`discover_chain`]
+/// needs: the client, our own peer id, and the bootstrap peer list.
+/// Shared by the CLI paths and the gRPC block-coverage handler.
+pub async fn connect_for_discovery(
+    cfg: &KwaaiNetConfig,
+) -> Result<(P2PClient, PeerId, Vec<String>)> {
+    let mut client = P2PClient::connect(&daemon_socket())
+        .await
+        .context("connecting to p2pd (is `kwaainet start` running?)")?;
+    let peer_id_hex = client.identify().await.context("identify peer")?;
+    let our_peer_id =
+        PeerId::from_bytes(&hex::decode(&peer_id_hex)?).context("parse our peer ID")?;
+    let bootstrap_peers = if cfg.initial_peers.is_empty() {
+        NetworkConfig::with_petals_bootstrap().bootstrap_peers
+    } else {
+        cfg.initial_peers.clone()
+    };
+    Ok((client, our_peer_id, bootstrap_peers))
+}
+
 // ── Inference peer discovery ───────────────────────────────────────────────────
 
 /// DHT key under which nodes advertise Ollama / shard-API availability.

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -51,6 +51,7 @@ service KwaaiNet {
 //   shardRun          ←  `kwaainet shard run <PROMPT>`
 //   status            ←  `kwaainet status`
 //   cancel            ←  (no CLI equivalent; aborts an in-flight op)
+//   blockCoverage     ←  `kwaainet shard chain`
 //
 // New operations are added as siblings here; preserving the flat shape
 // keeps the dispatch trivial on both sides.
@@ -78,6 +79,12 @@ message ClientFrame {
 
         // Cancel an in-flight operation by id.
         Cancel cancel = 14;
+
+        // Block-coverage snapshot / subscription. One-shot when
+        // `subscribe` is false (one BlockCoverageUpdate reply, then
+        // Done); a live feed when true (a BlockCoverageUpdate every
+        // refresh interval until cancelled with a `Cancel` body).
+        BlockCoverageRequest block_coverage = 15;
     }
 }
 
@@ -104,6 +111,11 @@ message ServerFrame {
 
         // Reply to a StatusRequest.
         StatusReply status = 14;
+
+        // Snapshot of model block coverage. Exactly one arrives for a
+        // one-shot BlockCoverageRequest; a subscription delivers one
+        // per refresh interval until the op is cancelled.
+        BlockCoverageUpdate block_coverage = 15;
     }
 }
 
@@ -223,6 +235,75 @@ message StatusReply {
 
     // Daemon process uptime in seconds.
     uint64 uptime_secs = 5;
+}
+
+// `kwaainet shard chain` — model block coverage from the DHT.
+message BlockCoverageRequest {
+    // DHT prefix to query. Defaults to the daemon's configured model
+    // prefix when empty.
+    optional string dht_prefix = 1;
+
+    // Total transformer blocks in the model. Defaults to the daemon's
+    // model config (`num_hidden_layers`) when unset.
+    optional uint32 total_blocks = 2;
+
+    // When true the operation stays open and the server pushes a fresh
+    // BlockCoverageUpdate every `interval_secs` until the client sends
+    // a Cancel body for this op id. When false a single update is sent
+    // followed by Done.
+    bool subscribe = 3;
+
+    // Refresh cadence for subscriptions, in seconds. 0 means the
+    // server default (5s). Ignored when `subscribe` is false.
+    uint32 interval_secs = 4;
+}
+
+// One peer serving a contiguous block range, as announced in the DHT.
+message BlockPeer {
+    // libp2p peer id, base58.
+    string peer_id = 1;
+
+    // Served block range: [start_block, end_block).
+    uint32 start_block = 2;
+    uint32 end_block = 3;
+
+    // Human-readable name the peer announced (may be empty).
+    string public_name = 4;
+
+    // Tokens/sec the peer claimed in its DHT announcement (0 = unknown).
+    double throughput = 5;
+
+    // Local reputation score in [0, 1]. Only meaningful when
+    // `trust_tier` is non-empty.
+    double trust_score = 6;
+
+    // Trust tier label ("UNKNOWN" / "KNOWN" / "VERIFIED" / "TRUSTED").
+    // Empty when the local reputation system is disabled.
+    string trust_tier = 7;
+}
+
+// Snapshot of which peers cover which blocks of the model.
+message BlockCoverageUpdate {
+    // Daemon wall-clock time of this snapshot, RFC 3339.
+    string server_time = 1;
+
+    // The model whose coverage was queried (daemon's configured model).
+    string model = 2;
+
+    // The DHT prefix actually queried.
+    string dht_prefix = 3;
+
+    // Total transformer blocks in the model.
+    uint32 total_blocks = 4;
+
+    // Number of blocks covered by at least one peer.
+    uint32 covered_blocks = 5;
+
+    // True when every block is covered — distributed inference ready.
+    bool full_coverage = 6;
+
+    // All discovered block servers, sorted by start_block.
+    repeated BlockPeer peers = 7;
 }
 
 // =====================================================================


### PR DESCRIPTION
## What

Exposes model block coverage — which peers serve which blocks, the data `kwaainet shard chain` prints — over gRPC, as both a one-shot fetch and a live subscription.

## Why

`shard chain` is currently terminal-only. A GUI or any other RPC client has no way to see whether the model is fully covered, where the gaps are, or who is serving what, short of shelling out and scraping stdout.

## How

Extends the existing `Session` bidi stream rather than adding a top-level rpc. The proto designates `Session` as the canonical surface ("Don't add new functionality here — use Session"), and it already provides per-id correlation, streaming and `Cancel` — so subscribe/unsubscribe semantics come for free and `spawn()` needs no changes.

- `BlockCoverageRequest` on `ClientFrame` (field 15), `BlockCoverageUpdate` on `ServerFrame` (field 15).
- `subscribe: false` → one update, then `Done`. `subscribe: true` → a live feed until the client sends a `Cancel` for that op id.
- `connect_for_discovery` is extracted from the existing CLI paths in `shard_cmd.rs` so the RPC handler and the CLI resolve peers identically.

Three behaviours worth flagging for review:

**Lazy p2pd connection.** The gRPC server binds before p2pd is up during daemon startup, so the handler connects lazily: a one-shot fetch fails fast with `UNAVAILABLE`, while a subscription simply retries on the next tick. A client can subscribe immediately at startup and start receiving updates once the DHT is live, rather than polling for readiness first.

**Asymmetric clamping.** A peer's announced `end_block` may exceed the model's block count. The range is clamped before indexing the coverage bitmap, but the peer's raw `end_block` is sent verbatim on the wire — so a client sees what the peer actually claimed rather than a silently truncated value.

**Unchanged updates are suppressed.** Coverage derives from DHT records with a 360 s TTL that peers re-announce every ~300 s, so at a 5 s cadence the overwhelming majority of ticks produce a byte-identical snapshot — a frame and a client rebuild each, conveying nothing. Updates now go out only when the snapshot differs from the last one sent.

The comparison deliberately excludes `server_time`, which advances every tick by construction and would mark everything as changed, suppressing nothing. Peers compare as a set, since the DHT returns them in whatever order responders answered in and a pure reordering isn't worth waking a UI for; the per-peer key covers every field a client renders, so range/name/throughput/trust changes still register.

Suppression alone would be unsafe — silence is ambiguous, and a client can't tell "nothing changed" from "the daemon wedged" — so an unchanged snapshot still goes out every 60 s. That bounds the ambiguity and keeps a client-side "last updated" display honest while still dropping roughly eleven ticks in twelve. One-shot requests are unaffected.

## Wire compatibility

Additive only, on new field numbers, per the header rule in `kwaai.proto`. Existing clients ignore fields they don't know; a new client against an older daemon simply never receives a `blockCoverage` frame. No existing field is renumbered or repurposed.

## Testing

- `cargo check -p kwaainet` and `cargo fmt --check` clean.
- `cargo test -p kwaainet`: 55 pass. Two pre-existing failures (`server_binds_and_shuts_down_cleanly`, `chat_returns_invalid_argument_on_empty_inbound_stream`) reproduce identically on unmodified `main` when a `kwaainet` daemon holds port 8093 locally — environmental, unrelated to this change.
- `coverage_update_counts_blocks_and_clamps_ranges` covers the bitmap math (gaps, overlaps, end-past-total clamping).
- `coverage_identity_ignores_time_and_peer_order` covers the diffing: time advance and peer reordering must not count as changes; departures, re-ranging and re-tiering must.

## Note

Force-pushed to add the third commit — GitHub doesn't allow retargeting a PR's head branch, so the branch was updated in place rather than opening a new PR. No reviews had been left at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)