### PR TITLE
feat(rpc): VPK storage-node discovery over the Session stream

### DIFF
--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -917,15 +917,60 @@ const DEFAULT_STORAGE_INTERVAL_SECS: u64 = 30;
 /// timeout, not one per unreachable node.
 const STORAGE_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-/// Serve a `storage_discovery` op within a Session: look up the VPK node
-/// registry in the DHT, emit it immediately, then probe each node's
-/// reachability and emit the resolved snapshot.
+/// The parts of a [`StorageUpdate`] that decide whether it tells the
+/// client anything new.
 ///
-/// Each round sends two updates because the two halves have very
+/// Deliberately excludes `server_time`: it changes every round by
+/// construction, so comparing whole updates would report every snapshot
+/// as changed and suppress nothing. Peers are compared as a *set* — the
+/// DHT returns them in whatever order responders answered in, and the
+/// wire order is already normalised by sorting, so a pure reordering is
+/// not a change worth waking the UI for.
+///
+/// `probes_pending` is not part of the identity: only resolved snapshots
+/// are ever compared, so it is false on both sides by construction.
+type StorageIdentity = std::collections::BTreeSet<String>;
+
+fn storage_identity(u: &StorageUpdate) -> StorageIdentity {
+    u.peers
+        .iter()
+        .map(|p| {
+            // Every field a client renders per row, so a node changing
+            // its capacity, tenancy, reachability or trust still counts
+            // as a change. Floats are formatted rather than compared
+            // bitwise: they round-trip through msgpack, and a stable
+            // rendering is what the client actually sees.
+            format!(
+                "{}|{}|{}|{}|{:.3}|{}|{}|{:.3}|{:.3}|{}",
+                p.peer_id,
+                p.public_name,
+                p.mode,
+                p.vpk_version,
+                p.capacity_gb,
+                p.tenant_count,
+                p.reachability,
+                p.capacity_gb_free,
+                p.trust_score,
+                p.trust_tier,
+            )
+        })
+        .collect()
+}
+
+/// Serve a `storage_discovery` op within a Session: look up the VPK node
+/// registry in the DHT, probe each node's reachability, and emit the
+/// resolved snapshot.
+///
+/// The *first* round sends two updates, because the two halves have very
 /// different latencies — the DHT answers in about a second, while probing
 /// nodes that will never answer costs a full timeout. Emitting the
 /// registry first lets a client show the node list while reachability is
-/// still resolving.
+/// still resolving, rather than holding a blank view.
+///
+/// Later rounds send at most one, and usually none: re-announcing every
+/// peer as unprobed would flicker the client's status column back to
+/// "checking" on each round, and a resolved snapshot identical to the
+/// last one is suppressed outright. See the comments inline.
 async fn spawn_session_storage_discovery(
     id: u64,
     req: StorageDiscoveryRequest,
@@ -954,6 +999,13 @@ async fn spawn_session_storage_discovery(
         let mut discovery: Option<(kwaai_p2p_daemon::P2PClient, libp2p::PeerId, Vec<String>)> =
             None;
 
+        // Identity of the last resolved snapshot actually sent, and when
+        // it went out — together these drive the change/heartbeat
+        // decision below. `last_sent` doubles as "has the client seen a
+        // resolved snapshot yet", which is what gates the pending phase.
+        let mut last_sent: Option<StorageIdentity> = None;
+        let mut last_send_at: Option<std::time::Instant> = None;
+
         loop {
             if discovery.is_none() {
                 match crate::shard_cmd::connect_for_discovery(&cfg).await {
@@ -981,35 +1033,75 @@ async fn spawn_session_storage_discovery(
                     Ok(entries) => {
                         let mut peers = build_storage_peers(&cfg, &entries);
 
-                        // Phase 1 — the registry, as advertised. Skipped
-                        // when probing is off: there is no second update
-                        // coming, so `probes_pending` would be a lie.
+                        // Phase 1 — the registry, as advertised, before
+                        // anything has been probed.
+                        //
+                        // Only worth sending when the client has nothing
+                        // better on screen. Once a resolved snapshot has
+                        // been sent, re-sending every peer as UNKNOWN
+                        // would throw the whole status column back to
+                        // "checking" each round — a visible flicker that
+                        // replaces good data with worse. Later rounds
+                        // therefore stay quiet until their probes land.
+                        //
+                        // Skipped entirely when probing is off: there is
+                        // no second update coming, so `probes_pending`
+                        // would be a lie.
                         if !req.skip_probes {
-                            let frame = ServerFrame {
-                                id,
-                                body: Some(server_frame::Body::Storage(StorageUpdate {
-                                    server_time: now_rfc3339(),
-                                    probes_pending: true,
-                                    peers: peers.clone(),
-                                })),
-                            };
-                            if out_tx.send(Ok(frame)).await.is_err() {
-                                break; // client went away
+                            if last_sent.is_none() {
+                                let frame = ServerFrame {
+                                    id,
+                                    body: Some(server_frame::Body::Storage(StorageUpdate {
+                                        server_time: now_rfc3339(),
+                                        probes_pending: true,
+                                        peers: peers.clone(),
+                                    })),
+                                };
+                                if out_tx.send(Ok(frame)).await.is_err() {
+                                    break; // client went away
+                                }
                             }
 
                             probe_storage_peers(client, &mut peers).await;
                         }
 
-                        let frame = ServerFrame {
-                            id,
-                            body: Some(server_frame::Body::Storage(StorageUpdate {
-                                server_time: now_rfc3339(),
-                                probes_pending: false,
-                                peers,
-                            })),
+                        let update = StorageUpdate {
+                            server_time: now_rfc3339(),
+                            probes_pending: false,
+                            peers,
                         };
-                        if out_tx.send(Ok(frame)).await.is_err() {
-                            break;
+
+                        // Suppress rounds that would tell the client
+                        // nothing new.
+                        //
+                        // The registry only moves on the ~120 s announce
+                        // cycle and most nodes' reachability is stable, so
+                        // at a 30 s cadence the majority of rounds produce
+                        // an identical snapshot. Sending them anyway costs
+                        // a frame and a client rebuild to convey nothing —
+                        // and, because the table re-sorts and re-renders,
+                        // shows up as a flicker.
+                        //
+                        // The heartbeat keeps that safe: silence alone is
+                        // ambiguous, so an unchanged snapshot still goes
+                        // out every HEARTBEAT to prove the daemon is alive
+                        // and keep the client's staleness cue honest.
+                        let changed = last_sent.as_ref() != Some(&storage_identity(&update));
+                        let heartbeat_due = last_send_at
+                            .map(|t: std::time::Instant| t.elapsed() >= HEARTBEAT)
+                            .unwrap_or(true);
+
+                        if changed || heartbeat_due || !req.subscribe {
+                            last_sent = Some(storage_identity(&update));
+                            last_send_at = Some(std::time::Instant::now());
+
+                            let frame = ServerFrame {
+                                id,
+                                body: Some(server_frame::Body::Storage(update)),
+                            };
+                            if out_tx.send(Ok(frame)).await.is_err() {
+                                break;
+                            }
                         }
                     }
                     Err(e) => {
@@ -1793,6 +1885,50 @@ mod tests {
         assert_eq!(peers[0].tenant_count, 2);
         assert_eq!(peers[0].mode, "eve");
         assert!(peers[0].trust_tier.is_empty());
+    }
+
+    #[test]
+    fn storage_identity_ignores_time_and_peer_order() {
+        let peer = |id: &str, reach: i32, free: f64| StoragePeer {
+            peer_id: id.into(),
+            public_name: "node".into(),
+            mode: "eve".into(),
+            vpk_version: "0.5.0".into(),
+            capacity_gb: 42.0,
+            tenant_count: 1,
+            reachability: reach,
+            capacity_gb_free: free,
+            trust_score: 0.5,
+            trust_tier: "KNOWN".into(),
+        };
+        let update = |time: &str, peers: Vec<StoragePeer>| StorageUpdate {
+            server_time: time.into(),
+            probes_pending: false,
+            peers,
+        };
+
+        let a = update("t0", vec![peer("A", 1, 10.0), peer("B", 2, 0.0)]);
+
+        // A later round with the same nodes tells the client nothing new,
+        // even though server_time always advances.
+        let later = update("t1", vec![peer("A", 1, 10.0), peer("B", 2, 0.0)]);
+        assert_eq!(storage_identity(&a), storage_identity(&later));
+
+        // Responder order is not information.
+        let reordered = update("t2", vec![peer("B", 2, 0.0), peer("A", 1, 10.0)]);
+        assert_eq!(storage_identity(&a), storage_identity(&reordered));
+
+        // A node dropping out of the registry is.
+        let departed = update("t3", vec![peer("A", 1, 10.0)]);
+        assert_ne!(storage_identity(&a), storage_identity(&departed));
+
+        // So is one coming back within reach — the status column changes.
+        let recovered = update("t4", vec![peer("A", 1, 10.0), peer("B", 1, 7.0)]);
+        assert_ne!(storage_identity(&a), storage_identity(&recovered));
+
+        // And so is free space moving, which is what the cylinder draws.
+        let filled = update("t5", vec![peer("A", 1, 3.0), peer("B", 2, 0.0)]);
+        assert_ne!(storage_identity(&a), storage_identity(&filled));
     }
 
     #[test]

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -42,7 +42,8 @@ use kwaai_rpc::v1::{
     kwaai_net_server::{KwaaiNet, KwaaiNetServer},
     server_frame, BlockCoverageRequest, BlockCoverageUpdate, BlockPeer, Cancel, ChatMessage,
     ChatToken, ClientFrame, Done, Error as RpcError, GenerateRequest, PingReply, PingRequest,
-    ServerFrame, ShardRunRequest, StatusReply,
+    ServerFrame, ShardRunRequest, StatusReply, StorageDiscoveryRequest, StoragePeer,
+    StorageReachability, StorageUpdate,
 };
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -266,6 +267,17 @@ impl KwaaiNet for KwaaiNetService {
 
                     client_frame::Body::BlockCoverage(req) => {
                         spawn_session_block_coverage(
+                            id,
+                            req,
+                            cfg.clone(),
+                            out_tx.clone(),
+                            cancels.clone(),
+                        )
+                        .await;
+                    }
+
+                    client_frame::Body::StorageDiscovery(req) => {
+                        spawn_session_storage_discovery(
                             id,
                             req,
                             cfg.clone(),
@@ -890,6 +902,256 @@ fn build_coverage_update(
     }
 }
 
+/// Default cadence for storage-discovery subscriptions.
+///
+/// Much slower than block coverage: a round dials every advertised node,
+/// and VPK records are re-announced on a ~120 s cycle, so polling faster
+/// spends real network work to observe a registry that has not moved.
+const DEFAULT_STORAGE_INTERVAL_SECS: u64 = 30;
+
+/// How long a single node's health probe may take before it counts as
+/// unreachable.
+///
+/// Probes run concurrently, so this bounds the whole probe phase rather
+/// than each node in sequence — the wall-clock cost of a round is one
+/// timeout, not one per unreachable node.
+const STORAGE_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Serve a `storage_discovery` op within a Session: look up the VPK node
+/// registry in the DHT, emit it immediately, then probe each node's
+/// reachability and emit the resolved snapshot.
+///
+/// Each round sends two updates because the two halves have very
+/// different latencies — the DHT answers in about a second, while probing
+/// nodes that will never answer costs a full timeout. Emitting the
+/// registry first lets a client show the node list while reachability is
+/// still resolving.
+async fn spawn_session_storage_discovery(
+    id: u64,
+    req: StorageDiscoveryRequest,
+    cfg: Arc<KwaaiNetConfig>,
+    out_tx: mpsc::Sender<Result<ServerFrame, Status>>,
+    cancels: Arc<Mutex<HashMap<u64, oneshot::Sender<()>>>>,
+) {
+    // Registered up-front so a Cancel arriving immediately after this
+    // frame still finds an entry to fire.
+    let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+    cancels.lock().await.insert(id, cancel_tx);
+
+    let cancels_for_cleanup = cancels.clone();
+    tokio::spawn(async move {
+        use std::time::Duration;
+
+        let interval = if req.interval_secs > 0 {
+            req.interval_secs as u64
+        } else {
+            DEFAULT_STORAGE_INTERVAL_SECS
+        };
+
+        // As with block coverage, the gRPC server binds before p2pd is
+        // up, so the connection is established lazily: a one-shot fails
+        // fast, a subscription retries on the next tick.
+        let mut discovery: Option<(kwaai_p2p_daemon::P2PClient, libp2p::PeerId, Vec<String>)> =
+            None;
+
+        loop {
+            if discovery.is_none() {
+                match crate::shard_cmd::connect_for_discovery(&cfg).await {
+                    Ok(conn) => discovery = Some(conn),
+                    Err(e) if !req.subscribe => {
+                        let _ = out_tx
+                            .send(Ok(error_frame(
+                                id,
+                                ErrorCode::Unavailable,
+                                &format!("{e:#}"),
+                            )))
+                            .await;
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::debug!(id, "storage discovery: p2pd not reachable yet: {e:#}");
+                    }
+                }
+            }
+
+            let mut client_died = false;
+
+            if let Some((client, our_peer_id, bootstrap_peers)) = discovery.as_mut() {
+                match crate::vpk::discover_nodes(client, our_peer_id, bootstrap_peers).await {
+                    Ok(entries) => {
+                        let mut peers = build_storage_peers(&cfg, &entries);
+
+                        // Phase 1 — the registry, as advertised. Skipped
+                        // when probing is off: there is no second update
+                        // coming, so `probes_pending` would be a lie.
+                        if !req.skip_probes {
+                            let frame = ServerFrame {
+                                id,
+                                body: Some(server_frame::Body::Storage(StorageUpdate {
+                                    server_time: now_rfc3339(),
+                                    probes_pending: true,
+                                    peers: peers.clone(),
+                                })),
+                            };
+                            if out_tx.send(Ok(frame)).await.is_err() {
+                                break; // client went away
+                            }
+
+                            probe_storage_peers(client, &mut peers).await;
+                        }
+
+                        let frame = ServerFrame {
+                            id,
+                            body: Some(server_frame::Body::Storage(StorageUpdate {
+                                server_time: now_rfc3339(),
+                                probes_pending: false,
+                                peers,
+                            })),
+                        };
+                        if out_tx.send(Ok(frame)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        // The p2pd handle may be stale (daemon restarted);
+                        // drop it so the next tick reconnects.
+                        client_died = true;
+                        if !req.subscribe {
+                            let _ = out_tx
+                                .send(Ok(error_frame(
+                                    id,
+                                    ErrorCode::Unavailable,
+                                    &format!("{e:#}"),
+                                )))
+                                .await;
+                            break;
+                        }
+                        tracing::debug!(id, "storage discovery round failed: {e:#}");
+                    }
+                }
+
+                if !req.subscribe {
+                    let _ = out_tx.send(Ok(done_frame(id))).await;
+                    break;
+                }
+            }
+
+            if client_died {
+                discovery = None;
+            }
+
+            tokio::select! {
+                _ = &mut cancel_rx => {
+                    let _ = out_tx
+                        .send(Ok(error_frame(
+                            id,
+                            ErrorCode::Cancelled,
+                            "cancelled by client",
+                        )))
+                        .await;
+                    break;
+                }
+                _ = tokio::time::sleep(Duration::from_secs(interval)) => {}
+            }
+        }
+
+        cancels_for_cleanup.lock().await.remove(&id);
+    });
+}
+
+/// Convert decoded DHT advertisements into wire peers, enriching each
+/// with its local reputation score/tier when enabled.
+///
+/// Sorted by name then peer id so a client's row order is stable across
+/// rounds — the DHT returns entries in whatever order responders
+/// answered in.
+fn build_storage_peers(
+    cfg: &KwaaiNetConfig,
+    entries: &[crate::vpk::VpkNodeEntry],
+) -> Vec<StoragePeer> {
+    let rep_store = if cfg.reputation.enabled {
+        Some(crate::reputation::ReputationStore::load())
+    } else {
+        None
+    };
+
+    let mut peers: Vec<StoragePeer> = entries
+        .iter()
+        .map(|e| {
+            let (trust_score, trust_tier) = match rep_store.as_ref() {
+                Some(store) => {
+                    let s = store.score(&e.peer_id);
+                    (s.score, s.tier.as_str().to_string())
+                }
+                None => (0.0, String::new()),
+            };
+            StoragePeer {
+                peer_id: e.peer_id.clone(),
+                public_name: e.public_name.clone(),
+                mode: e.mode.clone(),
+                vpk_version: e.vpk_version.clone(),
+                capacity_gb: e.capacity_gb,
+                tenant_count: e.tenant_count,
+                reachability: StorageReachability::Unknown as i32,
+                capacity_gb_free: 0.0,
+                trust_score,
+                trust_tier,
+            }
+        })
+        .collect();
+
+    peers.sort_by(|a, b| {
+        a.public_name
+            .cmp(&b.public_name)
+            .then_with(|| a.peer_id.cmp(&b.peer_id))
+    });
+    peers
+}
+
+/// Probe every peer's storage health concurrently, filling in
+/// `reachability` and `capacity_gb_free` in place.
+///
+/// Unlike the CLI's serial loop, the probes are issued together: a round
+/// then costs about one timeout rather than one per unreachable node,
+/// which matters because unreachable nodes are the common case on a
+/// NAT-heavy network.
+async fn probe_storage_peers(client: &kwaai_p2p_daemon::P2PClient, peers: &mut [StoragePeer]) {
+    let probes = peers.iter().map(|peer| {
+        let parsed = peer.peer_id.parse::<libp2p::PeerId>();
+        async move {
+            let Ok(pid) = parsed else {
+                // An unparseable id can never be dialled, so this is a
+                // permanent negative rather than a probe failure.
+                return None;
+            };
+            tokio::time::timeout(
+                STORAGE_PROBE_TIMEOUT,
+                crate::storage_rpc::rpc_health(client, &pid),
+            )
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+        }
+    });
+
+    let results = futures::future::join_all(probes).await;
+
+    for (peer, health) in peers.iter_mut().zip(results) {
+        match health {
+            Some(h) => {
+                peer.reachability = StorageReachability::Reachable as i32;
+                peer.capacity_gb_free = h.capacity_gb_available;
+                // The health reply is live; the DHT record may be up to
+                // an announce cycle stale, so prefer the probe.
+                peer.tenant_count = h.tenant_count.max(0) as u32;
+            }
+            None => {
+                peer.reachability = StorageReachability::Unreachable as i32;
+            }
+        }
+    }
+}
+
 /// Free-function variant of `KwaaiNetService::get_or_init_inference` so
 /// session worker tasks can call it without holding a `&self` borrow.
 async fn get_or_init_inference(
@@ -1485,6 +1747,52 @@ mod tests {
         assert_eq!(update.covered_blocks, 8);
         assert!(update.full_coverage);
         assert_eq!(update.peers[1].end_block, 12);
+    }
+
+    #[test]
+    fn storage_peers_start_unprobed_and_sort_stably() {
+        let mut cfg = KwaaiNetConfig::default();
+        // Keep the test hermetic: enabled reputation would read the real
+        // user's on-disk ReputationStore.
+        cfg.reputation.enabled = false;
+
+        let entry = |name: &str, peer: &str, cap: f64| crate::vpk::VpkNodeEntry {
+            peer_id: peer.into(),
+            mode: "eve".into(),
+            capacity_gb: cap,
+            tenant_count: 2,
+            vpk_version: "0.5.0".into(),
+            public_name: name.into(),
+        };
+
+        // Deliberately out of order — the DHT returns entries in whatever
+        // order responders answered in.
+        let peers = build_storage_peers(
+            &cfg,
+            &[
+                entry("metro", "12D3KooWZ", 48.3),
+                entry("arach", "12D3KooWA", 34.5),
+                entry("metro", "12D3KooWB", 1.0),
+            ],
+        );
+
+        // Name first, peer id as the tie-break.
+        let order: Vec<&str> = peers.iter().map(|p| p.peer_id.as_str()).collect();
+        assert_eq!(order, ["12D3KooWA", "12D3KooWB", "12D3KooWZ"]);
+
+        // Nothing has been probed yet, so every row must read as pending
+        // rather than as unreachable, and free capacity is not yet known.
+        for p in &peers {
+            assert_eq!(p.reachability, StorageReachability::Unknown as i32);
+            assert_eq!(p.capacity_gb_free, 0.0);
+        }
+
+        // Advertised values survive verbatim; trust stays empty while the
+        // reputation system is off.
+        assert_eq!(peers[0].capacity_gb, 34.5);
+        assert_eq!(peers[0].tenant_count, 2);
+        assert_eq!(peers[0].mode, "eve");
+        assert!(peers[0].trust_tier.is_empty());
     }
 
     #[test]

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1467,6 +1467,7 @@ mod tests {
             public_name: "peer".into(),
             throughput: 1.0,
             trust_score: None,
+            lease_v1: false,
         };
 
         // Gap at block 3: [0,3) + [4,8).

--- a/core/crates/kwaai-cli/src/vpk.rs
+++ b/core/crates/kwaai-cli/src/vpk.rs
@@ -195,74 +195,7 @@ async fn discover(json_output: bool) -> Result<()> {
         cfg.initial_peers.clone()
     };
 
-    // Build the FIND request for the VPK nodes registry key.
-    // Python Hivemind validates that every node_id is a 20-byte DHTID (SHA1-range).
-    // Raw PeerId bytes are 38+ bytes and fail that check, so we SHA1 them first —
-    // same as DHTID.generate(peer_id.to_bytes()) in Python.
-    let key = vpk_dht_id("_kwaai.vpk.nodes");
-    let our_dhtid = Sha1::new()
-        .chain_update(peer_id.to_bytes())
-        .finalize()
-        .to_vec();
-    let find_req = FindRequest {
-        auth: Some(RequestAuthInfo::new()),
-        keys: vec![key],
-        peer: Some(NodeInfo { node_id: our_dhtid }),
-    };
-    let mut req_bytes = Vec::new();
-    find_req.encode(&mut req_bytes)?;
-
-    // Query each bootstrap peer; deduplicate results by peer_id.
-    let mut found: Vec<VpkNodeEntry> = Vec::new();
-
-    for addr in &bootstrap_peers {
-        let Some(peer_id_str) = addr.split("/p2p/").nth(1) else {
-            continue;
-        };
-        let bp = match peer_id_str.parse::<PeerId>() {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        if client.connect_peer(addr).await.is_err() {
-            continue;
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        let resp_bytes = match client
-            .call_unary_handler(&bp.to_bytes(), "DHTProtocol.rpc_find", &req_bytes)
-            .await
-        {
-            Ok(b) => b,
-            Err(_) => continue,
-        };
-
-        let Ok(resp) = FindResponse::decode(&resp_bytes[..]) else {
-            continue;
-        };
-
-        for result in resp.results {
-            let rt = result.result_type;
-            if result.value.is_empty() {
-                continue;
-            }
-            // FoundRegular = 1 (our Rust DHTStorage or single-entry bootstrap)
-            // FoundDictionary = 2 (Python Hivemind bootstrap with multiple nodes)
-            if rt == 1 {
-                if let Some(entry) = parse_vpk_regular(&result.value) {
-                    if !found.iter().any(|e| e.peer_id == entry.peer_id) {
-                        found.push(entry);
-                    }
-                }
-            } else if rt == 2 {
-                parse_vpk_dictionary(&result.value, &mut found);
-            }
-        }
-    }
-
-    // Remove the local node — dialling self is always rejected by p2pd.
-    let local_b58 = peer_id.to_string();
-    found.retain(|e| e.peer_id != local_b58);
+    let found = discover_nodes(&mut client, &peer_id, &bootstrap_peers).await?;
 
     if found.is_empty() {
         if json_output {
@@ -581,14 +514,101 @@ fn vpk_dht_id(raw_key: &str) -> Vec<u8> {
     Sha1::new().chain_update(&packed).finalize().to_vec()
 }
 
+/// DHT key under which VPK-capable nodes advertise themselves.
+pub const VPK_NODES_DHT_KEY: &str = "_kwaai.vpk.nodes";
+
+/// Query the bootstrap peers for the VPK node registry.
+///
+/// Shared by `kwaainet vpk discover` and the gRPC `storage_discovery`
+/// op so both see the same registry. Results are deduplicated by peer
+/// id, and the local node is removed — p2pd always rejects dialling
+/// self, so leaving it in would guarantee one bogus "unreachable" row.
+///
+/// Individual bootstrap failures are skipped rather than propagated:
+/// one unreachable bootstrap should not blank out a registry the other
+/// can still answer for.
+pub async fn discover_nodes(
+    client: &mut P2PClient,
+    our_peer_id: &PeerId,
+    bootstrap_peers: &[String],
+) -> Result<Vec<VpkNodeEntry>> {
+    // Python Hivemind validates that every node_id is a 20-byte DHTID (SHA1-range).
+    // Raw PeerId bytes are 38+ bytes and fail that check, so we SHA1 them first —
+    // same as DHTID.generate(peer_id.to_bytes()) in Python.
+    let key = vpk_dht_id(VPK_NODES_DHT_KEY);
+    let our_dhtid = Sha1::new()
+        .chain_update(our_peer_id.to_bytes())
+        .finalize()
+        .to_vec();
+    let find_req = FindRequest {
+        auth: Some(RequestAuthInfo::new()),
+        keys: vec![key],
+        peer: Some(NodeInfo { node_id: our_dhtid }),
+    };
+    let mut req_bytes = Vec::new();
+    find_req.encode(&mut req_bytes)?;
+
+    let mut found: Vec<VpkNodeEntry> = Vec::new();
+
+    for addr in bootstrap_peers {
+        let Some(peer_id_str) = addr.split("/p2p/").nth(1) else {
+            continue;
+        };
+        let bp = match peer_id_str.parse::<PeerId>() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        if client.connect_peer(addr).await.is_err() {
+            continue;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let resp_bytes = match client
+            .call_unary_handler(&bp.to_bytes(), "DHTProtocol.rpc_find", &req_bytes)
+            .await
+        {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+
+        let Ok(resp) = FindResponse::decode(&resp_bytes[..]) else {
+            continue;
+        };
+
+        for result in resp.results {
+            let rt = result.result_type;
+            if result.value.is_empty() {
+                continue;
+            }
+            // FoundRegular = 1 (our Rust DHTStorage or single-entry bootstrap)
+            // FoundDictionary = 2 (Python Hivemind bootstrap with multiple nodes)
+            if rt == 1 {
+                if let Some(entry) = parse_vpk_regular(&result.value) {
+                    if !found.iter().any(|e| e.peer_id == entry.peer_id) {
+                        found.push(entry);
+                    }
+                }
+            } else if rt == 2 {
+                parse_vpk_dictionary(&result.value, &mut found);
+            }
+        }
+    }
+
+    let local_b58 = our_peer_id.to_string();
+    found.retain(|e| e.peer_id != local_b58);
+
+    Ok(found)
+}
+
 /// A decoded VPK node advertisement from the DHT.
-struct VpkNodeEntry {
-    peer_id: String,
-    mode: String,
-    capacity_gb: f64,
-    tenant_count: u32,
-    vpk_version: String,
-    public_name: String,
+pub struct VpkNodeEntry {
+    pub peer_id: String,
+    pub mode: String,
+    pub capacity_gb: f64,
+    pub tenant_count: u32,
+    pub vpk_version: String,
+    pub public_name: String,
 }
 
 /// Decode a FoundRegular value (direct msgpack VPK map) into a VpkNodeEntry.

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -85,6 +85,12 @@ message ClientFrame {
         // Done); a live feed when true (a BlockCoverageUpdate every
         // refresh interval until cancelled with a `Cancel` body).
         BlockCoverageRequest block_coverage = 15;
+
+        // VPK storage-node discovery. Like block_coverage, but for the
+        // `_kwaai.vpk.nodes` DHT registry. Note that even a one-shot
+        // request yields *two* StorageUpdate replies — see
+        // StorageUpdate.probes_pending.
+        StorageDiscoveryRequest storage_discovery = 16;
     }
 }
 
@@ -116,6 +122,11 @@ message ServerFrame {
         // one-shot BlockCoverageRequest; a subscription delivers one
         // per refresh interval until the op is cancelled.
         BlockCoverageUpdate block_coverage = 15;
+
+        // Snapshot of discovered VPK storage nodes. Arrives in pairs
+        // per discovery round: one with probes_pending set, then one
+        // with reachability resolved.
+        StorageUpdate storage = 16;
     }
 }
 
@@ -314,6 +325,107 @@ message BlockCoverageUpdate {
 
     // All discovered block servers, sorted by start_block.
     repeated BlockPeer peers = 7;
+}
+
+// `kwaainet vpk discover` — VPK storage nodes from the DHT.
+message StorageDiscoveryRequest {
+    // When true the operation stays open and the server runs a fresh
+    // discovery round every `interval_secs` until the client sends a
+    // Cancel body for this op id. When false a single round runs and
+    // the op ends with Done.
+    bool subscribe = 1;
+
+    // Discovery cadence for subscriptions, in seconds. 0 means the
+    // server default (30s). Ignored when `subscribe` is false.
+    //
+    // Slower than block coverage by default: each round dials every
+    // advertised node, so a tight interval spends real network work to
+    // observe a registry that only changes on the ~120s announce cycle.
+    uint32 interval_secs = 2;
+
+    // Skip the reachability probes and report DHT records only. Yields
+    // a single StorageUpdate per round with every peer left UNKNOWN,
+    // for callers that just want the advertised registry cheaply.
+    bool skip_probes = 3;
+}
+
+// Whether a discovered node answered a storage RPC.
+//
+// Reachability is a property of *this* node's route to the peer, not of
+// the peer itself: a node behind a NAT that we cannot traverse is
+// unreachable from here and fine from elsewhere.
+enum StorageReachability {
+    // Not probed yet. Every peer holds this in the first update of a
+    // round, and keeps it for the whole round when `skip_probes` is set.
+    STORAGE_REACHABILITY_UNKNOWN = 0;
+
+    // Answered a /kwaai/storage/1.0.0 health RPC. `capacity_gb_free`
+    // and `tenant_count` on this peer are live values from that reply.
+    STORAGE_REACHABILITY_REACHABLE = 1;
+
+    // Advertised in the DHT but did not answer — offline, or running a
+    // build without the storage protocol.
+    STORAGE_REACHABILITY_UNREACHABLE = 2;
+}
+
+// One VPK-capable node, as advertised in the DHT and (optionally)
+// confirmed by a live health probe.
+message StoragePeer {
+    // libp2p peer id, base58.
+    string peer_id = 1;
+
+    // Human-readable name the node announced (may be empty).
+    string public_name = 2;
+
+    // VPK role: "bob" (client), "eve" (server), or "both".
+    string mode = 3;
+
+    // VPK version string the node announced (may be empty).
+    string vpk_version = 4;
+
+    // Capacity the node advertised in its DHT record, in GB. Always
+    // present — this is what the registry claims.
+    double capacity_gb = 5;
+
+    // Tenants the node advertised in its DHT record.
+    uint32 tenant_count = 6;
+
+    // Whether this node answered a health probe this round.
+    StorageReachability reachability = 7;
+
+    // Free capacity in GB, from the health probe. Only meaningful when
+    // `reachability` is REACHABLE; 0 otherwise.
+    double capacity_gb_free = 8;
+
+    // Local reputation score in [0, 1]. Only meaningful when
+    // `trust_tier` is non-empty.
+    double trust_score = 9;
+
+    // Trust tier label ("UNKNOWN" / "KNOWN" / "VERIFIED" / "TRUSTED").
+    // Empty when the local reputation system is disabled.
+    string trust_tier = 10;
+}
+
+// Snapshot of the VPK storage nodes visible from this daemon.
+//
+// A discovery round emits two of these: the first as soon as the DHT
+// answers (`probes_pending` true, every peer UNKNOWN), the second once
+// the health probes resolve. The DHT lookup is fast and the probes are
+// not — splitting them lets a client render the registry immediately
+// rather than holding a blank view until the slowest dial times out.
+message StorageUpdate {
+    // Daemon wall-clock time of this snapshot, RFC 3339.
+    string server_time = 1;
+
+    // True on the first update of a round: the peer list is complete
+    // but reachability is still resolving, so a client should show the
+    // rows in a pending state rather than as unreachable. Always false
+    // when `skip_probes` was set — nothing is pending in that case.
+    bool probes_pending = 2;
+
+    // All discovered nodes, sorted by public_name then peer_id so the
+    // ordering is stable across rounds.
+    repeated StoragePeer peers = 3;
 }
 
 // =====================================================================

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -87,8 +87,8 @@ message ClientFrame {
         BlockCoverageRequest block_coverage = 15;
 
         // VPK storage-node discovery. Like block_coverage, but for the
-        // `_kwaai.vpk.nodes` DHT registry. Note that even a one-shot
-        // request yields *two* StorageUpdate replies — see
+        // `_kwaai.vpk.nodes` DHT registry. Note that a one-shot request
+        // yields *two* StorageUpdate replies before Done — see
         // StorageUpdate.probes_pending.
         StorageDiscoveryRequest storage_discovery = 16;
     }
@@ -408,19 +408,29 @@ message StoragePeer {
 
 // Snapshot of the VPK storage nodes visible from this daemon.
 //
-// A discovery round emits two of these: the first as soon as the DHT
-// answers (`probes_pending` true, every peer UNKNOWN), the second once
-// the health probes resolve. The DHT lookup is fast and the probes are
-// not — splitting them lets a client render the registry immediately
-// rather than holding a blank view until the slowest dial times out.
+// The first discovery round emits two of these: one as soon as the DHT
+// answers (`probes_pending` true, every peer UNKNOWN), and one once the
+// health probes resolve. The DHT lookup is fast and the probes are not —
+// splitting them lets a client render the registry immediately rather
+// than holding a blank view until the slowest dial times out.
+//
+// Subsequent rounds emit at most one update, and only when something
+// actually changed: re-sending the pending phase would throw a client's
+// status column back to "checking" every round, and an unchanged
+// resolved snapshot is suppressed. A client should therefore treat
+// silence as "nothing has changed", not as a stalled feed — an unchanged
+// snapshot is still sent periodically as a heartbeat, so a feed that
+// goes quiet for much longer than the discovery interval is genuinely
+// wedged.
 message StorageUpdate {
     // Daemon wall-clock time of this snapshot, RFC 3339.
     string server_time = 1;
 
-    // True on the first update of a round: the peer list is complete
-    // but reachability is still resolving, so a client should show the
-    // rows in a pending state rather than as unreachable. Always false
-    // when `skip_probes` was set — nothing is pending in that case.
+    // True on the pending update that opens the *first* round: the peer
+    // list is complete but reachability is still resolving, so a client
+    // should show the rows in a pending state rather than as
+    // unreachable. Never set on later rounds, and never when
+    // `skip_probes` was set.
     bool probes_pending = 2;
 
     // All discovered nodes, sorted by public_name then peer_id so the


### PR DESCRIPTION
Exposes `kwaainet vpk discover` as a Session op, so a client can show which VPK storage nodes the network has, how much capacity they advertise, and which of them the local node can actually reach.

### Stacked on #75 — please merge that first

This branch builds on `feat/block-coverage` and **includes its three commits**. The two features touch the same code by nature: adjacent arms in the same two `oneof`s, a shared `HEARTBEAT`, and `storage_identity` sitting alongside `coverage_identity`. Rebasing storage onto `main` alone would mean writing a standalone variant of that shared machinery and then unwinding it when #75 lands, so this deliberately depends on #75 rather than duplicating it.

Once #75 merges this diff reduces to its own two commits:

- `feat(rpc): storage-node discovery over the Session stream`
- `feat(rpc): suppress unchanged storage-discovery updates`

## Two-phase first round

The DHT lookup is fast; confirming reachability means dialling every advertised node, and on a NAT-heavy network most of those dials run to a timeout. The first round therefore emits the registry immediately and the resolved snapshot once probes land, so a client renders the node list instead of holding a blank view. Measured against the live network:

```
[1.19s] probes_pending=true   9 peers, 229.5 GB advertised, all UNKNOWN
[1.41s] probes_pending=false  3 reachable / 6 unreachable, 82.3 GB reachable
```

`skip_probes` opts out for callers that only want the advertised registry, and suppresses the pending update — nothing is pending in that case, so `probes_pending` would be a lie.

## Diffing

Later rounds send at most one update, and usually none. The pending phase runs only on the first round: re-announcing every peer as unprobed would throw a client's status column back to "checking" on a table that is already correct. Resolved snapshots are then diffed, as block coverage already does, with an unchanged snapshot every `HEARTBEAT` so silence stays unambiguous.

Over 75 s at a 5 s interval (deliberately tighter than the 30 s default, to force the issue) this sends 3 updates where the naive version sent ~26:

```
[ 1.21s] pending=true   9 peers, all unknown
[ 2.62s] pending=false  3 reachable, 82.3 GB
[67.14s] pending=false  3 reachable, 82.3 GB   (heartbeat)
```

## Probing

Probes run concurrently rather than serially as the CLI does, so a round costs about one timeout instead of one per unreachable node — 1.5 s here against the CLI's ~5 s for the same 9 nodes. Where a probe succeeds its live tenant count replaces the advertised one, since the DHT record can be a full announce cycle stale.

Subscriptions default to 30 s rather than block coverage's 5 s: VPK records are re-announced on a ~120 s cycle, so polling faster spends a dial per node per round to observe a registry that has not moved.

## Shared DHT query

The DHT query is extracted out of the CLI's `discover()` and shared with the new op, so the two paths cannot drift on how records are decoded or which entries are filtered out (dedup by peer id, and dropping self — p2pd always rejects dialling self, so leaving it in would guarantee one bogus "unreachable" row). Verified behaviour-preserving: `kwaainet vpk discover --json` returns the same 9 nodes as before the refactor.

## Wire compatibility

New fields only, with explicit numbers: `ClientFrame.storage_discovery = 16`, `ServerFrame.storage = 16`. Nothing existing changes.

## Testing

- `cargo test -p kwaainet --bin kwaainet` — 59 passed (2 grpc bind tests fail locally only when a daemon already holds port 8093)
- `cargo clippy` / `cargo fmt --check` clean
- Live-network verification against a running daemon, as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)