### PR TITLE
feat(config): make UPnP port mapping configurable

### DIFF
--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -287,6 +287,7 @@ pub enum ConfigAction {
     /// Valid keys:
     ///   model, blocks, start_block, port, use_gpu, log_level,
     ///   public_name, public_ip, announce_addr, no_relay, native_p2p,
+    ///   enable_upnp,
     ///   vpk_enabled, vpk_mode, vpk_local_port,
     ///   auto_rebalance, rebalance_interval_secs, rebalance_min_redundancy
     ///

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -142,6 +142,19 @@ pub struct KwaaiNetConfig {
     /// lands and the cutover in Phase 5 flips it.
     #[serde(default)]
     pub native_p2p: bool,
+    /// Ask the local gateway to map our listen port via UPnP/IGD
+    /// (`-natPortMap`).
+    ///
+    /// On by default, which is the behaviour this replaces — the flag was
+    /// previously passed unconditionally. Turning it off is how you get a
+    /// genuinely NATed node without touching router settings, which makes the
+    /// relay and hole-punch paths testable; it also lets an operator decline
+    /// to have the node ask the router to open ports at all.
+    ///
+    /// Takes effect at startup, since the mapping is requested when the daemon
+    /// launches. Changing it needs a restart.
+    #[serde(default = "default_enable_upnp")]
+    pub enable_upnp: bool,
 
     #[serde(default)]
     pub health_monitoring: HealthConfig,
@@ -577,6 +590,9 @@ fn default_trusted_relays() -> Vec<String> {
 fn default_force_private() -> bool {
     true
 }
+fn default_enable_upnp() -> bool {
+    true
+}
 fn default_api_endpoint() -> String {
     "https://map.kwaai.ai/api/v1/state".to_string()
 }
@@ -651,6 +667,7 @@ impl Default for KwaaiNetConfig {
             trusted_relays: default_trusted_relays(),
             force_private: default_force_private(),
             native_p2p: false,
+            enable_upnp: default_enable_upnp(),
             health_monitoring: HealthConfig::default(),
             model_dht_prefix: None,
             model_repository: None,
@@ -870,6 +887,7 @@ impl KwaaiNetConfig {
             "announce_addr" => self.announce_addr = Some(value.to_string()),
             "no_relay" => self.no_relay = parse_bool(value)?,
             "native_p2p" => self.native_p2p = parse_bool(value)?,
+            "enable_upnp" => self.enable_upnp = parse_bool(value)?,
             "start_block" => {
                 self.start_block = value
                     .parse()

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1467,6 +1467,7 @@ mod tests {
             public_name: "peer".into(),
             throughput: 1.0,
             trust_score: None,
+            lease_v1: false,
         };
 
         // Gap at block 3: [0,3) + [4,8).

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -229,7 +229,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
         // Pre-declaring private blocks AutoNAT from ever promoting the node
         // to public, even if it actually is. Only honour an explicit opt-in.
         .force_reachability_private(config.force_private)
-        .nat_portmap(true)
+        .nat_portmap(config.enable_upnp)
         .host_addrs([host_addr.clone()])
         .bootstrap_peers(bootstrap_peers.clone())
         .trusted_relays(trusted_relays.clone())
@@ -426,6 +426,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             &p2pd_path,
             &handler_addr,
             config.no_relay,
+            config.enable_upnp,
             config.port,
             config.identify_min_confirmations,
             config.identify_timeout_secs,
@@ -732,6 +733,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                             &mut daemon, &mut client, new_addrs,
                             &host_addr, &bootstrap_peers, &identity_key_path,
                             &p2pd_path, &handler_addr, config.no_relay,
+                            config.enable_upnp,
                         ).await {
                             warn!("Deferred p2pd restart failed: {}", e);
                         } else {
@@ -1384,6 +1386,7 @@ async fn restart_p2pd_with_addrs(
     p2pd_path: &Option<std::path::PathBuf>,
     handler_addr: &std::net::SocketAddr,
     no_relay: bool,
+    enable_upnp: bool,
 ) -> anyhow::Result<()> {
     let handler_addr_str = format!("/ip4/127.0.0.1/tcp/{}", handler_addr.port());
     let dht_protocols = vec![
@@ -1407,7 +1410,7 @@ async fn restart_p2pd_with_addrs(
         .relay(!no_relay)
         .auto_relay(true)
         .auto_nat(true)
-        .nat_portmap(true)
+        .nat_portmap(enable_upnp)
         .host_addrs([host_addr])
         .bootstrap_peers(bootstrap_peers.to_vec())
         .announce_addrs(announce_addrs.iter().map(|s| s.as_str()))
@@ -1524,6 +1527,7 @@ async fn discover_and_restart_with_announce(
     p2pd_path: &Option<std::path::PathBuf>,
     handler_addr: &std::net::SocketAddr,
     no_relay: bool,
+    enable_upnp: bool,
     port: u16,
     min_confirmations: usize,
     timeout_secs: u64,
@@ -1551,6 +1555,7 @@ async fn discover_and_restart_with_announce(
             p2pd_path,
             handler_addr,
             no_relay,
+            enable_upnp,
         )
         .await?;
         return Ok((daemon, client, cached));
@@ -1595,6 +1600,7 @@ async fn discover_and_restart_with_announce(
         p2pd_path,
         handler_addr,
         no_relay,
+        enable_upnp,
     )
     .await?;
 
@@ -2438,7 +2444,7 @@ async fn restart_p2pd(
         .auto_relay(true)
         .auto_nat(true)
         .force_reachability_private(config.force_private)
-        .nat_portmap(true)
+        .nat_portmap(config.enable_upnp)
         .host_addrs([host_addr])
         .bootstrap_peers(bootstrap_peers.to_vec())
         .trusted_relays(config.trusted_relays.clone())


### PR DESCRIPTION
`-natPortMap` was passed unconditionally at all three p2pd launch sites, so a node had no way to decline asking the router to open a port.

`enable_upnp` defaults to `true`, so no existing node changes behaviour on upgrade.

## Why

Turning it off is the supported way to get a genuinely NATed node without touching router settings, which makes the relay and hole-punch paths testable. It also lets an operator opt out of port mapping entirely.

The distinction matters more than it might look. While investigating DCUtR behaviour on a live node, UPnP started succeeding partway through a session — the node moved from `Private`/relay-dependent to `Public` on its own, which silently changed which code paths it exercised. Being able to hold that fixed is the difference between testing NAT traversal and hoping the router cooperates.

## Changes

- `enable_upnp: bool` on `KwaaiNetConfig`, defaulting true
- Threaded to all three `.nat_portmap(...)` call sites in `node.rs`
- Passed explicitly through `restart_p2pd_with_addrs` and `discover_and_restart_with_announce`, matching how `no_relay` already travels to those sites
- Settable via `kwaainet config set enable_upnp false`; added to the documented key list

## Testing

- `kwaainet config set enable_upnp false` round-trips to `config.yaml`
- `cargo test -p kwaainet` passes; the two `grpc_server` failures are a pre-existing port-8093 conflict with a locally running daemon, present on `main` too

Takes effect at startup, since the mapping is requested when the daemon launches.