### PR TITLE
fix(kwaai-cli): log full error chain on auto-update install failure

### DIFF
--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -2402,7 +2402,7 @@ async fn maybe_auto_update() -> Option<String> {
     );
 
     if let Err(e) = checker.install_update(&update.version).await {
-        warn!("Auto-update install failed: {e}");
+        warn!("Auto-update install failed: {e:?}");
         return None;
     }
 


### PR DESCRIPTION
## Summary
- \`node.rs:2405\` logged \`{e}\` on auto-update install failure — anyhow's Display, which only prints the top-level context string ("Could not rename kwaainet.exe — is another process holding it?"), never the underlying OS error.
- At least 6 prior commits (\`0ff5abc\`, \`22aa3eb\`, \`77215e5\`, \`35b7ef9\`/\`daff4a7\`, \`7c57102\`, \`33c5015\`) have attempted to fix Windows auto-update rename failures, all working from that same static message — none of them ever saw the actual Win32 error code.
- Reproduced the rename step directly on real Windows hardware (full daemon, \`DETACHED_PROCESS\`, live \`p2pd\` child, exact same \`fs::rename\` call \`install_update()\` uses) and it succeeded every time — the \`FILE_SHARE_DELETE\` assumption in the code comment held up in this repro. So whatever actually caused the July 27 failure on this machine wasn't captured by any existing test or log line.
- Changed to \`{e:?}\` so the next real occurrence logs the full anyhow chain, including the real OS error, instead of the canned context string.

## Test plan
- [x] \`cargo build -p kwaainet --release\` — clean build, no new warnings from this change
- [x] Reproduced the rename call live against a copy of the real binary + real daemon process tree (see conversation) — confirmed the diff doesn't change success/failure behavior, only what gets logged on failure
- [ ] Next real Windows auto-update failure should be diagnosed from the actual logged error instead of guesswork

🤖 Generated with [Claude Code](https://claude.com/claude-code)