### PR TITLE
feat(hivemind-dht): hivemind unary wire codec + p2pd interop gate (native-p2p 1/7)

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3062,6 +3062,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -3111,6 +3112,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]

--- a/core/crates/kwaai-hivemind-dht/Cargo.toml
+++ b/core/crates/kwaai-hivemind-dht/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { workspace = true }
 rmp-serde = { workspace = true }  # MessagePack
 prost = { workspace = true }       # Protobuf
 bincode = { workspace = true }
+unsigned-varint = { workspace = true }  # uvarint framing on the hivemind unary wire
 
 # Error handling
 thiserror = { workspace = true }

--- a/core/crates/kwaai-hivemind-dht/proto/persistent_conn.proto
+++ b/core/crates/kwaai-hivemind-dht/proto/persistent_conn.proto
@@ -1,0 +1,85 @@
+syntax = "proto2";
+
+// Hivemind unary-RPC wrapper as it appears ON THE LIBP2P WIRE between peers.
+//
+// This is a minimal, wire-compatible subset of go-libp2p-daemon's `p2pd.proto`
+// (see `crates/kwaai-p2p-daemon/proto/p2pd.proto`, package `p2pd.pb`). Field
+// numbers and types are copied verbatim — do not renumber.
+//
+// The Go daemon (`persistent_stream.go`) drives the peer-to-peer exchange like
+// this:
+//
+//   Caller side (`Daemon.exchangeMessages`):
+//     1. `host.NewStream(peer, protocol.ID(proto))` — the libp2p protocol ID is
+//        the BARE handler name, no leading slash (e.g. `DHTProtocol.rpc_store`).
+//     2. Writes ONE uvarint-length-delimited `PersistentConnectionRequest`
+//        with `callId` + `callUnary{peer, proto, data}`. `data` is the raw
+//        application protobuf (StoreRequest / FindRequest / PingRequest).
+//     3. Reads ONE uvarint-delimited `PersistentConnectionRequest` back and
+//        takes `remoteResp.GetUnaryResponse()`.
+//     4. Stream closes.
+//
+//   Responder side (`Daemon.persistentStreamHandler`):
+//     Reads the `PersistentConnectionRequest`, overwrites
+//     `callUnary.peer` with the CALLER's peer ID (so a value set by the
+//     caller — as hivemind's Python client does — is ignored), dispatches to
+//     the registered handler, and writes back a `PersistentConnectionRequest`
+//     carrying `unaryResponse` (field 4).
+//
+// NOTE THE ASYMMETRY: the reply on the libp2p wire is a
+// `PersistentConnectionRequest` with the `unaryResponse` oneof arm set — NOT a
+// `PersistentConnectionResponse`. `PersistentConnectionResponse` exists only on
+// the daemon's local control socket. Encoding the reply as a
+// `PersistentConnectionResponse` makes Go callers fail to unmarshal, because
+// field 2 there is `CallUnaryResponse` while field 2 of
+// `PersistentConnectionRequest` is `AddUnaryHandlerRequest` — whose proto2
+// `required` fields are absent.
+//
+// This file documents the schema of record. The Rust types live in `src/wire.rs`
+// as hand-written `prost::Message` derives, matching how `src/protocol.rs`
+// mirrors `proto/dht.proto` (this crate has no build.rs / prost-build step).
+
+package p2pd.pb;
+
+// Written by the caller onto the libp2p stream, and — with the `unaryResponse`
+// arm — written back by the responder.
+message PersistentConnectionRequest {
+  required bytes callId = 1;
+
+  oneof message {
+    AddUnaryHandlerRequest addUnaryHandler = 2;
+    CallUnaryRequest  callUnary = 3;
+    CallUnaryResponse unaryResponse = 4;
+    Cancel cancel = 5;
+    RemoveUnaryHandlerRequest removeUnaryHandler = 6;
+  }
+}
+
+message CallUnaryRequest {
+  required bytes peer = 1;
+  required string proto = 2;
+  required bytes data = 3;
+}
+
+message CallUnaryResponse {
+  oneof result {
+    bytes response = 1;
+    bytes error = 2;
+  }
+}
+
+message AddUnaryHandlerRequest {
+  required string proto = 1;
+  required bool balanced = 2;
+}
+
+message RemoveUnaryHandlerRequest {
+  required string proto = 1;
+}
+
+message DaemonError {
+  optional string message = 1;
+}
+
+message Cancel {
+}

--- a/core/crates/kwaai-hivemind-dht/src/lib.rs
+++ b/core/crates/kwaai-hivemind-dht/src/lib.rs
@@ -16,6 +16,7 @@ pub mod error;
 pub mod protocol;
 pub mod server;
 pub mod value;
+pub mod wire;
 
 pub use client::HivemindDHT;
 pub use error::{Error, Result};

--- a/core/crates/kwaai-hivemind-dht/src/wire.rs
+++ b/core/crates/kwaai-hivemind-dht/src/wire.rs
@@ -1,0 +1,722 @@
+//! Hivemind unary-RPC wire codec (peer-to-peer, on the libp2p stream).
+//!
+//! Hivemind's "unary handler" abstraction is not a daemon-local convention: the
+//! wrapper travels **on the libp2p wire between peers**. A caller opens a stream
+//! whose protocol ID is the bare handler name — *no leading slash*, e.g.
+//! `DHTProtocol.rpc_store` — and then:
+//!
+//! ```text
+//! caller  ──▶  uvarint(len) ++ PersistentConnectionRequest{callId, callUnary{peer, proto, data}}
+//! caller  ◀──  uvarint(len) ++ PersistentConnectionRequest{callId, unaryResponse{response|error}}
+//! (stream closes)
+//! ```
+//!
+//! `data` is the raw application protobuf (`StoreRequest`, `FindRequest`,
+//! `PingRequest` from [`crate::protocol`]) — there is no extra framing around it.
+//!
+//! **The reply is a `PersistentConnectionRequest`, not a
+//! `PersistentConnectionResponse`.** `PersistentConnectionResponse` only exists
+//! on the daemon's local control socket. This is verified against
+//! go-libp2p-daemon `persistent_stream.go`: `Daemon.exchangeMessages` reads the
+//! reply into `&pb.PersistentConnectionRequest{}` and calls `GetUnaryResponse()`
+//! (field 4). Writing a `PersistentConnectionResponse` instead makes Go callers
+//! fail to unmarshal — its field 2 is `CallUnaryResponse`, whereas field 2 of
+//! `PersistentConnectionRequest` is `AddUnaryHandlerRequest`, a proto2 message
+//! with `required` fields that are then missing.
+//!
+//! Two further details copied from the Go responder
+//! (`Daemon.persistentStreamHandler`):
+//!
+//! - It overwrites `callUnary.peer` with the *caller's* peer ID before
+//!   dispatching. Whatever a caller puts there is ignored (hivemind's Python
+//!   client sets it; the Go daemon sets it to `[]byte{}`). We match the Go
+//!   caller and send an empty `peer`.
+//! - Inbound frames are capped by `persistentConnMsgMaxSize`; we mirror the
+//!   10 MiB cap in [`MAX_FRAME_LEN`].
+//!
+//! The schema of record is `proto/persistent_conn.proto`. As elsewhere in this
+//! crate (see [`crate::protocol`] vs `proto/dht.proto`) the Rust types are
+//! hand-written `prost` derives rather than generated — the crate has no
+//! build.rs and pulls no `prost-build`.
+//!
+//! Supersedes the framing in [`crate::codec`], which is not hivemind-compatible.
+
+use prost::Message;
+use std::io;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+/// Maximum accepted frame payload, matching the Go daemon's
+/// `persistentConnMsgMaxSize` (10 MiB). Frames declaring more are rejected
+/// without allocating.
+pub const MAX_FRAME_LEN: usize = 10 * 1024 * 1024;
+
+/// Longest uvarint that can encode a `u64` (10 groups of 7 bits).
+const MAX_VARINT_LEN: usize = 10;
+
+// ============================================================================
+// Wire messages (subset of p2pd.pb, see proto/persistent_conn.proto)
+// ============================================================================
+
+/// `p2pd.pb.CallUnaryRequest` — the outbound half of a unary call.
+///
+/// All three fields are proto2 `required`, and Go *enforces* that on
+/// unmarshal: a frame missing any of them is dropped and the stream reset. The
+/// `required` labels below make prost encode them unconditionally — a plain
+/// prost field is silently omitted when empty, which Go rejects (verified
+/// against a real p2pd in `07_wire_interop`).
+#[derive(Clone, PartialEq, Message)]
+pub struct CallUnaryRequest {
+    /// Callee peer ID on the way out (Go's caller sets it to the dial target).
+    /// On the *unary-handler dispatch path* the responding daemon overwrites it
+    /// with the caller's peer ID; on a raw stream handler nothing rewrites it,
+    /// so it arrives exactly as sent. Never trust it for caller identity.
+    #[prost(bytes = "vec", required, tag = "1")]
+    pub peer: Vec<u8>,
+    /// Bare handler name, no leading slash (e.g. `DHTProtocol.rpc_store`).
+    #[prost(string, required, tag = "2")]
+    pub proto: String,
+    /// Raw application protobuf.
+    #[prost(bytes = "vec", required, tag = "3")]
+    pub data: Vec<u8>,
+}
+
+/// `p2pd.pb.CallUnaryResponse` — the inbound half, a `response`/`error` oneof.
+#[derive(Clone, PartialEq, Message)]
+pub struct CallUnaryResponse {
+    #[prost(oneof = "call_unary_response::Result", tags = "1, 2")]
+    pub result: Option<call_unary_response::Result>,
+}
+
+pub mod call_unary_response {
+    /// `oneof result` of [`super::CallUnaryResponse`].
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Result {
+        /// Successful payload: raw application protobuf.
+        #[prost(bytes, tag = "1")]
+        Response(Vec<u8>),
+        /// Handler error. Go encodes `err.Error()` as UTF-8 bytes.
+        #[prost(bytes, tag = "2")]
+        Error(Vec<u8>),
+    }
+}
+
+/// `p2pd.pb.AddUnaryHandlerRequest`.
+///
+/// Present so that the oneof tag numbering matches the daemon's exactly (field
+/// 2). This arm never appears on the libp2p wire — it is a control-socket-only
+/// message.
+#[derive(Clone, PartialEq, Message)]
+pub struct AddUnaryHandlerRequest {
+    #[prost(string, required, tag = "1")]
+    pub proto: String,
+    #[prost(bool, required, tag = "2")]
+    pub balanced: bool,
+}
+
+/// `p2pd.pb.RemoveUnaryHandlerRequest`. Control-socket only; see above.
+#[derive(Clone, PartialEq, Message)]
+pub struct RemoveUnaryHandlerRequest {
+    #[prost(string, required, tag = "1")]
+    pub proto: String,
+}
+
+/// `p2pd.pb.Cancel` — empty marker message.
+#[derive(Clone, PartialEq, Message)]
+pub struct Cancel {}
+
+/// `p2pd.pb.DaemonError`.
+#[derive(Clone, PartialEq, Message)]
+pub struct DaemonError {
+    #[prost(string, optional, tag = "1")]
+    pub message: Option<String>,
+}
+
+/// `p2pd.pb.PersistentConnectionRequest` — the envelope in **both** directions
+/// on the libp2p wire.
+#[derive(Clone, PartialEq, Message)]
+pub struct PersistentConnectionRequest {
+    /// 16 raw UUID bytes in practice; Go does `uuid.FromBytes` and drops the
+    /// message when that fails. proto2 `required` — always encoded.
+    #[prost(bytes = "vec", required, tag = "1")]
+    pub call_id: Vec<u8>,
+    #[prost(
+        oneof = "persistent_connection_request::Message",
+        tags = "2, 3, 4, 5, 6"
+    )]
+    pub message: Option<persistent_connection_request::Message>,
+}
+
+pub mod persistent_connection_request {
+    /// `oneof message` of [`super::PersistentConnectionRequest`].
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Message {
+        #[prost(message, tag = "2")]
+        AddUnaryHandler(super::AddUnaryHandlerRequest),
+        #[prost(message, tag = "3")]
+        CallUnary(super::CallUnaryRequest),
+        #[prost(message, tag = "4")]
+        UnaryResponse(super::CallUnaryResponse),
+        #[prost(message, tag = "5")]
+        Cancel(super::Cancel),
+        #[prost(message, tag = "6")]
+        RemoveUnaryHandler(super::RemoveUnaryHandlerRequest),
+    }
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+/// Failure decoding or reading a hivemind unary frame.
+#[derive(Debug, thiserror::Error)]
+pub enum WireError {
+    /// The uvarint length prefix was malformed or longer than 10 bytes.
+    #[error("malformed uvarint length prefix")]
+    BadVarint,
+    /// The frame declared a length above [`MAX_FRAME_LEN`].
+    #[error("frame too large: {len} bytes (max {MAX_FRAME_LEN})")]
+    FrameTooLarge {
+        /// Declared payload length.
+        len: usize,
+    },
+    /// The payload was not a decodable `PersistentConnectionRequest`.
+    #[error("protobuf decode failed: {0}")]
+    Decode(#[from] prost::DecodeError),
+    /// A well-formed envelope carrying the wrong oneof arm (or none).
+    #[error("unexpected message: {0}")]
+    UnexpectedMessage(String),
+    /// Underlying I/O failure while reading a frame.
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+}
+
+/// Result alias for wire codec operations.
+pub type WireResult<T> = std::result::Result<T, WireError>;
+
+// ============================================================================
+// Framing
+// ============================================================================
+
+/// Prefix `payload` with its uvarint length.
+pub fn frame(payload: &[u8]) -> Vec<u8> {
+    let mut buf = unsigned_varint::encode::usize_buffer();
+    let prefix = unsigned_varint::encode::usize(payload.len(), &mut buf);
+    let mut out = Vec::with_capacity(prefix.len() + payload.len());
+    out.extend_from_slice(prefix);
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Split one uvarint-framed message off the front of `bytes`.
+///
+/// Returns the payload and the total number of bytes consumed (prefix +
+/// payload), so callers can advance through a buffer holding several frames.
+pub fn unframe(bytes: &[u8]) -> WireResult<(&[u8], usize)> {
+    let (len, rest) = unsigned_varint::decode::usize(bytes).map_err(|_| WireError::BadVarint)?;
+    if len > MAX_FRAME_LEN {
+        return Err(WireError::FrameTooLarge { len });
+    }
+    let prefix_len = bytes.len() - rest.len();
+    if rest.len() < len {
+        return Err(WireError::Io(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            format!(
+                "frame declares {} bytes, only {} available",
+                len,
+                rest.len()
+            ),
+        )));
+    }
+    Ok((&rest[..len], prefix_len + len))
+}
+
+/// Read exactly one uvarint-framed message from an async reader.
+///
+/// Reads the length prefix a byte at a time (it is 1–10 bytes and we must not
+/// over-consume into the payload), rejects lengths above [`MAX_FRAME_LEN`]
+/// *before* allocating, then `read_exact`s the payload — so partial reads of a
+/// large frame are handled by tokio rather than by us.
+pub async fn read_framed<R>(reader: &mut R) -> WireResult<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut varint_buf = [0u8; MAX_VARINT_LEN];
+    let mut n = 0usize;
+
+    loop {
+        if n == MAX_VARINT_LEN {
+            return Err(WireError::BadVarint);
+        }
+        reader.read_exact(&mut varint_buf[n..n + 1]).await?;
+        let is_last = varint_buf[n] & 0x80 == 0;
+        n += 1;
+        if is_last {
+            break;
+        }
+    }
+
+    let (len, _) =
+        unsigned_varint::decode::usize(&varint_buf[..n]).map_err(|_| WireError::BadVarint)?;
+    if len > MAX_FRAME_LEN {
+        return Err(WireError::FrameTooLarge { len });
+    }
+
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload).await?;
+    Ok(payload)
+}
+
+// ============================================================================
+// Caller side
+// ============================================================================
+
+/// Build the caller's frame: `uvarint(len) ++ PersistentConnectionRequest{callId, callUnary}`.
+///
+/// `peer` is what Go puts in `CallUnaryRequest.peer` on the way out; the
+/// responder overwrites it, so an empty slice is fine and is what a Go-daemon
+/// caller effectively transmits after its own local dispatch.
+pub fn encode_unary_request(call_id: &[u8], peer: &[u8], proto: &str, data: &[u8]) -> Vec<u8> {
+    let req = PersistentConnectionRequest {
+        call_id: call_id.to_vec(),
+        message: Some(persistent_connection_request::Message::CallUnary(
+            CallUnaryRequest {
+                peer: peer.to_vec(),
+                proto: proto.to_string(),
+                data: data.to_vec(),
+            },
+        )),
+    };
+    frame(&req.encode_to_vec())
+}
+
+/// Decode an *unframed* caller payload into `(call_id, peer, proto, data)`.
+///
+/// Use [`read_framed`] or [`unframe`] first. Errors when the envelope carries
+/// any oneof arm other than `callUnary`.
+pub fn decode_unary_request(payload: &[u8]) -> WireResult<(Vec<u8>, Vec<u8>, String, Vec<u8>)> {
+    let req = PersistentConnectionRequest::decode(payload)?;
+    match req.message {
+        Some(persistent_connection_request::Message::CallUnary(cu)) => {
+            Ok((req.call_id, cu.peer, cu.proto, cu.data))
+        }
+        other => Err(WireError::UnexpectedMessage(format!(
+            "expected callUnary, got {}",
+            describe_arm(other.as_ref())
+        ))),
+    }
+}
+
+// ============================================================================
+// Responder side
+// ============================================================================
+
+/// Build the responder's frame:
+/// `uvarint(len) ++ PersistentConnectionRequest{callId, unaryResponse}`.
+///
+/// `Ok(data)` becomes `CallUnaryResponse.response`; `Err(msg)` becomes
+/// `CallUnaryResponse.error` with the message as UTF-8 bytes (Go writes
+/// `err.Error()` the same way).
+pub fn encode_unary_response(
+    call_id: &[u8],
+    result: std::result::Result<Vec<u8>, String>,
+) -> Vec<u8> {
+    let inner = match result {
+        Ok(data) => call_unary_response::Result::Response(data),
+        Err(msg) => call_unary_response::Result::Error(msg.into_bytes()),
+    };
+    let resp = PersistentConnectionRequest {
+        call_id: call_id.to_vec(),
+        message: Some(persistent_connection_request::Message::UnaryResponse(
+            CallUnaryResponse {
+                result: Some(inner),
+            },
+        )),
+    };
+    frame(&resp.encode_to_vec())
+}
+
+/// Decode an *unframed* responder payload into `(call_id, Ok(data) | Err(msg))`.
+///
+/// A `CallUnaryResponse` with neither arm set (an empty message) decodes to
+/// `Err` describing the empty response rather than silently yielding no bytes.
+#[allow(clippy::type_complexity)]
+pub fn decode_unary_response(
+    payload: &[u8],
+) -> WireResult<(Vec<u8>, std::result::Result<Vec<u8>, String>)> {
+    let req = PersistentConnectionRequest::decode(payload)?;
+    match req.message {
+        Some(persistent_connection_request::Message::UnaryResponse(r)) => {
+            let out = match r.result {
+                Some(call_unary_response::Result::Response(data)) => Ok(data),
+                Some(call_unary_response::Result::Error(err)) => {
+                    Err(String::from_utf8_lossy(&err).into_owned())
+                }
+                None => Err("empty CallUnaryResponse (neither response nor error set)".to_string()),
+            };
+            Ok((req.call_id, out))
+        }
+        other => Err(WireError::UnexpectedMessage(format!(
+            "expected unaryResponse, got {}",
+            describe_arm(other.as_ref())
+        ))),
+    }
+}
+
+fn describe_arm(arm: Option<&persistent_connection_request::Message>) -> &'static str {
+    use persistent_connection_request::Message as M;
+    match arm {
+        None => "no message",
+        Some(M::AddUnaryHandler(_)) => "addUnaryHandler",
+        Some(M::CallUnary(_)) => "callUnary",
+        Some(M::UnaryResponse(_)) => "unaryResponse",
+        Some(M::Cancel(_)) => "cancel",
+        Some(M::RemoveUnaryHandler(_)) => "removeUnaryHandler",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CALL_ID: [u8; 16] = [
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+        0x00,
+    ];
+
+    // ---------------------------------------------------------------- golden
+
+    /// Byte-for-byte layout of a request frame, checked against the proto2
+    /// encoding rules by hand rather than against our own encoder.
+    #[test]
+    fn golden_request_bytes() {
+        let framed = encode_unary_request(&CALL_ID, b"", "DHTProtocol.rpc_ping", b"\x08\x2a");
+
+        let mut expect_inner = Vec::new();
+        // field 1 (callId), wire type 2 → tag byte 0x0a, len 16
+        expect_inner.push(0x0a);
+        expect_inner.push(16);
+        expect_inner.extend_from_slice(&CALL_ID);
+        // field 3 (callUnary), wire type 2 → tag byte 0x1a
+        // starting with field 1 (peer), wire type 2 → 0x0a. proto2 `required`:
+        // encoded even when empty (len 0) — Go rejects the frame if it is absent.
+        let mut cu = vec![0x0a, 0x00];
+        // field 2 (proto), wire type 2 → 0x12
+        cu.push(0x12);
+        cu.push(20); // len("DHTProtocol.rpc_ping")
+        cu.extend_from_slice(b"DHTProtocol.rpc_ping");
+        // field 3 (data), wire type 2 → 0x1a
+        cu.push(0x1a);
+        cu.push(2);
+        cu.extend_from_slice(b"\x08\x2a");
+        expect_inner.push(0x1a);
+        expect_inner.push(cu.len() as u8);
+        expect_inner.extend_from_slice(&cu);
+
+        let mut expect = vec![expect_inner.len() as u8];
+        expect.extend_from_slice(&expect_inner);
+
+        assert_eq!(
+            framed, expect,
+            "request frame layout drifted\n got: {:02x?}\nwant: {:02x?}",
+            framed, expect
+        );
+    }
+
+    /// The reply envelope MUST be a `PersistentConnectionRequest` with the
+    /// oneof arm at field **4** (`unaryResponse`) — not field 2.
+    #[test]
+    fn golden_response_bytes_use_field_4() {
+        let framed = encode_unary_response(&CALL_ID, Ok(b"pong".to_vec()));
+        let (payload, consumed) = unframe(&framed).unwrap();
+        assert_eq!(consumed, framed.len());
+
+        // callId (tag 0x0a) then unaryResponse (field 4, wire type 2 → 0x22).
+        assert_eq!(payload[0], 0x0a);
+        assert_eq!(payload[1], 16);
+        assert_eq!(&payload[2..18], &CALL_ID);
+        assert_eq!(
+            payload[18], 0x22,
+            "unaryResponse must be field 4; 0x12 (field 2) is the historical bug"
+        );
+        // CallUnaryResponse{response: "pong"} → 0x0a 0x04 "pong"
+        assert_eq!(&payload[19..], &[0x06, 0x0a, 0x04, b'p', b'o', b'n', b'g']);
+    }
+
+    // ------------------------------------------------------------ round trip
+
+    #[test]
+    fn request_round_trip() {
+        let data = b"\x0a\x14some-dht-payload----";
+        let framed = encode_unary_request(&CALL_ID, b"\x00\x24peer", "DHTProtocol.rpc_store", data);
+        let (payload, consumed) = unframe(&framed).unwrap();
+        assert_eq!(consumed, framed.len());
+
+        let (call_id, peer, proto, out) = decode_unary_request(payload).unwrap();
+        assert_eq!(call_id, CALL_ID);
+        assert_eq!(peer, b"\x00\x24peer");
+        assert_eq!(proto, "DHTProtocol.rpc_store");
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn response_ok_round_trip() {
+        let framed = encode_unary_response(&CALL_ID, Ok(b"response-bytes".to_vec()));
+        let (payload, _) = unframe(&framed).unwrap();
+        let (call_id, result) = decode_unary_response(payload).unwrap();
+        assert_eq!(call_id, CALL_ID);
+        assert_eq!(result.unwrap(), b"response-bytes");
+    }
+
+    #[test]
+    fn response_error_round_trip() {
+        let framed = encode_unary_response(&CALL_ID, Err("handler exploded".to_string()));
+        let (payload, _) = unframe(&framed).unwrap();
+        let (call_id, result) = decode_unary_response(payload).unwrap();
+        assert_eq!(call_id, CALL_ID);
+        assert_eq!(result.unwrap_err(), "handler exploded");
+    }
+
+    /// An empty `data` must survive the round trip — and must still be
+    /// *present* on the wire: `data` is proto2 `required`, and Go's unmarshal
+    /// rejects the whole frame when a required field is absent.
+    #[test]
+    fn empty_payload_round_trip() {
+        let framed = encode_unary_request(&CALL_ID, b"", "DHTProtocol.rpc_ping", b"");
+        let (payload, _) = unframe(&framed).unwrap();
+        let (_, _, proto, data) = decode_unary_request(payload).unwrap();
+        assert_eq!(proto, "DHTProtocol.rpc_ping");
+        assert!(data.is_empty());
+    }
+
+    // -------------------------------------------------------- varint framing
+
+    /// Payload lengths straddling every uvarint width boundary.
+    #[test]
+    fn varint_length_edges() {
+        for &len in &[0usize, 1, 127, 128, 16_383, 16_384, 2_097_151, 2_097_152] {
+            let payload = vec![0xABu8; len];
+            let framed = frame(&payload);
+
+            let expected_prefix = match len {
+                0..=127 => 1,
+                128..=16_383 => 2,
+                16_384..=2_097_151 => 3,
+                _ => 4,
+            };
+            assert_eq!(
+                framed.len() - len,
+                expected_prefix,
+                "len {} should use a {}-byte uvarint prefix",
+                len,
+                expected_prefix
+            );
+
+            let (out, consumed) = unframe(&framed).unwrap();
+            assert_eq!(out, &payload[..], "unframe mismatch at len {}", len);
+            assert_eq!(consumed, framed.len());
+        }
+    }
+
+    /// `read_framed` must reassemble a multi-byte-varint frame delivered in
+    /// dribbles — the partial-read path.
+    #[tokio::test]
+    async fn read_framed_handles_multibyte_varint_and_partial_reads() {
+        for &len in &[0usize, 127, 128, 16_383, 16_384] {
+            let payload: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+            let framed = frame(&payload);
+
+            // duplex with a tiny buffer forces the writer to trickle.
+            let (client, mut server) = tokio::io::duplex(8);
+            let writer = tokio::spawn(async move {
+                use tokio::io::AsyncWriteExt as _;
+                for chunk in framed.chunks(3) {
+                    server.write_all(chunk).await.unwrap();
+                    tokio::task::yield_now().await;
+                }
+                server.flush().await.unwrap();
+            });
+
+            let mut client = client;
+            let got = read_framed(&mut client).await.unwrap();
+            writer.await.unwrap();
+            assert_eq!(got, payload, "read_framed mismatch at len {}", len);
+        }
+    }
+
+    /// Two frames back to back on one stream are read independently — the
+    /// varint reader must not over-consume into the second frame.
+    #[tokio::test]
+    async fn read_framed_reads_consecutive_frames() {
+        let a = encode_unary_request(&CALL_ID, b"", "DHTProtocol.rpc_ping", b"first");
+        let b = encode_unary_response(&CALL_ID, Ok(b"second".to_vec()));
+
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        {
+            use tokio::io::AsyncWriteExt as _;
+            server.write_all(&a).await.unwrap();
+            server.write_all(&b).await.unwrap();
+            server.flush().await.unwrap();
+        }
+
+        let f1 = read_framed(&mut client).await.unwrap();
+        let f2 = read_framed(&mut client).await.unwrap();
+        assert_eq!(decode_unary_request(&f1).unwrap().3, b"first");
+        assert_eq!(decode_unary_response(&f2).unwrap().1.unwrap(), b"second");
+    }
+
+    // ------------------------------------------------------------ rejections
+
+    #[test]
+    fn unframe_rejects_oversized_declaration() {
+        // Declare MAX_FRAME_LEN + 1 with no payload behind it: must be rejected
+        // on the declared length alone, never allocated.
+        let mut buf = unsigned_varint::encode::usize_buffer();
+        let prefix = unsigned_varint::encode::usize(MAX_FRAME_LEN + 1, &mut buf).to_vec();
+        match unframe(&prefix) {
+            Err(WireError::FrameTooLarge { len }) => assert_eq!(len, MAX_FRAME_LEN + 1),
+            other => panic!(
+                "expected FrameTooLarge, got {:?}",
+                other.map(|(p, _)| p.len())
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_framed_rejects_oversized_declaration() {
+        let mut buf = unsigned_varint::encode::usize_buffer();
+        let prefix = unsigned_varint::encode::usize(MAX_FRAME_LEN + 1, &mut buf).to_vec();
+
+        let (mut client, mut server) = tokio::io::duplex(64);
+        {
+            use tokio::io::AsyncWriteExt as _;
+            server.write_all(&prefix).await.unwrap();
+            server.flush().await.unwrap();
+        }
+        match read_framed(&mut client).await {
+            Err(WireError::FrameTooLarge { len }) => assert_eq!(len, MAX_FRAME_LEN + 1),
+            other => panic!("expected FrameTooLarge, got {:?}", other.map(|v| v.len())),
+        }
+    }
+
+    /// Exactly at the cap is legal (the cap is inclusive), so the guard must
+    /// not be off by one. Checked on the declaration only — no 10 MiB alloc.
+    #[test]
+    fn unframe_accepts_exactly_max_len_declaration() {
+        let mut buf = unsigned_varint::encode::usize_buffer();
+        let prefix = unsigned_varint::encode::usize(MAX_FRAME_LEN, &mut buf).to_vec();
+        // Payload is absent → UnexpectedEof, NOT FrameTooLarge.
+        match unframe(&prefix) {
+            Err(WireError::Io(e)) => assert_eq!(e.kind(), io::ErrorKind::UnexpectedEof),
+            other => panic!(
+                "expected UnexpectedEof, got {:?}",
+                other.map(|(p, _)| p.len())
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_framed_rejects_runaway_varint() {
+        // 11 continuation bytes: longer than any valid u64 uvarint.
+        let (mut client, mut server) = tokio::io::duplex(64);
+        {
+            use tokio::io::AsyncWriteExt as _;
+            server.write_all(&[0xFFu8; 11]).await.unwrap();
+            server.flush().await.unwrap();
+        }
+        assert!(matches!(
+            read_framed(&mut client).await,
+            Err(WireError::BadVarint)
+        ));
+    }
+
+    #[test]
+    fn unframe_rejects_truncated_payload() {
+        let framed = encode_unary_response(&CALL_ID, Ok(b"abcdefgh".to_vec()));
+        let truncated = &framed[..framed.len() - 3];
+        assert!(matches!(unframe(truncated), Err(WireError::Io(_))));
+    }
+
+    // ------------------------------------------------- wrong-envelope decode
+
+    /// A reply whose oneof arm sits at field 2. Decoded as a
+    /// `PersistentConnectionRequest` (which is what Go does) field 2 is
+    /// `AddUnaryHandlerRequest`, so this must NOT surface as a unary response.
+    #[test]
+    fn decode_rejects_response_with_arm_at_field_2() {
+        // Hand-build PersistentConnectionResponse{callId, callUnaryResponse=field 2}.
+        let mut payload = vec![0x0a, 16];
+        payload.extend_from_slice(&CALL_ID);
+        let inner = CallUnaryResponse {
+            result: Some(call_unary_response::Result::Response(b"pong".to_vec())),
+        }
+        .encode_to_vec();
+        payload.push(0x12); // field 2, wire type 2
+        payload.push(inner.len() as u8);
+        payload.extend_from_slice(&inner);
+
+        match decode_unary_response(&payload) {
+            // Either the bytes fail to parse as AddUnaryHandlerRequest, or they
+            // parse into the wrong arm — both are a hard failure for callers.
+            Err(WireError::Decode(_)) => {}
+            Err(WireError::UnexpectedMessage(m)) => {
+                assert!(m.contains("addUnaryHandler"), "unexpected arm: {m}");
+            }
+            other => panic!("field-2 reply must not decode as a unary response: {other:?}"),
+        }
+    }
+
+    /// A `DaemonError` payload is not a valid unary reply on the libp2p wire —
+    /// its field 1 is a string where `callId` expects bytes, and it carries no
+    /// oneof arm.
+    #[test]
+    fn decode_response_that_is_a_daemon_error() {
+        let err_bytes = DaemonError {
+            message: Some("stream reset".to_string()),
+        }
+        .encode_to_vec();
+
+        // Field 1 string vs bytes are the same wire type, so the envelope parses;
+        // the message text lands in call_id and no oneof arm is present.
+        let decoded = PersistentConnectionRequest::decode(err_bytes.as_slice()).unwrap();
+        assert_eq!(decoded.call_id, b"stream reset");
+        assert!(decoded.message.is_none());
+
+        match decode_unary_response(&err_bytes) {
+            Err(WireError::UnexpectedMessage(m)) => {
+                assert!(m.contains("no message"), "unexpected description: {m}");
+            }
+            other => panic!("expected UnexpectedMessage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_request_rejects_response_envelope() {
+        let framed = encode_unary_response(&CALL_ID, Ok(b"x".to_vec()));
+        let (payload, _) = unframe(&framed).unwrap();
+        match decode_unary_request(payload) {
+            Err(WireError::UnexpectedMessage(m)) => assert!(m.contains("unaryResponse")),
+            other => panic!("expected UnexpectedMessage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_response_rejects_request_envelope() {
+        let framed = encode_unary_request(&CALL_ID, b"", "DHTProtocol.rpc_ping", b"x");
+        let (payload, _) = unframe(&framed).unwrap();
+        match decode_unary_response(payload) {
+            Err(WireError::UnexpectedMessage(m)) => assert!(m.contains("callUnary")),
+            other => panic!("expected UnexpectedMessage, got {other:?}"),
+        }
+    }
+
+    /// The 10 MiB cap is a real ceiling, not a hard limit on realistic traffic:
+    /// a ~1 MiB store payload must round-trip through the framing intact.
+    #[test]
+    fn large_but_legal_payload_round_trips() {
+        let data: Vec<u8> = (0..1_000_000u32).map(|i| (i % 251) as u8).collect();
+        let framed = encode_unary_request(&CALL_ID, b"", "DHTProtocol.rpc_store", &data);
+        let (payload, _) = unframe(&framed).unwrap();
+        let (_, _, _, out) = decode_unary_request(payload).unwrap();
+        assert_eq!(out, data);
+    }
+}

--- a/core/crates/kwaai-hivemind-dht/src/wire.rs
+++ b/core/crates/kwaai-hivemind-dht/src/wire.rs
@@ -293,6 +293,7 @@ pub fn encode_unary_request(call_id: &[u8], peer: &[u8], proto: &str, data: &[u8
 ///
 /// Use [`read_framed`] or [`unframe`] first. Errors when the envelope carries
 /// any oneof arm other than `callUnary`.
+#[allow(clippy::type_complexity)]
 pub fn decode_unary_request(payload: &[u8]) -> WireResult<(Vec<u8>, Vec<u8>, String, Vec<u8>)> {
     let req = PersistentConnectionRequest::decode(payload)?;
     match req.message {

--- a/core/crates/kwaai-network-tests/Cargo.toml
+++ b/core/crates/kwaai-network-tests/Cargo.toml
@@ -31,6 +31,7 @@ rmp-serde = { workspace = true }
 hex       = "0.4"
 sha2      = "0.10"
 tempfile  = "3"
+unsigned-varint = { workspace = true }  # hand-built wire frames in 07_wire_interop
 
 [dev-dependencies]
 

--- a/core/crates/kwaai-network-tests/src/harness.rs
+++ b/core/crates/kwaai-network-tests/src/harness.rs
@@ -46,6 +46,49 @@ pub struct TestNode {
 }
 
 impl TestNode {
+    /// Start a bare p2pd on its own socket and TCP port — no DHT, no relay, no
+    /// bootstrap.
+    ///
+    /// Used by the hivemind unary wire tests, which only need two daemons that
+    /// can dial each other directly and speak `PERSISTENT_CONN_UPGRADE`. Keeping
+    /// DHT and relay off makes startup fast and removes all background peer
+    /// churn from what those tests observe.
+    ///
+    /// Every instance gets a fresh tmpdir (unique socket path) and no `-id`
+    /// flag, so p2pd generates a throwaway identity rather than touching any
+    /// persistent key.
+    pub async fn new_wire_peer() -> Result<Self> {
+        let p2p_port = free_port();
+        let tmpdir = TempDir::new()?;
+        let socket_path = tmpdir.path().join("p2pd.sock");
+        let socket_addr = format!("/unix/{}", socket_path.display());
+
+        let mut daemon = DaemonBuilder::new()
+            .with_listen_addr(&socket_addr)
+            .bootstrap(false)
+            .host_addrs([format!("/ip4/127.0.0.1/tcp/{p2p_port}")])
+            .spawn()
+            .await
+            .context("spawn wire peer")?;
+
+        let mut client = daemon.client().await.context("wire peer client")?;
+        let peer_id_hex = client.identify().await.context("wire peer identify")?;
+
+        Ok(Self {
+            daemon,
+            client,
+            peer_id_hex,
+            socket_addr,
+            p2p_port: Some(p2p_port),
+            _tmpdir: tmpdir,
+        })
+    }
+
+    /// Raw peer-ID bytes (what `CallUnaryRequest.peer` and `StreamOpenRequest.peer` want).
+    pub fn peer_id_bytes(&self) -> Vec<u8> {
+        hex::decode(&self.peer_id_hex).expect("peer_id_hex is valid hex")
+    }
+
     /// Start a relay + DHT server node on a deterministic TCP port.
     ///
     /// Other nodes bootstrap from `/ip4/127.0.0.1/tcp/{port}/p2p/{peer_id}`.

--- a/core/crates/kwaai-network-tests/tests/07_wire_interop.rs
+++ b/core/crates/kwaai-network-tests/tests/07_wire_interop.rs
@@ -1,0 +1,576 @@
+//! Hivemind unary-RPC wire interop — Phase 0 gate for the native-p2p migration.
+//!
+//! These tests put a **real p2pd on the other end of the wire** and check the
+//! codec in `kwaai-hivemind-dht::wire` against it in both directions. If the
+//! wire assumptions in `docs/NATIVE_P2P_MIGRATION.md` are wrong, they fail here
+//! rather than three phases later.
+//!
+//! The claim under test:
+//!
+//! ```text
+//! caller ──▶ uvarint(len) ++ PersistentConnectionRequest{callId, callUnary{peer, proto, data}}
+//! caller ◀── uvarint(len) ++ PersistentConnectionRequest{callId, unaryResponse{response|error}}
+//! (stream closes)
+//! ```
+//!
+//! on a libp2p stream whose protocol ID is the **bare handler name, no leading
+//! slash** (`DHTProtocol.rpc_ping`).
+//!
+//! Topology — two independent p2pd instances, each with its own tmpdir socket,
+//! its own throwaway identity (no `-id` flag) and its own ephemeral TCP port on
+//! 127.0.0.1:
+//!
+//! ```text
+//!   [daemon A]  ──dial──▶  [daemon B]
+//!    caller                 responder
+//! ```
+//!
+//! Coverage:
+//!
+//! | test | caller | responder | proves |
+//! | --- | --- | --- | --- |
+//! | `daemon_to_daemon_unary_round_trip` | p2pd A | p2pd B | the fixture + baseline |
+//! | `raw_wire_responder_is_accepted_by_daemon_caller` | p2pd A | **our wire.rs** | the fix works on the real wire |
+//! | `old_wrapper_shape_is_rejected_by_daemon_caller` | p2pd A | old encoding | the bug was real |
+//! | `raw_wire_responder_error_arm` | p2pd A | **our wire.rs** | the error arm propagates |
+//! | `raw_wire_caller_against_daemon_handler` | **our wire.rs** | p2pd B | our caller frame is accepted |
+//! | `slashless_protocol_negotiates` | **our wire.rs** | p2pd B | multistream-select takes a slash-less ID |
+//!
+//! Gate: `KWAAI_INTEGRATION_TESTS=1` (spawns p2pd processes), matching the other
+//! integration tiers in this crate.
+//!
+//! # Process hygiene
+//!
+//! Every daemon is spawned via `DaemonBuilder` and owned by a `TestNode`, whose
+//! `P2PDaemon` kills **its own child by PID** on drop. Nothing here kills by
+//! process name, and nothing touches the default socket path or `~/.kwaainet`.
+//! [`WirePair`] additionally holds the nodes so they drop — and the daemons die
+//! — even when a test panics mid-way.
+
+use kwaai_hivemind_dht::wire;
+use kwaai_network_tests::{harness::TestNode, metrics::MetricsRecorder, require_integration};
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+
+/// The protocol under test. **No leading slash** — this is the hivemind handler
+/// name exactly as it appears as a libp2p protocol ID.
+const PROTO: &str = "DHTProtocol.rpc_ping";
+
+/// Cap on any single test's daemon interaction, so a wire regression surfaces as
+/// a failure rather than a hung suite.
+const CALL_TIMEOUT: Duration = Duration::from_secs(20);
+
+// ============================================================================
+// Fixture
+// ============================================================================
+
+/// Two connected p2pd instances: `a` calls, `b` responds.
+///
+/// Dropping this drops both [`TestNode`]s, each of which SIGTERMs/kills the
+/// daemon child it spawned — by PID, never by name. Holding both in one struct
+/// means a panic anywhere in a test still tears down both processes via unwind.
+struct WirePair {
+    a: TestNode,
+    b: TestNode,
+}
+
+impl WirePair {
+    async fn new() -> anyhow::Result<Self> {
+        let (a, b) = tokio::try_join!(TestNode::new_wire_peer(), TestNode::new_wire_peer())?;
+        let mut pair = Self { a, b };
+
+        // A must know how to reach B before any stream can be opened. The Go
+        // daemon's `host.NewStream` will not dial an unknown peer.
+        let b_addr = pair
+            .b
+            .bootstrap_multiaddr()
+            .ok_or_else(|| anyhow::anyhow!("peer B has no listen port"))?;
+        pair.a.client.connect_peer(&b_addr).await?;
+
+        Ok(pair)
+    }
+}
+
+/// Bind an ephemeral localhost TCP listener for a p2pd stream handler to
+/// forward inbound streams to. Returns the listener and its multiaddr.
+async fn handler_listener() -> anyhow::Result<(TcpListener, String)> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    Ok((listener, format!("/ip4/127.0.0.1/tcp/{port}")))
+}
+
+// ============================================================================
+// (a) Baseline: daemon → daemon, both halves handled by p2pd
+// ============================================================================
+
+/// Register a unary handler on B via its own client, call it from A, and check
+/// the payload survives. This validates the two-daemon fixture and gives the
+/// later raw-wire tests a known-good reference.
+#[tokio::test]
+async fn daemon_to_daemon_unary_round_trip() {
+    require_integration!();
+    let mut rec = MetricsRecorder::start("integration::wire::daemon_to_daemon", "integration");
+
+    let pair = WirePair::new().await.expect("two-daemon fixture");
+
+    pair.b
+        .client
+        .add_unary_handler(
+            PROTO,
+            |req: Vec<u8>| async move {
+                let mut out = b"echo:".to_vec();
+                out.extend_from_slice(&req);
+                Ok(out)
+            },
+            false,
+        )
+        .await
+        .expect("register unary handler on B");
+
+    let response = tokio::time::timeout(
+        CALL_TIMEOUT,
+        pair.a
+            .client
+            .call_unary_handler(&pair.b.peer_id_bytes(), PROTO, b"ping-payload"),
+    )
+    .await
+    .expect("call did not time out")
+    .expect("call_unary_handler should succeed");
+
+    assert_eq!(response, b"echo:ping-payload");
+    rec.metric("response_len", response.len());
+    rec.finish(true);
+}
+
+// ============================================================================
+// (b) THE KEY TEST: our raw-wire responder, a real p2pd caller
+// ============================================================================
+
+/// Serve one inbound hivemind unary call using **only** `wire.rs` for the
+/// decode and the fixed `PersistentConnectionRequest{unaryResponse}` encode,
+/// then have a real p2pd caller invoke it.
+///
+/// B registers a *stream* handler (not a unary handler), so p2pd forwards the
+/// raw libp2p stream bytes to our TCP listener — exactly the shape `node.rs`
+/// `handle_rpc_stream` sees in production. If the caller gets its payload back,
+/// the wire format in `wire.rs` is correct against a real Go implementation.
+#[tokio::test]
+async fn raw_wire_responder_is_accepted_by_daemon_caller() {
+    require_integration!();
+    let mut rec = MetricsRecorder::start("integration::wire::raw_responder", "integration");
+
+    let mut pair = WirePair::new().await.expect("two-daemon fixture");
+    let (listener, listen_addr) = handler_listener().await.expect("handler listener");
+
+    pair.b
+        .client
+        .register_stream_handler(&listen_addr, vec![PROTO.to_string()])
+        .await
+        .expect("register stream handler on B");
+
+    // Serve exactly one call, entirely through wire.rs.
+    let served = tokio::spawn(async move {
+        let (mut tcp, _) = listener.accept().await?;
+
+        // p2pd prefixes the forwarded stream with a StreamInfo frame.
+        let info = kwaai_p2p_daemon::stream::parse_stream_info(&mut tcp)
+            .await
+            .map_err(|e| anyhow::anyhow!("parse_stream_info: {e}"))?;
+        anyhow::ensure!(
+            info.proto == PROTO,
+            "StreamInfo.proto should be the bare name, got {:?}",
+            info.proto
+        );
+
+        // Read + decode the caller's frame with our codec.
+        let frame = wire::read_framed(&mut tcp).await?;
+        let (call_id, peer, proto, data) = wire::decode_unary_request(&frame)?;
+        anyhow::ensure!(proto == PROTO, "proto mismatch: {proto}");
+
+        // Reply with our codec.
+        let mut payload = b"raw-wire:".to_vec();
+        payload.extend_from_slice(&data);
+        tcp.write_all(&wire::encode_unary_response(&call_id, Ok(payload)))
+            .await?;
+        tcp.flush().await?;
+
+        Ok::<_, anyhow::Error>((call_id, peer, data))
+    });
+
+    let response = tokio::time::timeout(
+        CALL_TIMEOUT,
+        pair.a
+            .client
+            .call_unary_handler(&pair.b.peer_id_bytes(), PROTO, b"hello"),
+    )
+    .await
+    .expect("call did not time out")
+    .expect("a real p2pd caller must accept our wire.rs reply");
+
+    assert_eq!(
+        response, b"raw-wire:hello",
+        "payload must survive the round trip unmodified"
+    );
+
+    let (call_id, peer, data) = served.await.expect("responder task").expect("responder");
+    assert_eq!(data, b"hello", "request payload must arrive verbatim");
+    assert_eq!(
+        call_id.len(),
+        16,
+        "callId is a 16-byte UUID; Go drops the message if uuid.FromBytes fails"
+    );
+    // MEASURED, and contrary to what the migration doc implies: on a *stream*
+    // handler the `peer` field is the CALLEE (B, ourselves) — the dial target
+    // the calling daemon wrote — not the caller.
+    //
+    // `Daemon.persistentStreamHandler`'s `req.GetCallUnary().Peer =
+    // s.Conn().RemotePeer()` rewrite only runs for handlers registered via
+    // `add_unary_handler`. `register_stream_handler` puts p2pd in raw-pipe mode,
+    // so nothing rewrites the field and it arrives exactly as the caller sent it.
+    //
+    // Consequence for Phase 2: a native responder must take the caller's
+    // identity from the libp2p connection, NEVER from `callUnary.peer`. Trusting
+    // this field would attribute every inbound RPC to ourselves.
+    assert_eq!(
+        peer,
+        pair.b.peer_id_bytes(),
+        "on a raw stream handler, callUnary.peer is the callee (unrewritten), \
+         not the caller"
+    );
+    assert_ne!(
+        peer,
+        pair.a.peer_id_bytes(),
+        "callUnary.peer is NOT the caller on this path — see comment above"
+    );
+
+    rec.metric("call_id_len", call_id.len());
+    rec.finish(true);
+}
+
+/// Regression witness: serve the **old** wrapper shape
+/// (`PersistentConnectionResponse{callId, callUnaryResponse}`, oneof arm at
+/// field 2) and confirm a real p2pd caller cannot use it.
+///
+/// This is what shipped before the `stream.rs` fix, so every inbound
+/// rpc_ping/store/find a Rust node served to a Go-daemon caller failed this way.
+#[tokio::test]
+async fn old_wrapper_shape_is_rejected_by_daemon_caller() {
+    require_integration!();
+    let mut rec = MetricsRecorder::start("integration::wire::old_shape_rejected", "integration");
+
+    let mut pair = WirePair::new().await.expect("two-daemon fixture");
+    let (listener, listen_addr) = handler_listener().await.expect("handler listener");
+
+    pair.b
+        .client
+        .register_stream_handler(&listen_addr, vec![PROTO.to_string()])
+        .await
+        .expect("register stream handler on B");
+
+    tokio::spawn(async move {
+        let (mut tcp, _) = listener.accept().await?;
+        kwaai_p2p_daemon::stream::parse_stream_info(&mut tcp)
+            .await
+            .map_err(|e| anyhow::anyhow!("parse_stream_info: {e}"))?;
+        let frame = wire::read_framed(&mut tcp).await?;
+        let (call_id, _, _, _) = wire::decode_unary_request(&frame)?;
+
+        // The pre-fix encoding, reconstructed byte-for-byte:
+        // PersistentConnectionResponse{callId=1, callUnaryResponse=2}.
+        tcp.write_all(&old_shape_response(&call_id, b"pong"))
+            .await?;
+        tcp.flush().await?;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let result = tokio::time::timeout(
+        CALL_TIMEOUT,
+        pair.a
+            .client
+            .call_unary_handler(&pair.b.peer_id_bytes(), PROTO, b"hello"),
+    )
+    .await
+    .expect("call did not time out");
+
+    match result {
+        Err(e) => {
+            // Expected: the Go caller cannot unmarshal the reply.
+            rec.metric("error_len", e.to_string().len());
+            eprintln!("old wrapper shape rejected as expected: {e}");
+        }
+        Ok(payload) => {
+            // Honest-reporting path: if the old shape somehow works, the bug
+            // premise is wrong and that matters far more than a green test.
+            panic!(
+                "the OLD wrapper shape was ACCEPTED by a real p2pd caller, returning {:?} \
+                 ({} bytes). The PersistentConnectionResponse-vs-Request premise in \
+                 docs/NATIVE_P2P_MIGRATION.md is wrong — investigate before proceeding.",
+                String::from_utf8_lossy(&payload),
+                payload.len()
+            );
+        }
+    }
+
+    rec.finish(true);
+}
+
+/// Build the pre-fix reply: `PersistentConnectionResponse{callId, callUnaryResponse}`.
+///
+/// Hand-assembled rather than taken from the daemon crate's types, so this test
+/// keeps witnessing the historical bytes even after `stream.rs` was corrected.
+fn old_shape_response(call_id: &[u8], payload: &[u8]) -> Vec<u8> {
+    // CallUnaryResponse{response = payload}: field 1, wire type 2.
+    let mut inner = vec![0x0a, payload.len() as u8];
+    inner.extend_from_slice(payload);
+
+    let mut msg = Vec::new();
+    // callId: field 1, wire type 2.
+    msg.push(0x0a);
+    msg.push(call_id.len() as u8);
+    msg.extend_from_slice(call_id);
+    // callUnaryResponse: field 2, wire type 2 → the bug. Field 2 of
+    // PersistentConnectionRequest is AddUnaryHandlerRequest.
+    msg.push(0x12);
+    msg.push(inner.len() as u8);
+    msg.extend_from_slice(&inner);
+
+    let mut buf = unsigned_varint::encode::usize_buffer();
+    let prefix = unsigned_varint::encode::usize(msg.len(), &mut buf);
+    let mut framed = Vec::with_capacity(prefix.len() + msg.len());
+    framed.extend_from_slice(prefix);
+    framed.extend_from_slice(&msg);
+    framed
+}
+
+/// The `error` arm of `CallUnaryResponse` must reach the caller as an error,
+/// not as an empty success.
+#[tokio::test]
+async fn raw_wire_responder_error_arm() {
+    require_integration!();
+    let rec = MetricsRecorder::start("integration::wire::responder_error_arm", "integration");
+
+    let mut pair = WirePair::new().await.expect("two-daemon fixture");
+    let (listener, listen_addr) = handler_listener().await.expect("handler listener");
+
+    pair.b
+        .client
+        .register_stream_handler(&listen_addr, vec![PROTO.to_string()])
+        .await
+        .expect("register stream handler on B");
+
+    tokio::spawn(async move {
+        let (mut tcp, _) = listener.accept().await?;
+        kwaai_p2p_daemon::stream::parse_stream_info(&mut tcp)
+            .await
+            .map_err(|e| anyhow::anyhow!("parse_stream_info: {e}"))?;
+        let frame = wire::read_framed(&mut tcp).await?;
+        let (call_id, _, _, _) = wire::decode_unary_request(&frame)?;
+        tcp.write_all(&wire::encode_unary_response(
+            &call_id,
+            Err("deliberate handler failure".to_string()),
+        ))
+        .await?;
+        tcp.flush().await?;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let result = tokio::time::timeout(
+        CALL_TIMEOUT,
+        pair.a
+            .client
+            .call_unary_handler(&pair.b.peer_id_bytes(), PROTO, b"hello"),
+    )
+    .await
+    .expect("call did not time out");
+
+    let err = result.expect_err("error arm must surface as an error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("deliberate handler failure"),
+        "the handler's message must reach the caller, got: {msg}"
+    );
+
+    rec.finish(true);
+}
+
+// ============================================================================
+// (c) Raw-wire caller: our frames, a real p2pd responder
+// ============================================================================
+
+/// Drive the caller side entirely from `wire.rs`.
+///
+/// B registers a normal unary handler via `add_unary_handler` — so p2pd itself
+/// is the responder. A opens a raw libp2p stream to it via `stream_open_raw`
+/// (which puts the daemon socket into pipe mode, so we are writing directly onto
+/// the libp2p stream), writes a frame built by `encode_unary_request`, and reads
+/// the reply with `read_framed` + `decode_unary_response`.
+///
+/// A real p2pd accepting our caller frame proves `encode_unary_request` matches
+/// what `Daemon.persistentStreamHandler` expects.
+#[tokio::test]
+async fn raw_wire_caller_against_daemon_handler() {
+    require_integration!();
+    let rec = MetricsRecorder::start("integration::wire::raw_caller", "integration");
+
+    let pair = WirePair::new().await.expect("two-daemon fixture");
+
+    pair.b
+        .client
+        .add_unary_handler(
+            PROTO,
+            |req: Vec<u8>| async move {
+                let mut out = b"daemon-served:".to_vec();
+                out.extend_from_slice(&req);
+                Ok(out)
+            },
+            false,
+        )
+        .await
+        .expect("register unary handler on B");
+
+    let call_id: Vec<u8> = (0u8..16).collect();
+    let (call_id_out, result) = tokio::time::timeout(
+        CALL_TIMEOUT,
+        raw_unary_call(&pair, &call_id, PROTO, b"from-raw-caller"),
+    )
+    .await
+    .expect("call did not time out")
+    .expect("raw wire call");
+
+    assert_eq!(call_id_out, call_id, "callId must be echoed verbatim");
+    assert_eq!(
+        result.expect("handler should succeed"),
+        b"daemon-served:from-raw-caller"
+    );
+
+    rec.finish(true);
+}
+
+/// Empirical check that multistream-select accepts a protocol ID with **no
+/// leading slash**, which is what hivemind uses and what rust-libp2p's
+/// `StreamProtocol::new` refuses to construct (it panics on slash-less names).
+///
+/// This is an open verification item in `docs/NATIVE_P2P_MIGRATION.md`: Phase 2
+/// plans a custom `UnaryProtocol(Arc<str>)` to sidestep that constructor, and it
+/// is only worth building if the negotiation itself is legal. A successful call
+/// here means the go-libp2p peer on the far end negotiated `DHTProtocol.rpc_ping`
+/// verbatim.
+#[tokio::test]
+async fn slashless_protocol_negotiates() {
+    require_integration!();
+    let rec = MetricsRecorder::start("integration::wire::slashless_protocol", "integration");
+
+    assert!(
+        !PROTO.starts_with('/'),
+        "this test is meaningless if the protocol ID is slashed"
+    );
+
+    let pair = WirePair::new().await.expect("two-daemon fixture");
+
+    pair.b
+        .client
+        .add_unary_handler(
+            PROTO,
+            |_req: Vec<u8>| async move { Ok(b"ok".to_vec()) },
+            false,
+        )
+        .await
+        .expect("register unary handler on B");
+
+    let call_id: Vec<u8> = (100u8..116).collect();
+    let (_, result) =
+        tokio::time::timeout(CALL_TIMEOUT, raw_unary_call(&pair, &call_id, PROTO, b""))
+            .await
+            .expect("call did not time out")
+            .expect("slash-less protocol must negotiate on the libp2p wire");
+
+    assert_eq!(result.expect("handler should succeed"), b"ok");
+    rec.finish(true);
+}
+
+/// One full caller-side exchange over a raw libp2p stream, using only `wire.rs`
+/// for encode/decode.
+#[allow(clippy::type_complexity)]
+async fn raw_unary_call(
+    pair: &WirePair,
+    call_id: &[u8],
+    proto: &str,
+    data: &[u8],
+) -> anyhow::Result<(Vec<u8>, Result<Vec<u8>, String>)> {
+    // A fresh control-socket client, because stream_open_raw consumes it: the
+    // daemon socket becomes the raw libp2p stream.
+    let client = kwaai_p2p_daemon::P2PClient::connect(&pair.a.socket_addr).await?;
+    let mut stream = client
+        .stream_open_raw(&pair.b.peer_id_bytes(), vec![proto.to_string()])
+        .await?;
+
+    // Go's caller (`Daemon.exchangeMessages`) sets `peer` to the dial target;
+    // mirror that. The field is proto2 `required`, so it must be present either
+    // way — an omitted field makes the responding daemon reset the stream.
+    stream
+        .write_all(&wire::encode_unary_request(
+            call_id,
+            &pair.b.peer_id_bytes(),
+            proto,
+            data,
+        ))
+        .await?;
+    stream.flush().await?;
+
+    let frame = wire::read_framed(&mut stream).await?;
+    Ok(wire::decode_unary_response(&frame)?)
+}
+
+// ============================================================================
+// Framing conformance against the real daemon
+// ============================================================================
+
+/// The daemon must accept a frame whose uvarint length prefix is multi-byte.
+///
+/// Anything over 127 bytes uses a 2-byte prefix, which is where a hand-rolled
+/// single-byte framer would break. DHT store payloads routinely exceed this, so
+/// the boundary is exercised in production traffic constantly.
+#[tokio::test]
+async fn multibyte_length_prefix_accepted_by_daemon() {
+    require_integration!();
+    let mut rec = MetricsRecorder::start("integration::wire::multibyte_prefix", "integration");
+
+    let pair = WirePair::new().await.expect("two-daemon fixture");
+
+    pair.b
+        .client
+        .add_unary_handler(
+            PROTO,
+            |req: Vec<u8>| async move { Ok(req.len().to_string().into_bytes()) },
+            false,
+        )
+        .await
+        .expect("register unary handler on B");
+
+    // 4 KiB payload → 2-byte uvarint on the inner data field and a 2-byte frame
+    // prefix on the envelope.
+    let data = vec![0x5Au8; 4096];
+    let call_id: Vec<u8> = (200u8..216).collect();
+
+    let framed = wire::encode_unary_request(&call_id, b"", PROTO, &data);
+    assert!(
+        framed.len() - 4096 > 3,
+        "envelope should need a multi-byte prefix"
+    );
+
+    let (_, result) =
+        tokio::time::timeout(CALL_TIMEOUT, raw_unary_call(&pair, &call_id, PROTO, &data))
+            .await
+            .expect("call did not time out")
+            .expect("multi-byte-prefixed frame must be accepted");
+
+    assert_eq!(
+        result.expect("handler should succeed"),
+        b"4096",
+        "the handler must see all 4096 bytes"
+    );
+
+    rec.metric("payload_bytes", data.len());
+    rec.finish(true);
+}

--- a/core/crates/kwaai-p2p-daemon/src/stream.rs
+++ b/core/crates/kwaai-p2p-daemon/src/stream.rs
@@ -226,14 +226,12 @@ mod tests {
 
         assert_eq!(decoded.call_id, call_id(), "callId must be echoed verbatim");
         match decoded.message {
-            Some(persistent_connection_request::Message::UnaryResponse(r)) => {
-                match r.result {
-                    Some(call_unary_response::Result::Response(data)) => {
-                        assert_eq!(data, b"dht-response");
-                    }
-                    other => panic!("expected Response arm, got {other:?}"),
+            Some(persistent_connection_request::Message::UnaryResponse(r)) => match r.result {
+                Some(call_unary_response::Result::Response(data)) => {
+                    assert_eq!(data, b"dht-response");
                 }
-            }
+                other => panic!("expected Response arm, got {other:?}"),
+            },
             other => panic!("expected unaryResponse arm, got {other:?}"),
         }
     }
@@ -335,4 +333,3 @@ mod tests {
         assert_eq!(decoded_len, len);
     }
 }
-

--- a/core/crates/kwaai-p2p-daemon/src/stream.rs
+++ b/core/crates/kwaai-p2p-daemon/src/stream.rs
@@ -153,23 +153,32 @@ pub fn unwrap_stream_handler_request(bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>)>
     Ok((call_id, dht_data))
 }
 
-/// Encode a DHT response as a varint-framed `PersistentConnectionResponse`.
+/// Encode a DHT response as a varint-framed `PersistentConnectionRequest`
+/// carrying the `unaryResponse` oneof arm (field 4).
 ///
 /// `call_id` must be the bytes extracted by `unwrap_stream_handler_request`.
 /// `response_data` is the raw protobuf of the DHT response.
 ///
 /// Returns the varint-framed bytes ready to write back to the TCP stream.
+///
+/// # Why `PersistentConnectionRequest` and not `...Response`
+///
+/// `PersistentConnectionResponse` exists only on the daemon's *local control
+/// socket*. On the libp2p wire between peers both directions are
+/// `PersistentConnectionRequest`: go-libp2p-daemon's `Daemon.exchangeMessages`
+/// (persistent_stream.go) reads the reply into `&pb.PersistentConnectionRequest{}`
+/// and takes `GetUnaryResponse()` — field 4.
 pub fn wrap_stream_handler_response(call_id: Vec<u8>, response_data: Vec<u8>) -> Vec<u8> {
     use crate::protocol::p2pd::{
-        call_unary_response, persistent_connection_response, CallUnaryResponse,
-        PersistentConnectionResponse,
+        call_unary_response, persistent_connection_request, CallUnaryResponse,
+        PersistentConnectionRequest,
     };
     use prost::Message as _;
     use unsigned_varint::encode as varint_encode;
 
-    let wrapper = PersistentConnectionResponse {
+    let wrapper = PersistentConnectionRequest {
         call_id,
-        message: Some(persistent_connection_response::Message::CallUnaryResponse(
+        message: Some(persistent_connection_request::Message::UnaryResponse(
             CallUnaryResponse {
                 result: Some(call_unary_response::Result::Response(response_data)),
             },
@@ -187,6 +196,130 @@ pub fn wrap_stream_handler_response(call_id: Vec<u8>, response_data: Vec<u8>) ->
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::protocol::p2pd::{
+        call_unary_response, persistent_connection_request, persistent_connection_response,
+        CallUnaryResponse, PersistentConnectionRequest, PersistentConnectionResponse,
+    };
+
+    fn call_id() -> Vec<u8> {
+        (0u8..16).collect()
+    }
+
+    /// Strip the uvarint prefix off a framed message.
+    fn unframe(framed: &[u8]) -> &[u8] {
+        let (len, rest) = unsigned_varint::decode::usize(framed).expect("varint prefix");
+        assert_eq!(rest.len(), len, "frame length prefix must match payload");
+        rest
+    }
+
+    /// The reply a Go caller sees must decode as `PersistentConnectionRequest`
+    /// with the `unaryResponse` arm — this is what `Daemon.exchangeMessages`
+    /// does (`ReadMsg(&pb.PersistentConnectionRequest{})` + `GetUnaryResponse()`).
+    #[test]
+    fn wrapped_response_decodes_as_persistent_connection_request() {
+        let framed = wrap_stream_handler_response(call_id(), b"dht-response".to_vec());
+        let payload = unframe(&framed);
+
+        let decoded =
+            PersistentConnectionRequest::decode(payload).expect("must decode as ...Request");
+
+        assert_eq!(decoded.call_id, call_id(), "callId must be echoed verbatim");
+        match decoded.message {
+            Some(persistent_connection_request::Message::UnaryResponse(r)) => {
+                match r.result {
+                    Some(call_unary_response::Result::Response(data)) => {
+                        assert_eq!(data, b"dht-response");
+                    }
+                    other => panic!("expected Response arm, got {other:?}"),
+                }
+            }
+            other => panic!("expected unaryResponse arm, got {other:?}"),
+        }
+    }
+
+    /// The oneof arm must land on field 4.
+    #[test]
+    fn wrapped_response_uses_field_4() {
+        let framed = wrap_stream_handler_response(call_id(), b"pong".to_vec());
+        let payload = unframe(&framed);
+
+        // callId: field 1, wire type 2.
+        assert_eq!(payload[0], 0x0a);
+        assert_eq!(payload[1], 16);
+        assert_eq!(&payload[2..18], &call_id()[..]);
+        // unaryResponse: field 4, wire type 2 → (4 << 3) | 2 == 0x22.
+        assert_eq!(
+            payload[18], 0x22,
+            "reply oneof must be field 4 (unaryResponse), not field 2"
+        );
+    }
+
+    /// A field-2 arm decodes as `AddUnaryHandlerRequest`: Go's gogo (proto2)
+    /// rejects it for the absent `required bool balanced`, while prost accepts
+    /// it and mis-decodes the payload as a handler name. `GetUnaryResponse()`
+    /// is nil either way.
+    #[test]
+    fn response_shaped_reply_does_not_yield_a_unary_response() {
+        let old = PersistentConnectionResponse {
+            call_id: call_id(),
+            message: Some(persistent_connection_response::Message::CallUnaryResponse(
+                CallUnaryResponse {
+                    result: Some(call_unary_response::Result::Response(b"pong".to_vec())),
+                },
+            )),
+        };
+        let bytes = old.encode_to_vec();
+
+        // Field 2 on the wire, exactly where AddUnaryHandlerRequest lives.
+        assert_eq!(bytes[18], 0x12, "old shape put its arm at field 2");
+
+        match PersistentConnectionRequest::decode(bytes.as_slice()) {
+            // Go's gogo unmarshal fails outright here (required fields absent).
+            Err(_) => {}
+            Ok(decoded) => {
+                // prost's observed behaviour: the response payload "pong" lands
+                // in AddUnaryHandlerRequest.proto. Nonsense, but not a
+                // unaryResponse — which is the point.
+                assert!(
+                    matches!(
+                        decoded.message,
+                        Some(persistent_connection_request::Message::AddUnaryHandler(ref h))
+                            if h.proto == "pong" && !h.balanced
+                    ),
+                    "expected the payload to be mis-read as AddUnaryHandlerRequest, got {:?}",
+                    decoded.message
+                );
+            }
+        }
+    }
+
+    /// Round trip through the pair of helpers a stream handler actually uses.
+    #[test]
+    fn unwrap_request_then_wrap_response_round_trip() {
+        use crate::protocol::p2pd::CallUnaryRequest;
+
+        let inbound = PersistentConnectionRequest {
+            call_id: call_id(),
+            message: Some(persistent_connection_request::Message::CallUnary(
+                CallUnaryRequest {
+                    peer: b"caller-peer".to_vec(),
+                    proto: "DHTProtocol.rpc_ping".to_string(),
+                    data: b"ping-payload".to_vec(),
+                },
+            )),
+        }
+        .encode_to_vec();
+
+        let (id, data) = unwrap_stream_handler_request(&inbound).expect("unwrap");
+        assert_eq!(id, call_id());
+        assert_eq!(data, b"ping-payload");
+
+        let framed = wrap_stream_handler_response(id.clone(), b"pong-payload".to_vec());
+        let decoded = PersistentConnectionRequest::decode(unframe(&framed)).expect("decode");
+        assert_eq!(decoded.call_id, id);
+    }
+
     #[test]
     fn test_varint_encoding() {
         let payload = b"test payload";
@@ -202,3 +335,4 @@ mod tests {
         assert_eq!(decoded_len, len);
     }
 }
+

--- a/docs/NATIVE_P2P_MIGRATION.md
+++ b/docs/NATIVE_P2P_MIGRATION.md
@@ -1,0 +1,331 @@
+# Native P2P Migration: Removing the Go p2p-daemon
+
+Status: **in progress** — implementation on `feature/native-p2p`.
+
+## Context
+
+The `kwaainet` node currently runs **no in-process libp2p at all**. It spawns the Go
+`go-libp2p-daemon` (hivemind fork, pinned `v0.5.0.hivemind1`) as a child process and drives
+it over a protobuf control socket (`/tmp/kwaai-p2pd.sock` / `KWAAINET_SOCKET`). This makes Go
+a hard build **and** runtime dependency (five separate build paths ship the binary), forces
+awkward workarounds (full daemon restart to change announce addrs; `connect_peer()` crashing
+p2pd goroutines, `node.rs:1635`; global kill-by-name of orphaned `p2pd` that can kill other
+nodes' daemons), and leaves all NAT/relay/AutoNAT capability in Go. Goal: a native
+rust-libp2p node, daemon removed entirely.
+
+Note: `docs/FEATURE_GAP_ANALYSIS.md` and `docs/HIVEMIND_RUST_ARCHITECTURE.md` describe the
+native-Rust stack as if it already exists — they are aspirational. This document reflects
+the verified current state.
+
+## Current state (verified)
+
+- `kwaai-p2p-daemon` = p2pd control-protocol **client** (identify, connect/disconnect,
+  list_peers, stream handlers, stream_open, persistent-conn unary handlers, DHT
+  put/get/find_peer/find_providers/provide). Its `build.rs` clones + `go build`s p2pd
+  (hard-fails without Go). Pubsub/connmanager/4 DHT verbs unimplemented — all unused.
+- `kwaai-p2p` (rust-libp2p 0.53.2) = **dead prototype**: kad+identify+stub, TCP/noise/yamux,
+  no event loop, DHT reads local-only, ephemeral keys. Only consumer is an example.
+- `kwaai-hivemind-dht` = hivemind DHT protobuf types (`DHTProtocol.rpc_{ping,store,find}`,
+  MessagePack values, SHA1(msgpack) 20-byte DHT IDs, f64 expiration). Gaps: storage ignores
+  subkeys (Petals module records are DictionaryDHTValues — mandatory), never returns
+  `FoundDictionary`, nearest-peers not XOR-sorted. Its 8-byte-BE+marker framing in
+  `codec.rs` is a kwaai invention that does NOT match the hivemind wire — replace, don't
+  reuse.
+- `kwaai-cli/src/node.rs` run_node(): spawn p2pd → register handlers (rpc_* forwarded to a
+  localhost TCP listener; unary handlers hello/ollama-proxy/shard-proxy/inference-mux) →
+  bootstrap dial → IDENTIFY self-discovery → **restart p2pd** with discovered addrs →
+  announce + 300 s re-announce loop, unannounce (state=-1) on shutdown.
+- The p2pd socket is a **multi-process service bus**: map-server crawler, `shard serve`,
+  `storage serve`, `rag`, `p2p`, `status`, vpk_bench, block_rpc, ollama_proxy, shard_api,
+  rag_api, inference_mux all attach as clients from other processes — and some **register
+  inbound handlers** (act as the node's peer identity). Any replacement must preserve this.
+- Python side (bootstraps = upstream petals `run_dht` via hivemind pip, RSA-2048 Qm… peer
+  IDs; health service) keeps its own p2pd — **out of scope**. Interop constraints:
+  TCP+noise+yamux dialability, hivemind `DHTProtocol.rpc_*` protocols, Kademlia peer
+  routing (`/ipfs/kad/1.0.0` — the go daemon uses defaults, no ProtocolPrefix), clean
+  protocol refusal for the health probe.
+
+## Feature gap: daemon features in use vs rust-libp2p
+
+| Daemon feature in use | rust-libp2p status |
+| --- | --- |
+| TCP v4/v6 + noise + yamux | ✅ |
+| Identify + observed-addr discovery | ✅ `libp2p-identify` |
+| Kademlia server mode, `/ipfs/kad/1.0.0` | ✅ `libp2p-kad` defaults interop |
+| Circuit relay v2 client + service | ✅ `libp2p-relay` |
+| dcutr hole punching | ✅ `libp2p-dcutr` |
+| AutoNAT (v1 — what go-libp2p speaks) | ✅ `libp2p-autonat` |
+| UPnP (`-natPortMap`) | ✅ `libp2p-upnp` |
+| **AutoRelay** (`-autoRelay -trustedRelays -relayDiscovery=false`) | ❌ **hand-roll** a RelayManager |
+| `-forceReachabilityPrivate` (config `force_private`, default true) | replaced by explicit reachability state machine |
+| RSA bootstrap peer IDs | ✅ `rsa` feature already enabled |
+| Unary handlers / persistent conn | wire format resolved (below); becomes `request_response` behaviour |
+| Pubsub, connmanager, QUIC | unused — out of scope |
+| Hivemind DictionaryDHTValue/subkeys | ❌ gap in our own `kwaai-hivemind-dht` — must implement |
+| 198.18.0.0/15 routability (nat-test bed) | rust-libp2p has **no default address blacklist** (`global_only` is opt-in) → the go-multiaddr patch apparatus retires |
+
+## Critical wire-format finding (verified in proto + Go source)
+
+Hivemind's unary RPC wrapper **is on the libp2p wire between peers**: one uvarint-delimited
+`PersistentConnectionRequest{callId, callUnary{peer, proto, data}}` out, one uvarint-delimited
+`PersistentConnectionRequest{callId, unaryResponse: CallUnaryResponse}` back, on a stream
+whose protocol ID is the bare handler name (no leading slash, e.g. `DHTProtocol.rpc_store`).
+`data` is the raw application protobuf.
+
+**Live interop bug found:** `wrap_stream_handler_response`
+(`kwaai-p2p-daemon/src/stream.rs:162-186`) writes a `PersistentConnectionResponse`
+(oneof field 2 = `callUnaryResponse`), but Go callers decode the reply as
+`PersistentConnectionRequest`, whose field 2 is `AddUnaryHandlerRequest` with a
+proto2-`required` `balanced` field → unmarshal failure. Every inbound rpc_ping/store/find
+served by a Rust node to a Go-daemon caller errors out today. The native codec must write
+`PersistentConnectionRequest{callId, unaryResponse}`; Phase 0 proves this against a real
+p2pd.
+
+## Design decisions
+
+1. **In-process swarm** lives in a gutted-and-rewritten `kwaai-p2p` crate (zero production
+   consumers today; keep `config.rs` skeleton). New files: `behaviour.rs`, `service.rs`
+   (single swarm task with command/handler-response/swarm-event/maintenance select loop),
+   `handle.rs` (`NetworkHandle` — clonable facade mirroring `P2PClient` method names),
+   `relay_manager.rs`, `addresses.rs`. Delete `network.rs`, `hivemind.rs`, `rpc.rs`,
+   `dht.rs`, `protocol.rs`.
+
+2. **Behaviour composition**: ping, identify, kad(MemoryStore, auto client/server mode +
+   `dht_server` config override), autonat(v1), relay client, `Toggle<relay server>`
+   (`!config.no_relay`), dcutr, `Toggle<upnp>`, `request_response<HivemindUnaryCodec>` for
+   ALL unary protocols (slash-less hivemind names via a custom `UnaryProtocol(Arc<str>)`
+   protocol type — `StreamProtocol::new` panics on slash-less, `request_response` only
+   needs `AsRef<str>`), `libp2p_stream` for slashed raw-stream protocols (inference-mux,
+   block_rpc). Transport: SwarmBuilder TCP+noise+yamux + dns + relay client. TCP-only
+   (fleet is TCP). Workspace libp2p features add: `ping, dcutr, autonat, upnp, dns`.
+
+3. **IPC for external processes — node-hosted p2pd-protocol control socket.** The node
+   serves the existing p2pd protobuf control protocol on the same socket path
+   (`KWAAINET_SOCKET` / `/tmp/kwaai-p2pd.sock`, TCP 5005 on Windows), translating into
+   `NetworkHandle` calls. All ~15 external client files (`client.rs`, `persistent.rs`,
+   `dht.rs` and every call site) stay **byte-for-byte unchanged**; external processes keep
+   acting as the node's peer identity, including `add_unary_handler` from
+   `shard serve`/`storage serve` (handler ownership tracked per socket connection;
+   deregister on disconnect — fixes today's stale-handler-after-crash bug). Serve only the
+   used subset; error on pubsub/connmgr. New: `kwaai-p2p-daemon/src/server.rs`.
+
+4. **Hivemind wire codec** in `kwaai-hivemind-dht/src/wire.rs` + minimal
+   `proto/persistent_conn.proto` (wire-compatible subset: PersistentConnectionRequest,
+   CallUnaryRequest/Response, Cancel, DaemonError; workspace prost 0.12 — kills the
+   0.12/0.13 split rationale). Delete the 8-byte-BE/marker framing; keep DHT prost types.
+   10 MiB inbound cap (parity). Fix the slashed constants in `lib.rs:31-33` (bare names).
+
+5. **DHT semantics completion** in `kwaai-hivemind-dht/src/server.rs`:
+   `Stored::{Regular, Dictionary(BTreeMap<subkey, (value, expiration)>)}`; per-subkey
+   freshness merge; `FoundDictionary` responses (msgpack DictionaryDHTValue layout —
+   verify against hivemind `dht/protocol.py` + live bootstrap capture); XOR-distance
+   nearest-peer selection over hivemind node IDs, k=20, fed from kad routing-table events.
+   Validators: follow-up, not parity-blocking.
+
+6. **NAT traversal**: reachability state machine (Unknown/Public/Private; `force_private`
+   short-circuits to Private = `-forceReachabilityPrivate` parity). AutoNAT probes against
+   bootstraps; identify observed-addrs + UPnP external addrs are candidates, promoted to
+   confirmed external addresses. RelayManager: reserve `/p2p-circuit` on up to 2 trusted
+   relays (or hop-capable bootstraps) when Private; backoff + rotation on loss; dcutr
+   upgrades relayed inbound to direct. **Announce lifecycle via
+   `watch::Receiver<AnnounceState>` — the entire p2pd restart dance is deleted**
+   (`restart_p2pd`, `restart_p2pd_with_addrs`, `discover_and_restart_with_announce`,
+   relay-addr cache, p2pd heartbeat/watchdog select arms, `find_p2pd_binary`,
+   `kill_orphaned_p2pd`).
+
+7. **Identity**: pass `NodeIdentity` keypair (`kwaai-cli/src/identity.rs`, already
+   Ed25519+RSA-capable protobuf encoding) to `SwarmBuilder::with_existing_identity`;
+   consider moving the loader into `kwaai-p2p` for map-server reuse.
+
+8. **Clean cut, no `--use-p2pd` runtime fallback** in shipped releases. Transition safety =
+   unchanged IPC protocol + last p2pd-based release tag remains installable (GUI pins via
+   `.kwaainet-version`) + dev-window flag on the feature branch only
+   (`native_p2p` config / `KWAAINET_NATIVE_P2P=1`, flipped then removed at cutover).
+
+9. **KwaaiNetGUI is runtime-transparent; the coupling is packaging-only.** No GUI source
+   touches p2pd (the `kwaainet` binary spawns it). But the GUI release workflow extracts
+   `p2pd`/`p2pd.exe` from the KwaaiNet release archive under strict error modes — an
+   archive without p2pd hard-fails the GUI build. The "gate" is one small change: make the
+   p2pd copy conditional-on-presence, landed before the first p2pd-free KwaaiNet tag;
+   delete the conditional later.
+
+10. **Forward-looking: Rust bootstrap nodes (design constraint, not in scope).** The
+    OpenAI-Petal Python bootstraps are themselves slated for replacement by KwaaiNet, and
+    the hivemind DHT is a known feature gap there. Decisions here must not paint us into a
+    corner: implement DHT storage/serving to *bootstrap grade* — real subkey/dictionary
+    semantics, XOR-sorted nearest peers fed from the kad routing table (not a flat list),
+    capacity/eviction that survives being a network root, and the `dht_server` mode knob.
+    Known additional gaps for a future Rust bootstrap, tracked but not built now: hivemind
+    record validators/signatures, petals `ReachabilityProtocol` (bootstraps serve it via
+    `attach_to_dht`), AutoNAT service + relay-hop service at bootstrap scale, RSA identity
+    generation (loading already works), and the health service's
+    `connect/disconnect/list_peers` probe surface.
+
+## Phasing (each independently landable)
+
+### Phase 0 — wire codec + interop proof (no behavior change)
+
+`kwaai-hivemind-dht/src/wire.rs` + `proto/persistent_conn.proto`; golden-byte tests.
+Interop test in `kwaai-network-tests`: real p2pd ↔ raw rust stream with new codec, both
+directions. Hot-fix the `stream.rs` response-wrapper bug in the p2pd path regardless —
+it's a live network bug. **This gates everything.**
+
+*Testable:* golden-byte unit tests of frame encode/decode; p2pd-in-the-loop round trips
+(rust codec calls a handler registered via P2PClient; p2pd `call_unary_handler` hits a
+raw-rust-served stream); explicit repro-then-fix test for the response-wrapper bug;
+empirical check that multistream-select negotiates the slash-less `DHTProtocol.rpc_ping`.
+
+*Expected issues:* proto2 `required` fields vs prost defaults (missing `balanced`/`callId`
+must fail loudly, not default); uvarint framing edge cases (multi-byte lengths, partial
+reads); the possibility that some deployed peer *depends* on the buggy responder format
+(unlikely — Go callers error out — but check the map-server crawler's find path);
+hivemind's Python client setting fields the Go daemon overwrites (e.g. `peer` in
+CallUnary) — match Go behavior, not Python's.
+
+### Phase 1 — swarm skeleton
+
+Rewrite `kwaai-p2p` (ping/identify/kad only), `NetworkService`/`NetworkHandle`, identity
+reuse from `kwaai-cli/src/identity.rs`.
+
+*Testable:* two-in-process-swarm unit tests (dial, identify exchange, kad lookup); against
+the live network or compose stack: dial bootstraps (RSA Qm… peers), `list_peers` shows
+them, kad FIND_PEER resolves a known peer, observed addrs captured from identify.
+
+*Expected issues:* RSA handshake with the Python bootstraps (rust-libp2p `rsa` feature is
+enabled but this path has never run in production); kad protocol-config drift (confirm
+`/ipfs/kad/1.0.0` and default query parallelism against go-libp2p-kad-dht); event-loop
+starvation mistakes (blocking calls inside the select loop); channel deadlocks between
+`NetworkHandle` calls and swarm events (command/oneshot leak on error paths).
+
+### Phase 2 — hivemind unary RPC native
+
+`request_response<HivemindUnaryCodec>` behaviour + handler dispatch; DHT serving + announce
+via `NetworkHandle`.
+
+*Testable:* node announces to bootstraps and shows on the health map; `rpc_find` against a
+Python bootstrap returns our record; a p2pd-based caller successfully calls our `rpc_ping`
+(previously broken inbound path); re-announce loop and clean unannounce (state=-1)
+observed on the bootstrap.
+
+*Expected issues:* `UnaryProtocol(Arc<str>)` slash-less negotiation end-to-end; per-request
+timeout semantics vs today's 30 s `send_to_bootstrap`; large-message caps (10 MiB parity);
+connect-before-call semantics (`call_unary_handler` must dial+resolve like Go's
+`host.NewStream`, or announces to not-yet-connected bootstraps fail); TTL/expiration
+skew — bootstraps reject TTLs shorter than the existing record (`node.rs:1381` note).
+
+### Phase 3 — IPC control-socket server + conformance rig
+
+`kwaai-p2p-daemon/src/server.rs`; rework `kwaai-network-tests/src/harness.rs`
+(`new_relay_server`/`new_dht_client`/`new_nat_client` spawn kwaainet nodes or in-process
+swarms instead of `DaemonBuilder`); existing client-side test bodies become the
+conformance suite — old tests, new server.
+
+*Testable:* the full existing daemon-client test suite green against the new server;
+multi-client smoke: `kwaainet status`, `p2p peers list`, `shard serve` (register handler +
+receive inbound call), `storage serve`, inference-mux `stream_open_raw`, two clients
+concurrently; handler deregistration on client disconnect (kill `storage serve`, verify
+the protocol is refused afterward).
+
+*Expected issues:* **riskiest sub-piece** — bidirectional callUnary routing across
+concurrent socket clients (handler ownership, disconnect cleanup, UUID call-ID collisions
+between independent clients); `stream_open_raw` pipe-mode fidelity (raw byte relay between
+unix socket and libp2p stream, backpressure both ways); subtle p2pd response-shape details
+existing clients depend on (error encodings, IdentifyResponse addr byte format); Windows
+TCP-socket path parity.
+
+### Phase 4 — node.rs integration behind flag + NAT traversal
+
+`native_p2p` selects the new path in run_node; hello/ollama-proxy/shard-proxy via
+`add_unary_handler`, inference-mux via `accept_streams`. autonat + upnp + RelayManager +
+dcutr + announce watch channel.
+
+*Testable (kwaaiai-env nat-test topology):* (a) direct node announces
+public_ip:public_port (incl. node-d asymmetric port map), (b) NATed↔NATed dcutr
+hole-punch (verify direct transport addr, not just connectivity), (c) symmetric-NAT node
+relay-only via trusted relay, (d) address change re-announces without restart, (e)
+unchanged map-server crawler sees all nodes (proves IPC compat end-to-end), (f) one
+p2pd-based node kept in the topology for the mixed-fleet window, fully interoperating.
+
+*Expected issues:* hand-rolled RelayManager edge cases (reservation refresh on relay
+restart, candidate rotation, duplicate circuit listens); dcutr success rate vs go-libp2p
+(measure, don't assume); AutoNAT v1 dialback against Python-bootstrap p2pd (if unanswered,
+identify-confirmation fallback must engage); RFC2544 addresses being classified
+unreachable somewhere in rust-libp2p (autonat/kad address scoring) — the nat-test bed will
+surface it; announce flapping if the address-book confirmation threshold is too eager.
+
+### Phase 5 — DHT parity + cutover + teardown
+
+- Dictionary/subkeys/XOR landed and verified against hivemind Python.
+- Flip default; delete: p2pd spawn path + watchdogs + `daemon.rs` + `kill_orphaned_p2pd` +
+  setup.rs p2pd download (`setup --get-deps` → no-op success) + `setup.sh:265`.
+- `kwaai-p2p-daemon/build.rs` → protoc-only (delete Go check/clone/build/P2PD_PATH); keep
+  crate as the IPC client+server (`client.rs`/`persistent.rs`/`dht.rs`/`server.rs`/proto).
+- Nix: delete `nix/p2pd.nix`; `flake.nix` drop p2pd outputs; `crane.nix` drop
+  `P2PD_BIN`/stub/`$out/bin/p2pd` symlink (keep pre-generated proto copy); `Makefile` p2pd
+  targets.
+- cargo-dist: `core/Cargo.toml` extra-artifacts, `scripts/build-p2pd.sh`, `release.yml`
+  setup-go + both p2pd-injection steps (incl. dist-manifest hash patching — native
+  checksums become correct again).
+- **GUI packaging tolerance (runtime is transparent):** make KwaaiNetGUI release
+  workflow's p2pd copy conditional-on-presence FIRST, then tag KwaaiNet vNEXT, then bump
+  `.kwaainet-version`; delete the conditional later. Also drop `p2pd` reaping in
+  OpenAI-Petal installers (`daemon_utils.py`, `Installer/*/kwaainet/daemon.py`).
+- kwaaiai-env: delete `docker/p2pd-patched/` + `patches/go-multiaddr/allow-rfc2544.patch`,
+  remove `p2pd-patched`/`nat-test-overlay-p2pd` services + depends_on edges + all
+  `GOLOG_LOG_LEVEL` envs (→ `RUST_LOG`); **keep** the bootstrap p2pd overlay patch (Python
+  side still needs it); update `patches/README.md`, `docs/nat-test-topology.md`, nat-test
+  node configs (preserve port/public_ip/public_port/announce_addr semantics).
+
+*Testable:* dictionary/subkey golden tests against hivemind Python semantics (capture
+`_petals.models` / `{prefix}.{block}` records from a live bootstrap; two peers storing
+under the same key accumulate, not overwrite); XOR nearest-peer ordering unit tests; full
+workspace builds **without a Go toolchain**; untar each release archive → `kwaainet` only,
+no `p2pd`, checksums valid without hash-patching; `kwaainet setup --get-deps` succeeds as
+a no-op; GUI CI dry-run against the release-candidate tag; final nat-test + compose
+acceptance re-run.
+
+*Expected issues:* hivemind's "regular store" subkey sentinel and DictionaryDHTValue
+msgpack layout not matching assumptions (verify against `hivemind/dht/protocol.py` first);
+nix/crane stub still referencing P2PD env vars breaking sandbox builds; cargo-dist
+regeneration clobbering hand-edited release.yml sections; stale `.kwaainet-version` or
+Homebrew-tap references to p2pd checksums; OpenAI-Petal installers killing the new
+single-binary node if reaping logic is only half-removed.
+
+**Riskiest steps:** (1) Phase 0's interop gate — if the wire assumptions are wrong nothing
+else lands; (2) Phase 3's persistent-conn server semantics for concurrent external
+clients; (3) dcutr/relay behavior parity under real NATs (mitigated by Phase 4 acceptance
+gates).
+
+## Open verification items
+
+- Hivemind's "regular store" subkey sentinel + exact DictionaryDHTValue msgpack layout
+  (read hivemind `dht/protocol.py`; golden-capture against a live bootstrap).
+- AutoNAT v1 service actually answering on bootstraps (fallback: identify-confirmation
+  path already kept; `force_private=true` default makes this low-risk).
+- Health-probe "protocol not supported" string vs rust-libp2p's unknown-protocol error
+  surface (the health patch matches on a substring).
+
+## Resolved verification items (Phase 0, `07_wire_interop` against a real p2pd)
+
+- Slash-less protocol IDs negotiate fine on the go-libp2p wire
+  (`slashless_protocol_negotiates`) — Phase 2's `UnaryProtocol(Arc<str>)` is viable.
+- The wire wrapper is exactly as described above (both directions proven; the old
+  `PersistentConnectionResponse` reply shape is provably rejected by Go callers).
+- **proto2 `required` is enforced by Go on unmarshal**: a frame omitting an empty
+  `peer`/`data` field is dropped and the stream reset. The wire.rs prost types carry
+  `required` labels so empty fields are still encoded.
+- **`callUnary.peer` is only rewritten to the caller's ID on the unary-handler dispatch
+  path.** On a raw stream handler it arrives exactly as the caller sent it (the callee's
+  ID, per Go's caller convention). A native responder must take caller identity from the
+  libp2p connection, never from this field.
+
+## Critical files
+
+- `core/crates/kwaai-p2p/src/*` — rewritten (service/handle/behaviour/relay_manager/addresses)
+- `core/crates/kwaai-hivemind-dht/src/{wire.rs(new),codec.rs,server.rs,lib.rs}`
+- `core/crates/kwaai-p2p-daemon/src/{server.rs(new),daemon.rs(delete),stream.rs(delete at cutover)}`, `build.rs`
+- `core/crates/kwaai-cli/src/{node.rs,daemon.rs,setup.rs,identity.rs}`
+- `core/crates/kwaai-network-tests/src/harness.rs`
+- `{flake.nix,nix/p2pd.nix,nix/crane.nix,Makefile,scripts/build-p2pd.sh,.github/workflows/release.yml,core/Cargo.toml}`
+- kwaaiai-env: `{docker-compose.yml,docker/p2pd-patched/,patches/go-multiaddr/,docker/nat-test/config-node-*.yaml,docs/nat-test-topology.md}`
+- KwaaiNetGUI: `.github/workflows/release.yml` (p2pd copy conditional)

--- a/tests/kwaai-network/results/metrics.jsonl
+++ b/tests/kwaai-network/results/metrics.jsonl
@@ -400,3 +400,25 @@
 {"timestamp":"2026-07-17T04:54:32.453156+00:00","git_rev":"7054ac3","test":"unit::rpc::server_frame_status_roundtrip","tier":"unit","passed":true,"duration_ms":0,"metrics":{}}{"timestamp":"2026-07-17T04:54:32.453175+00:00","git_rev":"7054ac3","test":"unit::rpc::server_frame_token_roundtrip","tier":"unit","passed":true,"duration_ms":0,"metrics":{}}
 
 {"timestamp":"2026-07-17T04:54:32.453168+00:00","git_rev":"7054ac3","test":"unit::rpc::server_frame_pong_roundtrip","tier":"unit","passed":true,"duration_ms":0,"metrics":{}}
+{"timestamp":"2026-07-31T05:39:51.267303+00:00","git_rev":"14a0bd1","test":"integration::wire::daemon_to_daemon","tier":"integration","passed":true,"duration_ms":265,"metrics":{"response_len":17}}
+{"timestamp":"2026-07-31T05:39:51.659471+00:00","git_rev":"14a0bd1","test":"integration::wire::old_shape_rejected","tier":"integration","passed":true,"duration_ms":136,"metrics":{"error_len":70}}
+{"timestamp":"2026-07-31T05:39:52.059542+00:00","git_rev":"14a0bd1","test":"integration::wire::responder_error_arm","tier":"integration","passed":true,"duration_ms":131,"metrics":{}}
+{"timestamp":"2026-07-31T05:40:41.411919+00:00","git_rev":"14a0bd1","test":"integration::wire::raw_responder","tier":"integration","passed":true,"duration_ms":116,"metrics":{"call_id_len":16}}
+{"timestamp":"2026-07-31T05:53:25.027584+00:00","git_rev":"14a0bd1","test":"integration::wire::raw_responder","tier":"integration","passed":true,"duration_ms":300,"metrics":{"call_id_len":16}}
+{"timestamp":"2026-07-31T05:53:25.027717+00:00","git_rev":"14a0bd1","test":"integration::wire::old_shape_rejected","tier":"integration","passed":true,"duration_ms":329,"metrics":{"error_len":70}}
+{"timestamp":"2026-07-31T05:53:25.037694+00:00","git_rev":"14a0bd1","test":"integration::wire::responder_error_arm","tier":"integration","passed":true,"duration_ms":385,"metrics":{}}
+{"timestamp":"2026-07-31T05:53:25.066942+00:00","git_rev":"14a0bd1","test":"integration::wire::daemon_to_daemon","tier":"integration","passed":true,"duration_ms":450,"metrics":{"response_len":17}}
+{"timestamp":"2026-07-31T05:56:09.588488+00:00","git_rev":"14a0bd1","test":"integration::wire::raw_caller","tier":"integration","passed":true,"duration_ms":230,"metrics":{}}
+{"timestamp":"2026-07-31T05:56:09.588461+00:00","git_rev":"14a0bd1","test":"integration::wire::multibyte_prefix","tier":"integration","passed":true,"duration_ms":232,"metrics":{"payload_bytes":4096}}
+{"timestamp":"2026-07-31T05:56:09.589993+00:00","git_rev":"14a0bd1","test":"integration::wire::responder_error_arm","tier":"integration","passed":true,"duration_ms":233,"metrics":{}}
+{"timestamp":"2026-07-31T05:56:09.592294+00:00","git_rev":"14a0bd1","test":"integration::wire::raw_responder","tier":"integration","passed":true,"duration_ms":232,"metrics":{"call_id_len":16}}
+{"timestamp":"2026-07-31T05:56:09.600899+00:00","git_rev":"14a0bd1","test":"integration::wire::daemon_to_daemon","tier":"integration","passed":true,"duration_ms":231,"metrics":{"response_len":17}}
+{"timestamp":"2026-07-31T05:56:09.642904+00:00","git_rev":"14a0bd1","test":"integration::wire::old_shape_rejected","tier":"integration","passed":true,"duration_ms":273,"metrics":{"error_len":70}}
+{"timestamp":"2026-07-31T05:56:09.650891+00:00","git_rev":"14a0bd1","test":"integration::wire::slashless_protocol","tier":"integration","passed":true,"duration_ms":291,"metrics":{}}
+{"timestamp":"2026-07-31T05:57:19.111807+00:00","git_rev":"14a0bd1","test":"integration::wire::slashless_protocol","tier":"integration","passed":true,"duration_ms":152,"metrics":{}}
+{"timestamp":"2026-07-31T05:57:19.112487+00:00","git_rev":"14a0bd1","test":"integration::wire::daemon_to_daemon","tier":"integration","passed":true,"duration_ms":157,"metrics":{"response_len":17}}
+{"timestamp":"2026-07-31T05:57:19.125600+00:00","git_rev":"14a0bd1","test":"integration::wire::multibyte_prefix","tier":"integration","passed":true,"duration_ms":156,"metrics":{"payload_bytes":4096}}
+{"timestamp":"2026-07-31T05:57:19.126307+00:00","git_rev":"14a0bd1","test":"integration::wire::old_shape_rejected","tier":"integration","passed":true,"duration_ms":153,"metrics":{"error_len":70}}
+{"timestamp":"2026-07-31T05:57:19.131699+00:00","git_rev":"14a0bd1","test":"integration::wire::raw_caller","tier":"integration","passed":true,"duration_ms":159,"metrics":{}}
+{"timestamp":"2026-07-31T05:57:19.140223+00:00","git_rev":"14a0bd1","test":"integration::wire::raw_responder","tier":"integration","passed":true,"duration_ms":183,"metrics":{"call_id_len":16}}
+{"timestamp":"2026-07-31T05:57:19.149713+00:00","git_rev":"14a0bd1","test":"integration::wire::responder_error_arm","tier":"integration","passed":true,"duration_ms":195,"metrics":{}}


### PR DESCRIPTION
**Stack** (review in order; each PR shows only its own diff):
| # | PR | What |
|---|----|------|
| 0 | #91 | build: patched deps via fetch script |
| 1 | #80 | hivemind unary wire codec |
| 2 | #81 | in-process rust-libp2p swarm |
| 3 | #82 | hivemind unary RPC |
| 4 | #83 | native hivemind DHT serving |
| 5 | #84 | p2pd control socket + pipe mode |
| 6 | #85 | run_node native path behind the flag |
| 7 | #86 | NAT traversal + libp2p 0.56 |

Rebuilt from the 73-commit `feat/native-p2p` branch into 57 commits. Tip is functionally identical to that branch.

---

## What this adds

A codec for hivemind's unary-RPC wire format — the uvarint-framed `PersistentConnectionRequest` envelopes that actually travel on a libp2p stream between peers — plus the fix for a long-standing bug in which our reply envelope used the wrong message type entirely.

## Why

Every later PR in this stack needs to speak hivemind's unary RPC natively. That format was not previously written down anywhere in this repo, and where it *was* implemented (`kwaai-p2p-daemon/src/stream.rs`) it was wrong: the reply was encoded as a `PersistentConnectionResponse`, a message that exists only on the daemon's local control socket, not on the peer-to-peer wire. Getting the envelope right is a prerequisite for a native responder, and documenting it as a schema of record stops the same mistake recurring. This PR also establishes the interop test tier that every subsequent phase gates on.

## What's in it

**The codec — `core/crates/kwaai-hivemind-dht/src/wire.rs`**

- Encode/decode for both directions of the hivemind unary exchange:
  - caller → `uvarint(len) ++ PersistentConnectionRequest{callId, callUnary}`
  - caller ← `uvarint(len) ++ PersistentConnectionRequest{callId, unaryResponse}`
  - on a stream whose protocol ID is the bare handler name with no leading slash (e.g. `DHTProtocol.rpc_store`), with `data` carrying the raw application protobuf.
- uvarint framing with a 10 MiB cap matching the Go daemon's `persistentConnMsgMaxSize`.
- An async `read_framed` that handles multi-byte varints and partial reads without over-consuming into the next frame.
- `core/crates/kwaai-hivemind-dht/proto/persistent_conn.proto` — the schema of record. A wire-compatible subset of `kwaai-p2p-daemon/proto/p2pd.proto` with field numbers copied verbatim. As with `proto/dht.proto` and `protocol.rs`, the Rust types are hand-written prost derives; this crate has no `build.rs`.

**The fix — `core/crates/kwaai-p2p-daemon/src/stream.rs`**

- `wrap_stream_handler_response` now emits a `PersistentConnectionRequest` with the `unaryResponse` arm (field 4) instead of a `PersistentConnectionResponse` (whose `callUnaryResponse` sits at field 2). Verified against go-libp2p-daemon `persistent_stream.go`, where `Daemon.exchangeMessages` reads the reply into `&pb.PersistentConnectionRequest{}` and calls `GetUnaryResponse()`.
- The old encoding, decoded as a `PersistentConnectionRequest`, reinterprets a `CallUnaryResponse{response: "pong"}` as `AddUnaryHandlerRequest{proto: "pong", balanced: false}` — a DHT payload read as a handler-registration name. Go's gogo proto2 rejects it outright since `required bool balanced` is absent. Either way `GetUnaryResponse()` is nil.

**Design record — `docs/NATIVE_P2P_MIGRATION.md`** (new, 331 lines): the wire format, the verification record, and the open/resolved verification items the later phases reference.

## Risk

**No default runtime behaviour changes** in the sense that matters for a dark launch — but note this PR does contain one genuine bug fix on shared code, so it deserves a closer read than the rest of the stack.

- `wrap_stream_handler_response` is corrected rather than added. **It has no callers anywhere in the workspace today** (verified by grep across `core/crates` at this commit), so in practice the change is confined to a function that nothing invokes; the native responder in PR3 is its first consumer. If a reviewer knows of an out-of-tree caller, that is the one place to look.
- `wire.rs` and `persistent_conn.proto` are new modules with no consumers at this commit.
- The `07_wire_interop` tier is gated behind `KWAAI_INTEGRATION_TESTS=1` like the other integration tiers, so it does not run in the default test path.

## Test coverage

**Unit tests in `wire.rs`** — golden byte layouts (including an explicit assertion that the reply oneof arm sits at field 4, not the historical field 2), varint width boundaries at 0/127/128/16383/16384, oversized-frame rejection on the length declaration alone, runaway varints, truncated payloads, and decode of a `DaemonError` payload.

**Unit tests in `stream.rs`** — that the emitted bytes decode as a `PersistentConnectionRequest` with the `unaryResponse` arm; that the arm's tag byte is `0x22` (field 4) rather than `0x12` (field 2); the unwrap/wrap round trip a stream handler performs; and the mis-decode above kept as an explicit regression witness.

**Tier 07 — `core/crates/kwaai-network-tests/tests/07_wire_interop.rs`** (7 tests, real go-libp2p-daemon on the other end of the stream):

- our responder frames are accepted by a p2pd caller, and the old `PersistentConnectionResponse` shape is provably rejected — the historical bug was real;
- our caller frames are accepted by a p2pd responder, including an empty payload and a multi-byte uvarint length prefix;
- the error arm propagates to the caller;
- multistream-select negotiates the slash-less `DHTProtocol.rpc_ping` protocol ID verbatim — this is the empirical proof that PR0's patch does what it claims.

Harness: `TestNode::new_wire_peer()` spawns a bare p2pd (no DHT, relay or bootstrap) on its own tmpdir socket with a throwaway identity.

**One measured finding recorded for later phases:** on a raw stream handler, `callUnary.peer` arrives unrewritten — it carries the callee's ID as the caller sent it. Only the unary-handler dispatch path rewrites it to the caller. PR3's native responder therefore takes caller identity from the connection, never from this field.

## Stacked on

`native-p2p-pr0-build-patched-deps`

---

## Verification run for this PR

- `cargo build --workspace --all-targets` at this branch head: clean.
- `cargo test --workspace`: **663 passing, 0 failures.**
- Daemon run, `native_p2p: false` (the flag does not exist before PR6, so only the p2pd path is meaningful here): starts, connects to bootstraps, no panic, clean shutdown.

This PR is one of a stack rebuilt from the 73-commit `feat/native-p2p` branch. The stack tip is functionally identical to that branch: the only difference in the whole tree is comment text in `core/Cargo.toml`.

---

**Rebased onto `main` @ v0.5.5 (2026-08-06).** Upstream landed Capacity Lease admission control (#a0a4065), which touched files this stack moves or refactors. Two conflicts were resolved, both carrying upstream's change forward rather than dropping it:

- **#83** — upstream added `lease_v1` to `DHTServerInfo`, which this PR relocates to `announce.rs`. The field, its encoder entry and its doc comment moved with the type; upstream's own `to_msgpack_announces_lease_v1_true` test passes against the relocated struct.
- **#85** — upstream added the lease admission gate to the mux frame loop, which this PR extracts into `serve_mux_frames`. `lease_table` and `connection_id` are threaded through, and the native mux path registers the capacity-lease handler, so the native transport is gated identically to the p2pd one rather than bypassing it.

Per-branch verification after the rebase (all clean, 0 failures): 659 / 689 / 696 / 723 / 784 / 824 / 829 / 916 tests.

