### PR TITLE
feat(kwaai-p2p): hivemind unary RPC over the native swarm (native-p2p 3/7)

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3123,6 +3123,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "futures",
+ "kwaai-hivemind-dht",
  "libp2p",
  "serde",
  "serde_json",
@@ -3132,6 +3133,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/core/crates/kwaai-network-tests/tests/08_unary_swarm_interop.rs
+++ b/core/crates/kwaai-network-tests/tests/08_unary_swarm_interop.rs
@@ -1,0 +1,249 @@
+//! `unary::Behaviour` ↔ real p2pd interop — the Phase 2 swarm gate.
+//!
+//! Where `07_wire_interop` proved the *frame bytes* against a Go daemon over
+//! p2pd-managed streams, this tier proves the whole native stack: a rust-libp2p
+//! swarm running `kwaai_p2p::unary::Behaviour` negotiates TCP + noise + yamux +
+//! slash-less multistream-select against go-libp2p and exchanges hivemind
+//! unary calls in both directions.
+//!
+//! This is also the live check on the vendored `multistream-select` patch
+//! (`core/patches/multistream-select`): a Go peer must accept our bare-name
+//! proposal, and our listener must parse Go's.
+//!
+//! | test | caller | responder |
+//! | --- | --- | --- |
+//! | `swarm_calls_daemon_handler` | **swarm** | p2pd |
+//! | `daemon_calls_swarm_handler` | p2pd | **swarm** |
+//! | `swarm_gets_clean_refusal_from_daemon` | **swarm** | p2pd (no handler) |
+//!
+//! Gate: `KWAAI_INTEGRATION_TESTS=1`, like the other integration tiers.
+
+use std::time::Duration;
+
+use kwaai_network_tests::{harness::TestNode, metrics::MetricsRecorder, require_integration};
+use kwaai_p2p::unary::{self, UnaryError, UnaryProtocol, UnaryResult};
+use libp2p::futures::StreamExt;
+use libp2p::{swarm::SwarmEvent, Multiaddr, PeerId, Swarm, SwarmBuilder};
+use tokio::sync::{mpsc, oneshot};
+
+const PROTO: &str = "DHTProtocol.rpc_ping";
+const CALL_TIMEOUT: Duration = Duration::from_secs(20);
+
+// ============================================================================
+// Swarm harness
+// ============================================================================
+
+/// A driven swarm node: commands in via channels, its event loop on a task.
+struct SwarmNode {
+    peer_id: PeerId,
+    /// Listen address including `/p2p/<id>`, dialable by a p2pd.
+    addr: String,
+    calls: mpsc::UnboundedSender<(PeerId, String, Vec<u8>, oneshot::Sender<UnaryResult>)>,
+}
+
+impl SwarmNode {
+    /// Spawn a swarm serving `PROTO` with `handler`, and knowing `known_peer`'s
+    /// address for dial-on-demand.
+    async fn spawn(
+        known_peer: Option<(PeerId, Multiaddr)>,
+        handler: impl Fn(Vec<u8>) -> Result<Vec<u8>, String> + Send + 'static,
+    ) -> Self {
+        let mut swarm: Swarm<unary::Behaviour> = SwarmBuilder::with_new_identity()
+            .with_tokio()
+            .with_tcp(
+                libp2p::tcp::Config::default().nodelay(true),
+                libp2p::noise::Config::new,
+                libp2p::yamux::Config::default,
+            )
+            .expect("tcp transport")
+            .with_behaviour(|_| unary::Behaviour::new(unary::Config::default()))
+            .expect("behaviour")
+            .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(60)))
+            .build();
+
+        swarm
+            .behaviour_mut()
+            .register_protocol(UnaryProtocol::new(PROTO));
+        if let Some((peer, addr)) = known_peer {
+            swarm.add_peer_address(peer, addr);
+        }
+
+        let peer_id = *swarm.local_peer_id();
+        swarm
+            .listen_on("/ip4/127.0.0.1/tcp/0".parse().expect("valid multiaddr"))
+            .expect("listen");
+        let listen_addr = loop {
+            if let SwarmEvent::NewListenAddr { address, .. } = swarm.select_next_some().await {
+                break address;
+            }
+        };
+
+        let (calls_tx, mut calls_rx) =
+            mpsc::unbounded_channel::<(PeerId, String, Vec<u8>, oneshot::Sender<UnaryResult>)>();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    call = calls_rx.recv() => match call {
+                        Some((peer, proto, data, reply)) => swarm.behaviour_mut().send_request(
+                            peer,
+                            UnaryProtocol::new(proto),
+                            data,
+                            reply,
+                        ),
+                        None => break,
+                    },
+                    event = swarm.select_next_some() => {
+                        if let SwarmEvent::Behaviour(unary::Event::InboundRequest { request, .. }) = event {
+                            let _ = request.responder.send(handler(request.data));
+                        }
+                    }
+                }
+            }
+        });
+
+        Self {
+            peer_id,
+            addr: format!("{listen_addr}/p2p/{peer_id}"),
+            calls: calls_tx,
+        }
+    }
+
+    async fn call(&self, peer: PeerId, proto: &str, data: &[u8]) -> UnaryResult {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.calls
+            .send((peer, proto.to_string(), data.to_vec(), reply_tx))
+            .expect("swarm task alive");
+        tokio::time::timeout(CALL_TIMEOUT, reply_rx)
+            .await
+            .expect("call must resolve within the timeout")
+            .expect("reply oneshot must not be dropped")
+    }
+}
+
+/// The daemon's peer identity as swarm-side types.
+fn daemon_peer(node: &TestNode) -> (PeerId, Multiaddr) {
+    let peer_id = PeerId::from_bytes(&node.peer_id_bytes()).expect("valid peer id bytes");
+    let port = node.p2p_port.expect("wire peer has a fixed port");
+    let addr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{port}")
+        .parse()
+        .expect("valid multiaddr");
+    (peer_id, addr)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Native swarm → Go daemon: our dialer negotiates noise, yamux and the bare
+/// protocol name against go-libp2p, and the daemon-served handler answers.
+#[tokio::test]
+async fn swarm_calls_daemon_handler() {
+    require_integration!();
+    let mut rec = MetricsRecorder::start(
+        "integration::unary_swarm::swarm_calls_daemon",
+        "integration",
+    );
+
+    let daemon = TestNode::new_wire_peer().await.expect("wire peer daemon");
+    daemon
+        .client
+        .add_unary_handler(
+            PROTO,
+            |req: Vec<u8>| async move {
+                let mut out = b"daemon:".to_vec();
+                out.extend_from_slice(&req);
+                Ok(out)
+            },
+            false,
+        )
+        .await
+        .expect("register unary handler on daemon");
+
+    let (daemon_id, daemon_addr) = daemon_peer(&daemon);
+    let swarm = SwarmNode::spawn(Some((daemon_id, daemon_addr)), |data| Ok(data)).await;
+
+    let response = swarm
+        .call(daemon_id, PROTO, b"from-swarm")
+        .await
+        .expect("a Go daemon must accept a native swarm's unary call");
+    assert_eq!(response, b"daemon:from-swarm");
+
+    rec.metric("response_len", response.len());
+    rec.finish(true);
+}
+
+/// Go daemon → native swarm: go-libp2p dials us, proposes the bare name, and
+/// our behaviour serves the call.
+#[tokio::test]
+async fn daemon_calls_swarm_handler() {
+    require_integration!();
+    let mut rec = MetricsRecorder::start(
+        "integration::unary_swarm::daemon_calls_swarm",
+        "integration",
+    );
+
+    let mut daemon = TestNode::new_wire_peer().await.expect("wire peer daemon");
+    let swarm = SwarmNode::spawn(None, |data| {
+        let mut out = b"swarm:".to_vec();
+        out.extend_from_slice(&data);
+        Ok(out)
+    })
+    .await;
+
+    daemon
+        .client
+        .connect_peer(&swarm.addr)
+        .await
+        .expect("daemon must dial the native swarm");
+
+    let response = tokio::time::timeout(
+        CALL_TIMEOUT,
+        daemon
+            .client
+            .call_unary_handler(&swarm.peer_id.to_bytes(), PROTO, b"from-daemon"),
+    )
+    .await
+    .expect("call did not time out")
+    .expect("a native swarm must serve a Go daemon's unary call");
+    assert_eq!(response, b"swarm:from-daemon");
+
+    rec.metric("response_len", response.len());
+    rec.finish(true);
+}
+
+/// Calling a protocol the daemon does not serve must come back as the clean
+/// `UnsupportedProtocol` refusal (go-libp2p answering `na`), and the
+/// connection must remain usable.
+#[tokio::test]
+async fn swarm_gets_clean_refusal_from_daemon() {
+    require_integration!();
+    let rec = MetricsRecorder::start("integration::unary_swarm::clean_refusal", "integration");
+
+    let daemon = TestNode::new_wire_peer().await.expect("wire peer daemon");
+    daemon
+        .client
+        .add_unary_handler(PROTO, |req: Vec<u8>| async move { Ok(req) }, false)
+        .await
+        .expect("register unary handler on daemon");
+
+    let (daemon_id, daemon_addr) = daemon_peer(&daemon);
+    let swarm = SwarmNode::spawn(Some((daemon_id, daemon_addr)), |data| Ok(data)).await;
+
+    let error = swarm
+        .call(daemon_id, "DHTProtocol.rpc_nonexistent", b"x")
+        .await
+        .expect_err("unserved protocol must be refused");
+    assert!(
+        matches!(error, UnaryError::UnsupportedProtocol(_)),
+        "expected UnsupportedProtocol, got {error:?}"
+    );
+
+    let response = swarm
+        .call(daemon_id, PROTO, b"still-alive")
+        .await
+        .expect("the connection must survive the refusal");
+    assert_eq!(response, b"still-alive");
+
+    rec.finish(true);
+}

--- a/core/crates/kwaai-network-tests/tests/09_service_unary_interop.rs
+++ b/core/crates/kwaai-network-tests/tests/09_service_unary_interop.rs
@@ -1,0 +1,331 @@
+//! `NetworkService` ↔ real p2pd unary interop — the Phase 2 service gate.
+//!
+//! `08_unary_swarm_interop` proved `unary::Behaviour` against a Go daemon with a
+//! hand-driven bare swarm. This tier raises the left-hand side to the thing
+//! production will actually run: a full [`NetworkService`] — the composed
+//! `KwaaiBehaviour` (ping + identify + kad + unary) behind a `NetworkHandle` —
+//! exchanging hivemind unary calls with a real p2pd in both directions.
+//!
+//! What that adds over 08:
+//!
+//! - the call path is `NetworkHandle::call_unary_handler`, including its
+//!   `UnaryError` → `P2PError` mapping, rather than raw `send_request`,
+//! - inbound calls go through the service's dispatch map and a handler
+//!   registered with `NetworkHandle::add_unary_handler`, not an inline match on
+//!   a swarm event,
+//! - ping, identify and kad share the connection, so this also checks that the
+//!   composed behaviour does not disturb unary negotiation against go-libp2p
+//!   (identify runs on the same connection; a Go peer must tolerate it).
+//!
+//! ```text
+//!   [NetworkService]  ◀──unary──▶  [p2pd]
+//! ```
+//!
+//! | test | caller | responder |
+//! | --- | --- | --- |
+//! | `service_calls_daemon_handler` | **service** | p2pd |
+//! | `daemon_calls_service_handler` | p2pd | **service** |
+//! | `service_maps_daemon_refusal_to_protocol_error` | **service** | p2pd (no handler) |
+//! | `removing_a_handler_makes_the_daemon_call_fail` | p2pd | **service** (handler removed) |
+//!
+//! Gate: `KWAAI_INTEGRATION_TESTS=1`, like the other integration tiers.
+//!
+//! # Process hygiene
+//!
+//! Each daemon is spawned via `TestNode::new_wire_peer`, whose `P2PDaemon`
+//! kills **its own child by PID** on drop — nothing here kills by process name
+//! or touches the default socket path. The `NetworkService` side listens on an
+//! ephemeral loopback port with a freshly generated key, so it cannot collide
+//! with a node running on the same machine; its task is shut down explicitly at
+//! the end of each test.
+
+use std::time::Duration;
+
+use kwaai_network_tests::{harness::TestNode, metrics::MetricsRecorder, require_integration};
+use kwaai_p2p::{NetworkConfig, NetworkHandle, NetworkService, P2PError, PeerId};
+use libp2p::{identity::Keypair, Multiaddr};
+
+const PROTO: &str = "DHTProtocol.rpc_ping";
+
+/// Cap on any single daemon interaction, so a regression surfaces as a failure
+/// rather than a hung suite.
+const CALL_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// A `NetworkService` on loopback, kept alive with its task.
+struct ServiceNode {
+    handle: NetworkHandle,
+    peer_id: PeerId,
+    /// Listen address including `/p2p/<id>`, dialable by a p2pd.
+    addr: String,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl ServiceNode {
+    /// Spawn a loopback service. `kad_hint`, when given, seeds the routing
+    /// table so a unary call can dial the peer on demand — the same route
+    /// production takes, where Kademlia supplies the address.
+    async fn spawn(kad_hint: Option<(PeerId, Multiaddr)>) -> Self {
+        let keypair = Keypair::generate_ed25519();
+        let peer_id = keypair.public().to_peer_id();
+        let (handle, task) = NetworkService::spawn(NetworkConfig::for_tests(), keypair)
+            .expect("network service should start");
+
+        let listen_addr = tokio::time::timeout(CALL_TIMEOUT, async {
+            loop {
+                if let Some(addr) = handle
+                    .listen_addrs()
+                    .await
+                    .ok()
+                    .and_then(|a| a.into_iter().next())
+                {
+                    return addr;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("the service must report a listen address");
+
+        if let Some((peer, addr)) = kad_hint {
+            handle
+                .add_kad_address(peer, addr)
+                .await
+                .expect("seed the routing table");
+        }
+
+        Self {
+            handle,
+            peer_id,
+            addr: format!("{listen_addr}/p2p/{peer_id}"),
+            task,
+        }
+    }
+
+    /// Stop the event loop and wait for the task to exit, so a test never
+    /// leaves a listener behind.
+    async fn shutdown(self) {
+        let _ = self.handle.shutdown().await;
+        let _ = tokio::time::timeout(Duration::from_secs(5), self.task).await;
+    }
+}
+
+/// The daemon's peer identity as swarm-side types.
+fn daemon_peer(node: &TestNode) -> (PeerId, Multiaddr) {
+    let peer_id = PeerId::from_bytes(&node.peer_id_bytes()).expect("valid peer id bytes");
+    let port = node.p2p_port.expect("wire peer has a fixed port");
+    let addr: Multiaddr = format!("/ip4/127.0.0.1/tcp/{port}")
+        .parse()
+        .expect("valid multiaddr");
+    (peer_id, addr)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Service → Go daemon: `call_unary_handler` dials on demand off the Kademlia
+/// hint, negotiates the bare protocol name against go-libp2p, and returns the
+/// daemon-served handler's bytes.
+#[tokio::test]
+async fn service_calls_daemon_handler() {
+    require_integration!();
+    let mut rec = MetricsRecorder::start(
+        "integration::service_unary::service_calls_daemon",
+        "integration",
+    );
+
+    let daemon = TestNode::new_wire_peer().await.expect("wire peer daemon");
+    daemon
+        .client
+        .add_unary_handler(
+            PROTO,
+            |req: Vec<u8>| async move {
+                let mut out = b"daemon:".to_vec();
+                out.extend_from_slice(&req);
+                Ok(out)
+            },
+            false,
+        )
+        .await
+        .expect("register unary handler on daemon");
+
+    let (daemon_id, daemon_addr) = daemon_peer(&daemon);
+    let service = ServiceNode::spawn(Some((daemon_id, daemon_addr))).await;
+
+    let response = tokio::time::timeout(
+        CALL_TIMEOUT,
+        service
+            .handle
+            .call_unary_handler(daemon_id, PROTO, b"from-service"),
+    )
+    .await
+    .expect("the call must resolve within the timeout")
+    .expect("a Go daemon must accept a NetworkService's unary call");
+    assert_eq!(response, b"daemon:from-service");
+
+    rec.metric("response_len", response.len());
+    service.shutdown().await;
+    rec.finish(true);
+}
+
+/// Go daemon → service: go-libp2p dials us, and the call is dispatched through
+/// the service's handler map to a closure registered via `add_unary_handler`.
+#[tokio::test]
+async fn daemon_calls_service_handler() {
+    require_integration!();
+    let mut rec = MetricsRecorder::start(
+        "integration::service_unary::daemon_calls_service",
+        "integration",
+    );
+
+    let mut daemon = TestNode::new_wire_peer().await.expect("wire peer daemon");
+    let service = ServiceNode::spawn(None).await;
+
+    service
+        .handle
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move {
+            let mut out = b"service:".to_vec();
+            out.extend_from_slice(&data);
+            Ok(out)
+        })
+        .await
+        .expect("register a handler on the service");
+
+    daemon
+        .client
+        .connect_peer(&service.addr)
+        .await
+        .expect("daemon must dial the NetworkService");
+
+    let response = tokio::time::timeout(
+        CALL_TIMEOUT,
+        daemon
+            .client
+            .call_unary_handler(&service.peer_id.to_bytes(), PROTO, b"from-daemon"),
+    )
+    .await
+    .expect("call did not time out")
+    .expect("a NetworkService must serve a Go daemon's unary call");
+    assert_eq!(response, b"service:from-daemon");
+
+    rec.metric("response_len", response.len());
+    service.shutdown().await;
+    rec.finish(true);
+}
+
+/// A protocol the daemon does not serve comes back as go-libp2p's clean `na`
+/// refusal, which the handle reports as `P2PError::Protocol` — and the
+/// connection stays usable afterwards.
+#[tokio::test]
+async fn service_maps_daemon_refusal_to_protocol_error() {
+    require_integration!();
+    let rec = MetricsRecorder::start(
+        "integration::service_unary::refusal_maps_to_protocol_error",
+        "integration",
+    );
+
+    let daemon = TestNode::new_wire_peer().await.expect("wire peer daemon");
+    daemon
+        .client
+        .add_unary_handler(PROTO, |req: Vec<u8>| async move { Ok(req) }, false)
+        .await
+        .expect("register unary handler on daemon");
+
+    let (daemon_id, daemon_addr) = daemon_peer(&daemon);
+    let service = ServiceNode::spawn(Some((daemon_id, daemon_addr))).await;
+
+    let error = tokio::time::timeout(
+        CALL_TIMEOUT,
+        service
+            .handle
+            .call_unary_handler(daemon_id, "DHTProtocol.rpc_nonexistent", b"x"),
+    )
+    .await
+    .expect("the refusal must resolve within the timeout")
+    .expect_err("an unserved protocol must be refused");
+
+    match &error {
+        P2PError::Protocol(text) => assert!(
+            text.contains("does not support"),
+            "a negotiation refusal must map to an unsupported-protocol message, got {text}"
+        ),
+        other => panic!("expected P2PError::Protocol, got {other:?}"),
+    }
+
+    let response = tokio::time::timeout(
+        CALL_TIMEOUT,
+        service
+            .handle
+            .call_unary_handler(daemon_id, PROTO, b"still-alive"),
+    )
+    .await
+    .expect("the follow-up call must resolve")
+    .expect("the connection must survive the refusal");
+    assert_eq!(response, b"still-alive");
+
+    service.shutdown().await;
+    rec.finish(true);
+}
+
+/// `remove_unary_handler` must be visible to a foreign stack: after removal the
+/// daemon's call fails rather than hanging or being silently accepted. This is
+/// the deregistration path Phase 3 relies on when an IPC client disconnects.
+#[tokio::test]
+async fn removing_a_handler_makes_the_daemon_call_fail() {
+    require_integration!();
+    let rec = MetricsRecorder::start(
+        "integration::service_unary::removal_visible_to_daemon",
+        "integration",
+    );
+
+    let mut daemon = TestNode::new_wire_peer().await.expect("wire peer daemon");
+    let service = ServiceNode::spawn(None).await;
+
+    service
+        .handle
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("register a handler on the service");
+
+    daemon
+        .client
+        .connect_peer(&service.addr)
+        .await
+        .expect("daemon must dial the NetworkService");
+
+    let response = tokio::time::timeout(
+        CALL_TIMEOUT,
+        daemon
+            .client
+            .call_unary_handler(&service.peer_id.to_bytes(), PROTO, b"before"),
+    )
+    .await
+    .expect("call did not time out")
+    .expect("the handler is registered");
+    assert_eq!(response, b"before");
+
+    assert!(
+        service
+            .handle
+            .remove_unary_handler(PROTO)
+            .await
+            .expect("remove should reach the service"),
+        "removing a registered handler reports true"
+    );
+
+    let result = tokio::time::timeout(
+        CALL_TIMEOUT,
+        daemon
+            .client
+            .call_unary_handler(&service.peer_id.to_bytes(), PROTO, b"after"),
+    )
+    .await
+    .expect("the post-removal call must resolve, not hang");
+    assert!(
+        result.is_err(),
+        "a removed handler must not answer, got {result:?}"
+    );
+
+    service.shutdown().await;
+    rec.finish(true);
+}

--- a/core/crates/kwaai-p2p/Cargo.toml
+++ b/core/crates/kwaai-p2p/Cargo.toml
@@ -16,6 +16,8 @@ async-trait = { workspace = true }
 
 # P2P
 libp2p = { workspace = true }
+kwaai-hivemind-dht = { workspace = true }  # hivemind unary wire codec
+uuid = { workspace = true }                # 16-byte call IDs on the unary wire
 
 # Serialization
 serde = { workspace = true }

--- a/core/crates/kwaai-p2p/src/behaviour.rs
+++ b/core/crates/kwaai-p2p/src/behaviour.rs
@@ -1,7 +1,6 @@
 //! The composed libp2p `NetworkBehaviour` for a KwaaiNet node.
 //!
-//! Phase 1 composes the minimum set needed for a node to join the network and
-//! be observed by it:
+//! The minimum set needed for a node to join the network and be observed by it:
 //!
 //! - [`ping`] — liveness / RTT, and it keeps otherwise-idle connections honest.
 //! - [`identify`] — protocol/agent advertisement plus the **observed address**
@@ -10,6 +9,10 @@
 //!   protocol. This is deliberate: the Python bootstraps run hivemind's
 //!   go-libp2p daemon with no `ProtocolPrefix`, so any custom protocol name
 //!   here silently partitions us from the live network.
+//!
+//! - [`unary`] — hivemind unary RPC. Inbound handler protocols register at
+//!   runtime, so the behaviour starts with an empty protocol set and the
+//!   service loop drives `register_protocol`/`unregister_protocol`.
 
 use std::time::Duration;
 
@@ -22,6 +25,7 @@ use libp2p::{
 };
 
 use crate::config::NetworkConfig;
+use crate::unary;
 
 /// The `protocol_version` advertised over identify.
 ///
@@ -42,6 +46,7 @@ pub struct KwaaiBehaviour {
     pub ping: ping::Behaviour,
     pub identify: identify::Behaviour,
     pub kad: kad::Behaviour<MemoryStore>,
+    pub unary: unary::Behaviour,
 }
 
 impl KwaaiBehaviour {
@@ -92,10 +97,20 @@ impl KwaaiBehaviour {
         // Otherwise leave `auto_mode` on: kad flips to Server once an external
         // address is confirmed, Client until then.
 
+        // The inbound protocol set starts empty — handlers register at runtime
+        // through `NetworkHandle::add_unary_handler`. `max_concurrent_streams`
+        // keeps its default: it is a per-connection resource guard, unrelated to
+        // anything `NetworkConfig` currently expresses.
+        let unary = unary::Behaviour::new(unary::Config {
+            request_timeout: config.request_timeout,
+            ..unary::Config::default()
+        });
+
         Self {
             ping,
             identify,
             kad,
+            unary,
         }
     }
 }

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -15,10 +15,50 @@
 //! on *both* the success and failure event, or the caller waits forever — see
 //! the error arms in `service.rs`.
 
+use std::future::Future;
+use std::pin::Pin;
+
 use libp2p::{Multiaddr, PeerId};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::error::{P2PError, P2PResult};
+use crate::unary::UnaryResult;
+
+/// One inbound unary call handed to a registered handler task.
+///
+/// The `responder` is `unary::InboundRequest::responder`: sending on it writes
+/// the success or error arm back on the caller's stream. Dropping it makes the
+/// stream worker synthesise an error arm, so a panicking handler still resolves
+/// the remote caller rather than stalling it until its own timeout.
+#[derive(Debug)]
+pub struct InboundUnaryCall {
+    /// The caller, derived from the connection — never from the frame's `peer`
+    /// field, which arrives unrewritten on this path.
+    pub peer: PeerId,
+    /// The raw application payload.
+    pub data: Vec<u8>,
+    /// Where this call's result goes.
+    pub responder: oneshot::Sender<Result<Vec<u8>, String>>,
+}
+
+/// The channel the service uses to hand inbound calls to a handler task.
+///
+/// Unbounded, and therefore never blocking the swarm event loop — the bound
+/// that matters is `unary::Config::max_concurrent_streams`, applied per
+/// connection before a request is ever decoded.
+pub type InboundUnarySender = mpsc::UnboundedSender<InboundUnaryCall>;
+
+/// A registered unary handler: request bytes in, response-or-error-arm out.
+///
+/// Boxed rather than generic because handlers for different protocols live in
+/// one map. The shape mirrors `kwaai_p2p_daemon::P2PClient::add_unary_handler`'s
+/// `F: Fn(Vec<u8>) -> Fut` so call sites migrate without restructuring.
+pub type UnaryHandler = Box<
+    dyn Fn(Vec<u8>) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + Send>>
+        + Send
+        + Sync
+        + 'static,
+>;
 
 /// A connected peer, as reported by [`NetworkHandle::list_peers`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,6 +138,29 @@ pub enum Command {
         peers: Vec<Multiaddr>,
         reply: oneshot::Sender<P2PResult<()>>,
     },
+    /// Call a hivemind unary handler on a remote peer.
+    ///
+    /// Unlike the other slow commands this carries no pending-map entry: the
+    /// `reply` is handed to `unary::Behaviour::send_request`, which resolves it
+    /// on every outcome including dial failure and timeout.
+    CallUnary {
+        peer: PeerId,
+        proto: String,
+        data: Vec<u8>,
+        reply: oneshot::Sender<UnaryResult>,
+    },
+    /// Start serving `proto`, routing inbound calls to `sender`.
+    AddUnaryHandler {
+        proto: String,
+        sender: InboundUnarySender,
+        reply: oneshot::Sender<()>,
+    },
+    /// Stop serving `proto`. Subsequent calls to it get a clean negotiation
+    /// refusal. Reports whether a handler was actually registered.
+    RemoveUnaryHandler {
+        proto: String,
+        reply: oneshot::Sender<bool>,
+    },
     /// Stop the event loop.
     Shutdown { reply: oneshot::Sender<()> },
 }
@@ -107,13 +170,22 @@ pub enum Command {
 pub struct NetworkHandle {
     local_peer_id: PeerId,
     commands: mpsc::Sender<Command>,
+    /// The configured per-call unary budget, kept here purely so a timeout can
+    /// be reported as [`P2PError::Timeout`] with the real number of
+    /// milliseconds rather than a placeholder.
+    request_timeout: std::time::Duration,
 }
 
 impl NetworkHandle {
-    pub(crate) fn new(local_peer_id: PeerId, commands: mpsc::Sender<Command>) -> Self {
+    pub(crate) fn new(
+        local_peer_id: PeerId,
+        commands: mpsc::Sender<Command>,
+        request_timeout: std::time::Duration,
+    ) -> Self {
         Self {
             local_peer_id,
             commands,
+            request_timeout,
         }
     }
 
@@ -201,9 +273,133 @@ impl NetworkHandle {
         .await?
     }
 
+    /// Call the unary handler `proto` on `peer` with `data`.
+    ///
+    /// Mirrors `kwaai_p2p_daemon::P2PClient::call_unary_handler` (which takes
+    /// peer-ID *bytes*; here the peer is already typed). Dials on demand, so a
+    /// call to a peer we are not connected to works as long as some behaviour —
+    /// Kademlia in practice — can supply an address, matching Go's
+    /// `host.NewStream` semantics.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::unary::UnaryError`] maps onto [`P2PError`] as follows, chosen so
+    /// call sites can keep the coarse distinctions they already make:
+    ///
+    /// | `UnaryError` | `P2PError` | why |
+    /// | --- | --- | --- |
+    /// | `Timeout` | [`P2PError::Timeout`] | carries the configured budget in ms |
+    /// | `UnsupportedProtocol` | [`P2PError::Protocol`] | a clean refusal is a protocol-level answer, not a transport fault |
+    /// | `DialFailure` | [`P2PError::DialFailed`] | we never reached the peer |
+    /// | `Remote` | [`P2PError::Protocol`] | the remote handler ran and returned its error arm; its text is preserved verbatim |
+    /// | `Wire` | [`P2PError::Transport`] | the exchange broke below the application layer |
+    pub async fn call_unary_handler(
+        &self,
+        peer: PeerId,
+        proto: &str,
+        data: &[u8],
+    ) -> P2PResult<Vec<u8>> {
+        let result = self
+            .call(|reply| Command::CallUnary {
+                peer,
+                proto: proto.to_string(),
+                data: data.to_vec(),
+                reply,
+            })
+            .await?;
+        result.map_err(|e| unary_error(e, proto, self.request_timeout))
+    }
+
+    /// Serve `proto`, dispatching each inbound call to `handler`.
+    ///
+    /// Mirrors `kwaai_p2p_daemon::P2PClient::add_unary_handler` minus its
+    /// `balanced` flag, which is a p2pd-side load-balancing knob with no
+    /// meaning for an in-process handler.
+    ///
+    /// Spawns one long-lived dispatch task that owns the receiving end of the
+    /// service's dispatch channel and spawns a task **per call**, so a slow
+    /// handler delays only its own caller. Registering a protocol that is
+    /// already served replaces the previous handler; the old dispatch task ends
+    /// when the service drops its sender.
+    pub async fn add_unary_handler<F, Fut>(&self, proto: &str, handler: F) -> P2PResult<()>
+    where
+        F: Fn(Vec<u8>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Vec<u8>, String>> + Send + 'static,
+    {
+        let handler: UnaryHandler = Box::new(move |data| Box::pin(handler(data)));
+        self.add_unary_handler_boxed(proto, handler).await
+    }
+
+    /// [`NetworkHandle::add_unary_handler`] with the handler already boxed, for
+    /// call sites that store handlers in a collection (Phase 3's IPC server
+    /// dispatches by protocol name at runtime).
+    pub async fn add_unary_handler_boxed(
+        &self,
+        proto: &str,
+        handler: UnaryHandler,
+    ) -> P2PResult<()> {
+        let (tx, mut rx) = mpsc::unbounded_channel::<InboundUnaryCall>();
+
+        self.call(|reply| Command::AddUnaryHandler {
+            proto: proto.to_string(),
+            sender: tx,
+            reply,
+        })
+        .await?;
+
+        let handler = std::sync::Arc::new(handler);
+        // Ends when the service drops its sender — on shutdown, on
+        // `remove_unary_handler`, or when this protocol is re-registered.
+        tokio::spawn(async move {
+            while let Some(call) = rx.recv().await {
+                let handler = std::sync::Arc::clone(&handler);
+                tokio::spawn(async move {
+                    let result = handler(call.data).await;
+                    // The receiver is gone only if the stream worker already
+                    // gave up (its own timeout); nothing left to report.
+                    let _ = call.responder.send(result);
+                });
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Stop serving `proto`. Returns `true` if a handler was registered.
+    ///
+    /// After this resolves, calls to `proto` are refused during negotiation —
+    /// the remote sees [`crate::unary::UnaryError::UnsupportedProtocol`], the
+    /// same clean refusal a never-registered protocol produces.
+    pub async fn remove_unary_handler(&self, proto: &str) -> P2PResult<bool> {
+        self.call(|reply| Command::RemoveUnaryHandler {
+            proto: proto.to_string(),
+            reply,
+        })
+        .await
+    }
+
     /// Ask the event loop to stop. Returns once it has acknowledged; await the
     /// `JoinHandle` from `NetworkService::spawn` to know it has fully exited.
     pub async fn shutdown(&self) -> P2PResult<()> {
         self.call(|reply| Command::Shutdown { reply }).await
+    }
+}
+
+/// Map a unary failure onto the crate error type. See
+/// [`NetworkHandle::call_unary_handler`] for the rationale behind each arm.
+fn unary_error(
+    error: crate::unary::UnaryError,
+    proto: &str,
+    request_timeout: std::time::Duration,
+) -> P2PError {
+    use crate::unary::UnaryError;
+    match error {
+        UnaryError::Timeout => P2PError::Timeout(request_timeout.as_millis() as u64),
+        UnaryError::UnsupportedProtocol(p) => {
+            P2PError::Protocol(format!("remote does not support protocol {p}"))
+        }
+        UnaryError::DialFailure(e) => P2PError::DialFailed(e),
+        UnaryError::Remote(e) => P2PError::Protocol(format!("remote handler error ({proto}): {e}")),
+        UnaryError::Wire(e) => P2PError::Transport(e),
     }
 }

--- a/core/crates/kwaai-p2p/src/lib.rs
+++ b/core/crates/kwaai-p2p/src/lib.rs
@@ -40,6 +40,7 @@ pub mod handle;
 pub mod identity;
 pub mod service;
 pub mod transport;
+pub mod unary;
 
 pub use behaviour::{KwaaiBehaviour, KwaaiBehaviourEvent};
 pub use config::{

--- a/core/crates/kwaai-p2p/src/lib.rs
+++ b/core/crates/kwaai-p2p/src/lib.rs
@@ -7,8 +7,10 @@
 //! the swarm must be polled from exactly one place, while many call sites need
 //! to dial peers, list connections and run DHT lookups concurrently.
 //!
-//! Behaviours: ping, identify and Kademlia — enough for a node to join the
-//! network, learn its observed addresses, and resolve peers.
+//! Behaviours: ping, identify, Kademlia, and hivemind unary RPC
+//! ([`NetworkHandle::call_unary_handler`] to call a remote handler,
+//! [`NetworkHandle::add_unary_handler`] to serve one, both named after their
+//! `kwaai_p2p_daemon::P2PClient` counterparts).
 //!
 //! ## Example
 //!
@@ -47,7 +49,7 @@ pub use config::{
     NetworkConfig, KWAAI_BOOTSTRAP_SERVERS, KWAAI_BOOTSTRAP_SERVERS_DNS, PETALS_BOOTSTRAP_SERVERS,
 };
 pub use error::{P2PError, P2PResult};
-pub use handle::{Direction, NetworkHandle, PeerInfo};
+pub use handle::{Direction, InboundUnaryCall, NetworkHandle, PeerInfo, UnaryHandler};
 pub use service::NetworkService;
 
 // Re-exported so downstream crates can name peers and addresses without taking

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -13,6 +13,9 @@
 //! `pending_kad` (keyed by `QueryId`). The invariant that keeps callers from
 //! hanging forever is that **every pending entry is removed on both the success
 //! and the failure event**.
+//!
+//! Unary needs no such bookkeeping: the behaviour owns each outbound `oneshot`,
+//! and inbound dispatch is an unbounded send, which never blocks the loop.
 
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::time::Duration;
@@ -31,7 +34,10 @@ use tracing::{debug, info, trace, warn};
 use crate::behaviour::{KwaaiBehaviour, KwaaiBehaviourEvent};
 use crate::config::NetworkConfig;
 use crate::error::{P2PError, P2PResult};
-use crate::handle::{Command, Direction, NetworkHandle, PeerInfo};
+use crate::handle::{
+    Command, Direction, InboundUnaryCall, InboundUnarySender, NetworkHandle, PeerInfo,
+};
+use crate::unary::{self, UnaryProtocol};
 
 /// How often the maintenance arm refreshes the Kademlia routing table.
 const KAD_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
@@ -62,6 +68,10 @@ pub struct NetworkService {
     /// Addresses peers reported observing us at → the set of peers that said so.
     /// A set (not a counter) so repeated identifies from one peer count once.
     observed_addrs: HashMap<Multiaddr, HashSet<PeerId>>,
+    /// Registered unary handlers: negotiated protocol → the handler task's
+    /// channel. Kept in lockstep with the behaviour's inbound protocol set, so
+    /// an entry here means the protocol is advertised and vice versa.
+    unary_handlers: HashMap<String, InboundUnarySender>,
 }
 
 /// A parked DHT lookup.
@@ -131,11 +141,15 @@ impl NetworkService {
             pending_kad: HashMap::new(),
             connections: HashMap::new(),
             observed_addrs: HashMap::new(),
+            unary_handlers: HashMap::new(),
         };
 
         let task = tokio::spawn(service.run());
         info!(peer_id = %local_peer_id, "network service started");
-        Ok((NetworkHandle::new(local_peer_id, tx), task))
+        Ok((
+            NetworkHandle::new(local_peer_id, tx, config.request_timeout),
+            task,
+        ))
     }
 
     /// The event loop. Exits on `Command::Shutdown` or when all handles drop.
@@ -259,6 +273,41 @@ impl NetworkService {
                 let _ = reply.send(self.start_bootstrap(peers));
             }
 
+            Command::CallUnary {
+                peer,
+                proto,
+                data,
+                reply,
+            } => {
+                self.swarm.behaviour_mut().unary.send_request(
+                    peer,
+                    UnaryProtocol::new(proto),
+                    data,
+                    reply,
+                );
+            }
+
+            Command::AddUnaryHandler {
+                proto,
+                sender,
+                reply,
+            } => {
+                self.swarm
+                    .behaviour_mut()
+                    .unary
+                    .register_protocol(UnaryProtocol::new(proto.clone()));
+                // Re-registering replaces the sender; dropping the old one ends
+                // the previous handler's dispatch task.
+                self.unary_handlers.insert(proto.clone(), sender);
+                debug!(%proto, "unary handler registered");
+                let _ = reply.send(());
+            }
+
+            Command::RemoveUnaryHandler { proto, reply } => {
+                let existed = self.unregister_unary(&proto);
+                let _ = reply.send(existed);
+            }
+
             // Handled in `run` so the loop can break.
             Command::Shutdown { reply } => {
                 let _ = reply.send(());
@@ -362,6 +411,58 @@ impl NetworkService {
         addrs
     }
 
+    /// Stop serving `proto`: drop the dispatch channel and stop advertising it.
+    /// Returns whether a handler was registered. Idempotent.
+    fn unregister_unary(&mut self, proto: &str) -> bool {
+        let existed = self.unary_handlers.remove(proto).is_some();
+        self.swarm
+            .behaviour_mut()
+            .unary
+            .unregister_protocol(&UnaryProtocol::new(proto));
+        if existed {
+            debug!(%proto, "unary handler removed");
+        }
+        existed
+    }
+
+    /// Route one inbound unary call to its handler.
+    ///
+    /// Dispatch is keyed on the **negotiated** protocol, never the frame's
+    /// `proto` field. Three outcomes, none of which may block:
+    ///
+    /// - handler present and its task alive → hand the call over; the task owns
+    ///   the responder from here,
+    /// - handler present but its receiver dropped (the task died) → deregister
+    ///   the protocol so subsequent calls get a clean refusal instead of a
+    ///   silent black hole, and fail this call,
+    /// - nothing registered → fail immediately. This is the rare path: the
+    ///   protocol was deregistered between negotiation and decode, since
+    ///   unregistered protocols are refused during negotiation.
+    fn dispatch_unary(&mut self, peer: PeerId, request: unary::InboundRequest) {
+        let unary::InboundRequest {
+            proto,
+            data,
+            responder,
+        } = request;
+        let proto = proto.as_ref().to_string();
+
+        let Some(sender) = self.unary_handlers.get(&proto) else {
+            let _ = responder.send(Err(format!("no handler for {proto}")));
+            return;
+        };
+
+        let call = InboundUnaryCall {
+            peer,
+            data,
+            responder,
+        };
+        if let Err(e) = sender.send(call) {
+            warn!(%proto, "unary handler task is gone; deregistering the protocol");
+            self.unregister_unary(&proto);
+            let _ = e.0.responder.send(Err(format!("no handler for {proto}")));
+        }
+    }
+
     /// Resolve every parked request with `error`. Called on shutdown so no
     /// caller is left awaiting a reply that will never come.
     fn fail_all_pending(&mut self, error: P2PError) {
@@ -461,6 +562,9 @@ impl NetworkService {
                 Ok(rtt) => trace!(peer = %peer, ?rtt, "ping"),
                 Err(e) => debug!(peer = %peer, error = %e, "ping failed"),
             },
+            KwaaiBehaviourEvent::Unary(unary::Event::InboundRequest { peer, request }) => {
+                self.dispatch_unary(peer, request)
+            }
         }
     }
 

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -260,31 +260,44 @@ pub struct Handler {
     inbound_protocols: Arc<RwLock<HashSet<UnaryProtocol>>>,
     config: Config,
 
-    /// Outbound requests not yet emitted as substream requests.
+    /// Outbound requests not yet emitted as substream requests. Emission is
+    /// throttled in `poll` so `requested_outbound` + `outbound_workers` stays
+    /// within `max_concurrent_streams`; excess requests wait here under the
+    /// caller's own timeout-free patience (each has a caller awaiting it, so
+    /// the queue is bounded by local concurrency).
     pending_outbound: VecDeque<OutboundMessage>,
-    /// Emitted substream requests awaiting negotiation.
+    /// Emitted substream requests awaiting negotiation, keyed by the request
+    /// id passed as `OutboundOpenInfo`.
     ///
-    /// **Not** correlated by position: with several calls in flight on one
-    /// connection, `FullyNegotiatedOutbound` events arrive in completion order,
-    /// which is not emission order — each negotiation is an independent
-    /// round-trip. Streams are therefore matched to their request by *negotiated
-    /// protocol* (see [`Handler::take_requested`]), which is exact here because
-    /// each substream request proposes exactly one protocol.
-    ///
-    /// Two concurrent calls to the *same* protocol are still matched
-    /// positionally among themselves, which is correct: they are
-    /// interchangeable, each carrying its own reply channel.
-    requested_outbound: VecDeque<OutboundMessage>,
+    /// Correlation must be by id, never by position or protocol:
+    /// `FullyNegotiatedOutbound`/`DialUpgradeError` arrive in *completion*
+    /// order (each negotiation is an independent round-trip), and the id is
+    /// the only token the swarm echoes back verbatim on both the success and
+    /// the failure path.
+    requested_outbound: HashMap<u64, OutboundMessage>,
+    /// Source for `requested_outbound` keys, unique per handler lifetime.
+    next_outbound_id: u64,
 
-    /// Stream workers. Timeouts live inside each future so every worker
-    /// resolves its oneshot on every path.
-    workers: FuturesUnordered<BoxFuture<'static, ()>>,
+    /// Inbound stream workers (serving remote calls). Bounded by
+    /// `max_concurrent_streams`, with a small overflow allowance for workers
+    /// that only write a refusal frame.
+    inbound_workers: FuturesUnordered<BoxFuture<'static, ()>>,
+    /// Outbound stream workers (our calls). Bounded by
+    /// `max_concurrent_streams` via emission throttling in `poll`, so a local
+    /// call burst cannot starve inbound serving. Timeouts live inside each
+    /// future so every worker resolves its oneshot on every path.
+    outbound_workers: FuturesUnordered<BoxFuture<'static, ()>>,
 
     /// Inbound requests decoded by workers, drained in `poll`. Zero-capacity:
     /// a worker parks until the handler actually forwards its request.
     inbound_rx: mpsc::Receiver<InboundStreamRequest>,
     inbound_tx: mpsc::Sender<InboundStreamRequest>,
 }
+
+/// Extra inbound worker slots reserved for writing "at capacity" refusal
+/// frames once the real slots are full. Beyond cap + this, streams are
+/// dropped without a reply — the remote's own timeout is then the backstop.
+const REFUSAL_SLOTS: usize = 16;
 
 impl Handler {
     fn new(
@@ -298,23 +311,53 @@ impl Handler {
             inbound_protocols,
             config,
             pending_outbound: VecDeque::new(),
-            requested_outbound: VecDeque::new(),
-            workers: FuturesUnordered::new(),
+            requested_outbound: HashMap::new(),
+            next_outbound_id: 0,
+            inbound_workers: FuturesUnordered::new(),
+            outbound_workers: FuturesUnordered::new(),
             inbound_rx,
             inbound_tx,
         }
     }
 
     fn on_fully_negotiated_inbound(&mut self, mut stream: Stream, proto: UnaryProtocol) {
-        if self.workers.len() >= self.config.max_concurrent_streams {
-            warn!(%proto, "dropping inbound unary stream: at capacity");
+        if self.inbound_workers.len() >= self.config.max_concurrent_streams {
+            // Refuse politely while the overflow allowance lasts: read the
+            // request (its callId is needed for any reply), answer with the
+            // error arm, close. Beyond the allowance, drop outright.
+            if self.inbound_workers.len() < self.config.max_concurrent_streams + REFUSAL_SLOTS {
+                warn!(%proto, "refusing inbound unary stream: at capacity");
+                self.inbound_workers.push(
+                    async move {
+                        let refusal = async {
+                            let frame = wire::read_framed_futures(&mut stream).await?;
+                            let (call_id, ..) = wire::decode_unary_request(&frame)?;
+                            stream
+                                .write_all(&wire::encode_unary_response(
+                                    &call_id,
+                                    Err("node at capacity".to_string()),
+                                ))
+                                .await?;
+                            stream.flush().await?;
+                            stream.close().await?;
+                            Ok::<_, wire::WireError>(())
+                        };
+                        // A short budget: a refusal that cannot complete
+                        // quickly is not worth a slot.
+                        let _ = tokio::time::timeout(Duration::from_secs(5), refusal).await;
+                    }
+                    .boxed(),
+                );
+            } else {
+                warn!(%proto, "dropping inbound unary stream: at capacity");
+            }
             return;
         }
 
         let mut to_handler = self.inbound_tx.clone();
         let timeout = self.config.request_timeout;
 
-        self.workers.push(
+        self.inbound_workers.push(
             async move {
                 let outcome: Result<(), wire::WireError> = async {
                     let frame = wire::read_framed_futures(&mut stream).await?;
@@ -361,34 +404,20 @@ impl Handler {
         );
     }
 
-    /// Claim the pending request that `proto` belongs to.
-    ///
-    /// Falls back to the oldest request when the protocol does not match any —
-    /// which should not happen, but losing the correlation must not strand a
-    /// caller's reply channel forever.
-    fn take_requested(&mut self, proto: &UnaryProtocol) -> Option<OutboundMessage> {
-        let index = self
-            .requested_outbound
-            .iter()
-            .position(|m| &m.proto == proto)
-            .or(if self.requested_outbound.is_empty() {
-                None
-            } else {
-                Some(0)
-            })?;
-        self.requested_outbound.remove(index)
-    }
-
-    fn on_fully_negotiated_outbound(&mut self, mut stream: Stream, proto: UnaryProtocol) {
-        let Some(message) = self.take_requested(&proto) else {
-            debug!(%proto, "negotiated an outbound stream without a pending message");
+    fn on_fully_negotiated_outbound(&mut self, mut stream: Stream, proto: UnaryProtocol, id: u64) {
+        let Some(message) = self.requested_outbound.remove(&id) else {
+            debug!(%proto, id, "negotiated an outbound stream without a pending message");
             return;
         };
+        debug_assert_eq!(
+            message.proto, proto,
+            "a substream request proposes exactly one protocol"
+        );
 
         let callee = self.remote.to_bytes();
         let timeout = self.config.request_timeout;
 
-        self.workers.push(
+        self.outbound_workers.push(
             async move {
                 let exchange = async {
                     // 16 raw UUID bytes: Go does `uuid.FromBytes` and drops the
@@ -431,15 +460,19 @@ impl Handler {
         );
     }
 
-    /// A failed upgrade carries no negotiated protocol — there is none — so the
-    /// oldest pending request is claimed. With several *different* protocols in
-    /// flight this can attribute a refusal to the wrong call, but both calls are
-    /// to the same peer and only one of them can be the failing one; the other
-    /// then fails on its own path. Reporting the wrong protocol name in the
-    /// error text is strictly better than panicking or leaking a reply channel.
-    fn on_dial_upgrade_error(&mut self, error: StreamUpgradeError<std::convert::Infallible>) {
-        let Some(message) = self.requested_outbound.pop_front() else {
-            debug!("upgrade error for an outbound stream without a pending message");
+    /// A failed upgrade carries no negotiated protocol, but it does echo the
+    /// request id we passed as `OutboundOpenInfo`, so attribution is exact on
+    /// the failure path too.
+    fn on_dial_upgrade_error(
+        &mut self,
+        error: StreamUpgradeError<std::convert::Infallible>,
+        id: u64,
+    ) {
+        let Some(message) = self.requested_outbound.remove(&id) else {
+            debug!(
+                id,
+                "upgrade error for an outbound stream without a pending message"
+            );
             return;
         };
 
@@ -455,13 +488,32 @@ impl Handler {
     }
 }
 
+impl Drop for Handler {
+    /// The connection is gone; every queued and still-negotiating request
+    /// resolves with a definite error rather than a silently dropped channel.
+    /// (In-flight exchanges resolve through their worker futures' own drop —
+    /// the caller sees the channel close, which the handle maps to a service
+    /// error; only the not-yet-started calls can be given the precise cause.)
+    fn drop(&mut self) {
+        for message in self
+            .pending_outbound
+            .drain(..)
+            .chain(self.requested_outbound.drain().map(|(_, m)| m))
+        {
+            let _ = message
+                .reply
+                .send(Err(UnaryError::Wire("connection closed".to_string())));
+        }
+    }
+}
+
 impl ConnectionHandler for Handler {
     type FromBehaviour = OutboundMessage;
     type ToBehaviour = InboundStreamRequestEvent;
     type InboundProtocol = Protocols;
     type OutboundProtocol = Protocols;
     type InboundOpenInfo = ();
-    type OutboundOpenInfo = ();
+    type OutboundOpenInfo = u64;
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, ()> {
         let protocols = self
@@ -481,10 +533,11 @@ impl ConnectionHandler for Handler {
     fn poll(
         &mut self,
         cx: &mut Context<'_>,
-    ) -> Poll<ConnectionHandlerEvent<Protocols, (), Self::ToBehaviour>> {
-        // Drive stream workers; their outcomes travel through oneshots, so
+    ) -> Poll<ConnectionHandlerEvent<Protocols, u64, Self::ToBehaviour>> {
+        // Drive both worker pools; outcomes travel through oneshots, so
         // completion here is just cleanup.
-        while let Poll::Ready(Some(())) = self.workers.poll_next_unpin(cx) {}
+        while let Poll::Ready(Some(())) = self.inbound_workers.poll_next_unpin(cx) {}
+        while let Poll::Ready(Some(())) = self.outbound_workers.poll_next_unpin(cx) {}
 
         if let Poll::Ready(Some(request)) = self.inbound_rx.poll_next_unpin(cx) {
             return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
@@ -492,14 +545,24 @@ impl ConnectionHandler for Handler {
             ));
         }
 
-        if let Some(message) = self.pending_outbound.pop_front() {
-            let protocols = Protocols {
-                protocols: vec![message.proto.clone()],
-            };
-            self.requested_outbound.push_back(message);
-            return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                protocol: SubstreamProtocol::new(protocols, ()),
-            });
+        // Emit the next outbound request only while within the cap, counting
+        // both still-negotiating and in-flight streams. Requests beyond it
+        // wait in `pending_outbound` and are re-examined when a worker
+        // completes (worker completion wakes this poll).
+        if self.requested_outbound.len() + self.outbound_workers.len()
+            < self.config.max_concurrent_streams
+        {
+            if let Some(message) = self.pending_outbound.pop_front() {
+                let protocols = Protocols {
+                    protocols: vec![message.proto.clone()],
+                };
+                let id = self.next_outbound_id;
+                self.next_outbound_id += 1;
+                self.requested_outbound.insert(id, message);
+                return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
+                    protocol: SubstreamProtocol::new(protocols, id),
+                });
+            }
         }
 
         Poll::Pending
@@ -507,7 +570,7 @@ impl ConnectionHandler for Handler {
 
     fn on_connection_event(
         &mut self,
-        event: ConnectionEvent<Self::InboundProtocol, Self::OutboundProtocol, (), ()>,
+        event: ConnectionEvent<Self::InboundProtocol, Self::OutboundProtocol, (), u64>,
     ) {
         match event {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
@@ -516,10 +579,10 @@ impl ConnectionHandler for Handler {
             }) => self.on_fully_negotiated_inbound(stream, proto),
             ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
                 protocol: (stream, proto),
-                ..
-            }) => self.on_fully_negotiated_outbound(stream, proto),
-            ConnectionEvent::DialUpgradeError(DialUpgradeError { error, .. }) => {
-                self.on_dial_upgrade_error(error)
+                info,
+            }) => self.on_fully_negotiated_outbound(stream, proto, info),
+            ConnectionEvent::DialUpgradeError(DialUpgradeError { error, info }) => {
+                self.on_dial_upgrade_error(error, info)
             }
             _ => {}
         }

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -8,8 +8,7 @@
 //!
 //! ## Why not `libp2p::request_response`
 //!
-//! The migration plan originally called for `request_response` with a custom
-//! codec, but two of its design constants do not fit hivemind:
+//! Two of its design constants do not fit hivemind:
 //!
 //! - **Protocol-per-request.** `request_response::Behaviour` negotiates from
 //!   one protocol list fixed at construction; `send_request` cannot say which

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -282,6 +282,16 @@ pub struct Handler {
     /// `max_concurrent_streams`, with a small overflow allowance for workers
     /// that only write a refusal frame.
     inbound_workers: FuturesUnordered<BoxFuture<'static, ()>>,
+    /// Refusal-frame writers, tracked apart from `inbound_workers` so pending
+    /// refusals neither consume real capacity nor inflate the measure that
+    /// admits them.
+    refusal_workers: FuturesUnordered<BoxFuture<'static, ()>>,
+    /// Waker from the last `poll`, woken whenever a throttle-relevant slot is
+    /// freed outside worker completion (`FuturesUnordered` wakes on its own
+    /// completions, but `requested_outbound` shrinking on a negotiation
+    /// failure does not — without this, a queued call could wait forever
+    /// behind a slot freed by `DialUpgradeError`).
+    waker: Option<std::task::Waker>,
     /// Outbound stream workers (our calls). Bounded by
     /// `max_concurrent_streams` via emission throttling in `poll`, so a local
     /// call burst cannot starve inbound serving. Timeouts live inside each
@@ -314,7 +324,9 @@ impl Handler {
             requested_outbound: HashMap::new(),
             next_outbound_id: 0,
             inbound_workers: FuturesUnordered::new(),
+            refusal_workers: FuturesUnordered::new(),
             outbound_workers: FuturesUnordered::new(),
+            waker: None,
             inbound_rx,
             inbound_tx,
         }
@@ -325,9 +337,9 @@ impl Handler {
             // Refuse politely while the overflow allowance lasts: read the
             // request (its callId is needed for any reply), answer with the
             // error arm, close. Beyond the allowance, drop outright.
-            if self.inbound_workers.len() < self.config.max_concurrent_streams + REFUSAL_SLOTS {
+            if self.refusal_workers.len() < REFUSAL_SLOTS {
                 warn!(%proto, "refusing inbound unary stream: at capacity");
-                self.inbound_workers.push(
+                self.refusal_workers.push(
                     async move {
                         let refusal = async {
                             let frame = wire::read_framed_futures(&mut stream).await?;
@@ -404,7 +416,16 @@ impl Handler {
         );
     }
 
+    /// Re-run `poll` after a throttle-relevant slot was freed outside the
+    /// worker pools (they wake the task themselves; map mutations do not).
+    fn wake(&mut self) {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+    }
+
     fn on_fully_negotiated_outbound(&mut self, mut stream: Stream, proto: UnaryProtocol, id: u64) {
+        self.wake();
         let Some(message) = self.requested_outbound.remove(&id) else {
             debug!(%proto, id, "negotiated an outbound stream without a pending message");
             return;
@@ -468,6 +489,7 @@ impl Handler {
         error: StreamUpgradeError<std::convert::Infallible>,
         id: u64,
     ) {
+        self.wake();
         let Some(message) = self.requested_outbound.remove(&id) else {
             debug!(
                 id,
@@ -537,6 +559,7 @@ impl ConnectionHandler for Handler {
         // Drive both worker pools; outcomes travel through oneshots, so
         // completion here is just cleanup.
         while let Poll::Ready(Some(())) = self.inbound_workers.poll_next_unpin(cx) {}
+        while let Poll::Ready(Some(())) = self.refusal_workers.poll_next_unpin(cx) {}
         while let Poll::Ready(Some(())) = self.outbound_workers.poll_next_unpin(cx) {}
 
         if let Poll::Ready(Some(request)) = self.inbound_rx.poll_next_unpin(cx) {
@@ -565,6 +588,7 @@ impl ConnectionHandler for Handler {
             }
         }
 
+        self.waker = Some(cx.waker().clone());
         Poll::Pending
     }
 

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -1,0 +1,730 @@
+//! Hivemind unary RPC as a libp2p `NetworkBehaviour`.
+//!
+//! One request and one response per stream, framed and enveloped by
+//! `kwaai_hivemind_dht::wire`, on a protocol ID that is the **bare hivemind
+//! handler name with no leading slash** (`DHTProtocol.rpc_store`, `hello`, …).
+//! Phase 0 proved this wire shape and the slash-less negotiation against a
+//! real go-libp2p-daemon (`kwaai-network-tests/tests/07_wire_interop.rs`).
+//!
+//! ## Why not `libp2p::request_response`
+//!
+//! The migration plan originally called for `request_response` with a custom
+//! codec, but two of its design constants do not fit hivemind:
+//!
+//! - **Protocol-per-request.** `request_response::Behaviour` negotiates from
+//!   one protocol list fixed at construction; `send_request` cannot say which
+//!   protocol a given request is for. A hivemind call *is* its protocol — the
+//!   handler name — so every outbound request here negotiates exactly one
+//!   protocol, the one the caller asked for.
+//! - **Dynamic inbound registration.** External processes register and remove
+//!   unary handlers at runtime (`add_unary_handler` over the IPC socket,
+//!   Phase 3). The inbound protocol set therefore lives behind an
+//!   `Arc<RwLock<…>>` shared with every connection handler, and
+//!   `listen_protocol()` reads it per inbound stream — a registration made
+//!   after a connection was established is still visible to that connection's
+//!   next negotiation.
+//!
+//! `libp2p_stream` is also out: `StreamProtocol` rejects names without a
+//! leading `/`, and hivemind names have none.
+//!
+//! ## Shape
+//!
+//! [`Behaviour`] mirrors `request_response`'s structure (pending-request
+//! queues, preloading handlers on connection establishment, dial-on-demand)
+//! but resolves outcomes through the `oneshot` each request carries instead of
+//! surfacing request-ID events — the caller side of [`Behaviour::send_request`]
+//! awaits its own reply channel, so no request-ID bookkeeping leaks into the
+//! service loop. Inbound requests surface as [`Event::InboundRequest`] with a
+//! `responder` oneshot; the stream worker writes whatever arrives on it (or an
+//! error frame on timeout/drop) and closes the stream.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
+use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures::channel::mpsc;
+use futures::future::BoxFuture;
+use futures::io::AsyncWriteExt as _;
+use futures::stream::FuturesUnordered;
+use futures::{FutureExt, SinkExt, StreamExt};
+use libp2p::core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+use libp2p::core::{Endpoint, Multiaddr};
+use libp2p::swarm::handler::{
+    ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
+};
+use libp2p::swarm::{
+    behaviour::PeerAddresses, dial_opts::DialOpts, ConnectionDenied, ConnectionHandler,
+    ConnectionHandlerEvent, ConnectionId, FromSwarm, NetworkBehaviour, NotifyHandler,
+    StreamUpgradeError, SubstreamProtocol, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
+};
+use libp2p::swarm::{DialFailure, Stream};
+use libp2p::PeerId;
+use tokio::sync::oneshot;
+use tracing::{debug, trace, warn};
+
+use kwaai_hivemind_dht::wire;
+
+/// A hivemind unary protocol ID: the bare handler name, no leading slash.
+///
+/// This type exists because `libp2p::StreamProtocol` refuses slash-less names;
+/// multistream-select itself does not care (Phase 0,
+/// `slashless_protocol_negotiates`). `Arc<str>` because one registration is
+/// cloned into every connection handler and every negotiation.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct UnaryProtocol(Arc<str>);
+
+impl UnaryProtocol {
+    /// Wrap a handler name. Empty names are a caller bug — multistream-select
+    /// cannot negotiate them — hence the panic, mirroring `StreamProtocol::new`.
+    pub fn new(name: impl Into<Arc<str>>) -> Self {
+        let name = name.into();
+        assert!(!name.is_empty(), "unary protocol name must not be empty");
+        Self(name)
+    }
+}
+
+impl AsRef<str> for UnaryProtocol {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for UnaryProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "UnaryProtocol({})", self.0)
+    }
+}
+
+impl fmt::Display for UnaryProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Why an outbound unary call failed.
+#[derive(Debug, thiserror::Error)]
+pub enum UnaryError {
+    /// No response within the configured timeout.
+    #[error("unary call timed out")]
+    Timeout,
+    /// The remote refused the protocol during negotiation — it serves no such
+    /// handler. This is the "clean protocol refusal" the health probe relies on.
+    #[error("remote does not support protocol {0}")]
+    UnsupportedProtocol(String),
+    /// We could not establish any connection to the peer.
+    #[error("dial failed: {0}")]
+    DialFailure(String),
+    /// The remote handler ran and returned the error arm.
+    #[error("remote handler error: {0}")]
+    Remote(String),
+    /// The exchange broke below the application layer (stream reset, bad
+    /// frame, callId mismatch, …).
+    #[error("unary wire failure: {0}")]
+    Wire(String),
+}
+
+/// An application-level result: the responder's payload or its error arm.
+pub type UnaryResult = Result<Vec<u8>, UnaryError>;
+
+/// One outbound call, from `send_request` until its stream worker resolves it.
+pub struct OutboundMessage {
+    proto: UnaryProtocol,
+    data: Vec<u8>,
+    reply: oneshot::Sender<UnaryResult>,
+}
+
+impl fmt::Debug for OutboundMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OutboundMessage")
+            .field("proto", &self.proto)
+            .field("data_len", &self.data.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// An inbound call decoded off a stream, en route to whoever serves `proto`.
+///
+/// Send the handler's outcome on `responder`; the stream worker encodes it
+/// (success or error arm) with the original callId and closes the stream.
+/// Dropping `responder` sends the error arm instead — the caller is never left
+/// hanging until its own timeout.
+#[derive(Debug)]
+pub struct InboundRequest {
+    /// The negotiated protocol (authoritative — the frame's `proto` field is
+    /// logged on mismatch but never trusted for dispatch).
+    pub proto: UnaryProtocol,
+    /// The raw application payload (`CallUnaryRequest.data`).
+    pub data: Vec<u8>,
+    /// Where the handler's result goes.
+    pub responder: oneshot::Sender<Result<Vec<u8>, String>>,
+}
+
+/// Events surfaced to the swarm owner.
+#[derive(Debug)]
+pub enum Event {
+    /// A remote peer called one of our registered unary handlers.
+    InboundRequest {
+        /// The caller, taken from the connection — NEVER from
+        /// `callUnary.peer`, which arrives unrewritten on this path (Phase 0
+        /// finding, `raw_wire_responder_is_accepted_by_daemon_caller`).
+        peer: PeerId,
+        /// The decoded request.
+        request: InboundRequest,
+    },
+}
+
+/// Tuning knobs, deliberately few.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Per-call budget, covering the whole exchange after negotiation
+    /// (write + remote handler + read). Also bounds how long an inbound
+    /// stream waits for its local handler.
+    pub request_timeout: Duration,
+    /// Cap on concurrent stream workers per connection; streams beyond it are
+    /// dropped at negotiation.
+    pub max_concurrent_streams: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            // Matches the p2pd client's `send_to_bootstrap` budget.
+            request_timeout: Duration::from_secs(30),
+            max_concurrent_streams: 100,
+        }
+    }
+}
+
+// ============================================================================
+// Substream upgrade
+// ============================================================================
+
+/// A one-shot upgrade that hands back the stream plus whichever protocol
+/// multistream-select agreed on. Like `libp2p::core::upgrade::ReadyUpgrade`,
+/// except it advertises many protocols and reports the selected one.
+pub struct Protocols {
+    protocols: Vec<UnaryProtocol>,
+}
+
+impl UpgradeInfo for Protocols {
+    type Info = UnaryProtocol;
+    type InfoIter = std::vec::IntoIter<UnaryProtocol>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        self.protocols.clone().into_iter()
+    }
+}
+
+impl InboundUpgrade<Stream> for Protocols {
+    type Output = (Stream, UnaryProtocol);
+    type Error = std::convert::Infallible;
+    type Future = futures::future::Ready<Result<Self::Output, Self::Error>>;
+
+    fn upgrade_inbound(self, io: Stream, protocol: Self::Info) -> Self::Future {
+        futures::future::ready(Ok((io, protocol)))
+    }
+}
+
+impl OutboundUpgrade<Stream> for Protocols {
+    type Output = (Stream, UnaryProtocol);
+    type Error = std::convert::Infallible;
+    type Future = futures::future::Ready<Result<Self::Output, Self::Error>>;
+
+    fn upgrade_outbound(self, io: Stream, protocol: Self::Info) -> Self::Future {
+        futures::future::ready(Ok((io, protocol)))
+    }
+}
+
+// ============================================================================
+// Connection handler
+// ============================================================================
+
+/// What an inbound stream worker hands the connection handler once it has a
+/// decoded request.
+struct InboundStreamRequest {
+    proto: UnaryProtocol,
+    data: Vec<u8>,
+    responder: oneshot::Sender<Result<Vec<u8>, String>>,
+}
+
+/// Per-connection handler: negotiates streams and runs one worker future per
+/// stream. Workers resolve their own oneshots, so `ToBehaviour` only ever
+/// carries inbound requests.
+pub struct Handler {
+    /// The peer on the other end — `CallUnaryRequest.peer` on outbound frames,
+    /// matching what Go's caller writes (the dial target).
+    remote: PeerId,
+    /// Shared with [`Behaviour`]; read per `listen_protocol()` call so runtime
+    /// registrations reach existing connections.
+    inbound_protocols: Arc<RwLock<HashSet<UnaryProtocol>>>,
+    config: Config,
+
+    /// Outbound requests not yet emitted as substream requests.
+    pending_outbound: VecDeque<OutboundMessage>,
+    /// Emitted substream requests awaiting negotiation, in emission order —
+    /// `FullyNegotiatedOutbound`/`DialUpgradeError` arrive in the same order.
+    requested_outbound: VecDeque<OutboundMessage>,
+
+    /// Stream workers. Timeouts live inside each future so every worker
+    /// resolves its oneshot on every path.
+    workers: FuturesUnordered<BoxFuture<'static, ()>>,
+
+    /// Inbound requests decoded by workers, drained in `poll`. Zero-capacity:
+    /// a worker parks until the handler actually forwards its request.
+    inbound_rx: mpsc::Receiver<InboundStreamRequest>,
+    inbound_tx: mpsc::Sender<InboundStreamRequest>,
+}
+
+impl Handler {
+    fn new(
+        remote: PeerId,
+        inbound_protocols: Arc<RwLock<HashSet<UnaryProtocol>>>,
+        config: Config,
+    ) -> Self {
+        let (inbound_tx, inbound_rx) = mpsc::channel(0);
+        Self {
+            remote,
+            inbound_protocols,
+            config,
+            pending_outbound: VecDeque::new(),
+            requested_outbound: VecDeque::new(),
+            workers: FuturesUnordered::new(),
+            inbound_rx,
+            inbound_tx,
+        }
+    }
+
+    fn on_fully_negotiated_inbound(&mut self, mut stream: Stream, proto: UnaryProtocol) {
+        if self.workers.len() >= self.config.max_concurrent_streams {
+            warn!(%proto, "dropping inbound unary stream: at capacity");
+            return;
+        }
+
+        let mut to_handler = self.inbound_tx.clone();
+        let timeout = self.config.request_timeout;
+
+        self.workers.push(
+            async move {
+                let outcome: Result<(), wire::WireError> = async {
+                    let frame = wire::read_framed_futures(&mut stream).await?;
+                    let (call_id, _peer, frame_proto, data) = wire::decode_unary_request(&frame)?;
+                    if frame_proto != proto.as_ref() {
+                        // Dispatch is by negotiated protocol; the frame field is
+                        // informational (hivemind's Python client fills it, Go
+                        // ignores it).
+                        debug!(negotiated = %proto, in_frame = %frame_proto,
+                            "unary frame proto differs from negotiated protocol");
+                    }
+
+                    let (result_tx, result_rx) = oneshot::channel();
+                    let request = InboundStreamRequest {
+                        proto,
+                        data,
+                        responder: result_tx,
+                    };
+                    let result = if to_handler.send(request).await.is_err() {
+                        // Handler shutting down with the stream mid-flight.
+                        Err("node shutting down".to_string())
+                    } else {
+                        match tokio::time::timeout(timeout, result_rx).await {
+                            Ok(Ok(result)) => result,
+                            Ok(Err(_)) => Err("handler dropped the request".to_string()),
+                            Err(_) => Err("handler timed out".to_string()),
+                        }
+                    };
+
+                    stream
+                        .write_all(&wire::encode_unary_response(&call_id, result))
+                        .await?;
+                    stream.flush().await?;
+                    stream.close().await?;
+                    Ok(())
+                }
+                .await;
+
+                if let Err(e) = outcome {
+                    trace!(error = %e, "inbound unary stream failed");
+                }
+            }
+            .boxed(),
+        );
+    }
+
+    fn on_fully_negotiated_outbound(&mut self, mut stream: Stream, proto: UnaryProtocol) {
+        let message = self
+            .requested_outbound
+            .pop_front()
+            .expect("negotiated an outbound stream without a pending message");
+        debug_assert_eq!(message.proto, proto, "outbound negotiation out of order");
+
+        let callee = self.remote.to_bytes();
+        let timeout = self.config.request_timeout;
+
+        self.workers.push(
+            async move {
+                let exchange = async {
+                    // 16 raw UUID bytes: Go does `uuid.FromBytes` and drops the
+                    // message if that fails.
+                    let call_id = uuid::Uuid::new_v4().into_bytes();
+                    stream
+                        .write_all(&wire::encode_unary_request(
+                            &call_id,
+                            &callee,
+                            proto.as_ref(),
+                            &message.data,
+                        ))
+                        .await
+                        .map_err(|e| UnaryError::Wire(e.to_string()))?;
+                    stream
+                        .flush()
+                        .await
+                        .map_err(|e| UnaryError::Wire(e.to_string()))?;
+
+                    let frame = wire::read_framed_futures(&mut stream)
+                        .await
+                        .map_err(|e| UnaryError::Wire(e.to_string()))?;
+                    let (echoed_id, result) = wire::decode_unary_response(&frame)
+                        .map_err(|e| UnaryError::Wire(e.to_string()))?;
+                    if echoed_id != call_id {
+                        return Err(UnaryError::Wire("callId mismatch in reply".to_string()));
+                    }
+                    let _ = stream.close().await;
+
+                    result.map_err(UnaryError::Remote)
+                };
+
+                let result = match tokio::time::timeout(timeout, exchange).await {
+                    Ok(result) => result,
+                    Err(_) => Err(UnaryError::Timeout),
+                };
+                let _ = message.reply.send(result);
+            }
+            .boxed(),
+        );
+    }
+
+    fn on_dial_upgrade_error(&mut self, error: StreamUpgradeError<std::convert::Infallible>) {
+        let message = self
+            .requested_outbound
+            .pop_front()
+            .expect("upgrade error for an outbound stream without a pending message");
+
+        let error = match error {
+            StreamUpgradeError::Timeout => UnaryError::Timeout,
+            StreamUpgradeError::NegotiationFailed => {
+                UnaryError::UnsupportedProtocol(message.proto.to_string())
+            }
+            StreamUpgradeError::Io(e) => UnaryError::Wire(e.to_string()),
+            StreamUpgradeError::Apply(infallible) => match infallible {},
+        };
+        let _ = message.reply.send(Err(error));
+    }
+}
+
+impl ConnectionHandler for Handler {
+    type FromBehaviour = OutboundMessage;
+    type ToBehaviour = InboundStreamRequestEvent;
+    type InboundProtocol = Protocols;
+    type OutboundProtocol = Protocols;
+    type InboundOpenInfo = ();
+    type OutboundOpenInfo = ();
+
+    fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, ()> {
+        let protocols = self
+            .inbound_protocols
+            .read()
+            .expect("inbound protocol set lock poisoned")
+            .iter()
+            .cloned()
+            .collect();
+        SubstreamProtocol::new(Protocols { protocols }, ())
+    }
+
+    fn on_behaviour_event(&mut self, message: Self::FromBehaviour) {
+        self.pending_outbound.push_back(message);
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<ConnectionHandlerEvent<Protocols, (), Self::ToBehaviour>> {
+        // Drive stream workers; their outcomes travel through oneshots, so
+        // completion here is just cleanup.
+        while let Poll::Ready(Some(())) = self.workers.poll_next_unpin(cx) {}
+
+        if let Poll::Ready(Some(request)) = self.inbound_rx.poll_next_unpin(cx) {
+            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                InboundStreamRequestEvent(request),
+            ));
+        }
+
+        if let Some(message) = self.pending_outbound.pop_front() {
+            let protocols = Protocols {
+                protocols: vec![message.proto.clone()],
+            };
+            self.requested_outbound.push_back(message);
+            return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
+                protocol: SubstreamProtocol::new(protocols, ()),
+            });
+        }
+
+        Poll::Pending
+    }
+
+    fn on_connection_event(
+        &mut self,
+        event: ConnectionEvent<Self::InboundProtocol, Self::OutboundProtocol, (), ()>,
+    ) {
+        match event {
+            ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
+                protocol: (stream, proto),
+                ..
+            }) => self.on_fully_negotiated_inbound(stream, proto),
+            ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
+                protocol: (stream, proto),
+                ..
+            }) => self.on_fully_negotiated_outbound(stream, proto),
+            ConnectionEvent::DialUpgradeError(DialUpgradeError { error, .. }) => {
+                self.on_dial_upgrade_error(error)
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Newtype so the handler's `ToBehaviour` has a `Debug` impl without exposing
+/// the internal request struct.
+pub struct InboundStreamRequestEvent(InboundStreamRequest);
+
+impl fmt::Debug for InboundStreamRequestEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InboundStreamRequestEvent")
+            .field("proto", &self.0.proto)
+            .field("data_len", &self.0.data.len())
+            .finish()
+    }
+}
+
+// ============================================================================
+// Behaviour
+// ============================================================================
+
+/// The hivemind unary RPC behaviour. See the module docs for the design.
+pub struct Behaviour {
+    config: Config,
+    /// Inbound protocol registrations, shared with every connection handler.
+    inbound_protocols: Arc<RwLock<HashSet<UnaryProtocol>>>,
+    /// Live connections per peer, most-recent last.
+    connected: HashMap<PeerId, Vec<ConnectionId>>,
+    /// Requests to not-yet-connected peers, flushed on establishment, failed
+    /// on dial failure.
+    pending_outbound_requests: HashMap<PeerId, Vec<OutboundMessage>>,
+    /// Events for the swarm, drained in `poll`.
+    pending_events: VecDeque<ToSwarm<Event, OutboundMessage>>,
+    /// Peer addresses learned from the swarm (`NewExternalAddrOfPeer`), served
+    /// back on dial-on-demand. In production Kademlia's routing table supplies
+    /// most dial addresses; this cache covers hints injected via
+    /// `Swarm::add_peer_address`.
+    addresses: PeerAddresses,
+}
+
+impl Behaviour {
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            inbound_protocols: Arc::new(RwLock::new(HashSet::new())),
+            connected: HashMap::new(),
+            pending_outbound_requests: HashMap::new(),
+            pending_events: VecDeque::new(),
+            addresses: PeerAddresses::default(),
+        }
+    }
+
+    /// Start advertising `proto` on inbound negotiation. Idempotent. Takes
+    /// effect for every subsequent inbound stream, including on connections
+    /// that already exist.
+    pub fn register_protocol(&mut self, proto: UnaryProtocol) {
+        self.inbound_protocols
+            .write()
+            .expect("inbound protocol set lock poisoned")
+            .insert(proto);
+    }
+
+    /// Stop advertising `proto`. Streams already negotiated are unaffected.
+    pub fn unregister_protocol(&mut self, proto: &UnaryProtocol) {
+        self.inbound_protocols
+            .write()
+            .expect("inbound protocol set lock poisoned")
+            .remove(proto);
+    }
+
+    /// Call `proto` on `peer` with `data`, resolving `reply` with the outcome.
+    ///
+    /// Dials on demand: if no connection exists the request is parked, a dial
+    /// is issued (addresses come from the composed behaviours — Kademlia's
+    /// routing table in practice, matching Go's `host.NewStream` semantics),
+    /// and the request is preloaded onto the first connection that
+    /// establishes. If the dial fails, `reply` resolves with
+    /// [`UnaryError::DialFailure`].
+    pub fn send_request(
+        &mut self,
+        peer: PeerId,
+        proto: UnaryProtocol,
+        data: Vec<u8>,
+        reply: oneshot::Sender<UnaryResult>,
+    ) {
+        let message = OutboundMessage { proto, data, reply };
+
+        match self.connected.get(&peer) {
+            Some(connections) if !connections.is_empty() => {
+                // Streams are cheap; the first connection is fine.
+                self.pending_events.push_back(ToSwarm::NotifyHandler {
+                    peer_id: peer,
+                    handler: NotifyHandler::One(connections[0]),
+                    event: message,
+                });
+            }
+            _ => {
+                let parked = self.pending_outbound_requests.entry(peer).or_default();
+                // One dial per burst: requests parked while a dial is in
+                // flight ride along on the connection it establishes.
+                if parked.is_empty() {
+                    self.pending_events.push_back(ToSwarm::Dial {
+                        opts: DialOpts::peer_id(peer).build(),
+                    });
+                }
+                parked.push(message);
+            }
+        }
+    }
+
+    /// Hand queued requests for `peer` to a freshly built connection handler.
+    fn preload_new_handler(&mut self, handler: &mut Handler, peer: PeerId) {
+        if let Some(pending) = self.pending_outbound_requests.remove(&peer) {
+            for message in pending {
+                handler.on_behaviour_event(message);
+            }
+        }
+    }
+}
+
+impl NetworkBehaviour for Behaviour {
+    type ConnectionHandler = Handler;
+    type ToSwarm = Event;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        let mut handler = Handler::new(
+            peer,
+            Arc::clone(&self.inbound_protocols),
+            self.config.clone(),
+        );
+        self.preload_new_handler(&mut handler, peer);
+        self.connected.entry(peer).or_default().push(connection_id);
+        Ok(handler)
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer: PeerId,
+        _addr: &Multiaddr,
+        _role_override: Endpoint,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        let mut handler = Handler::new(
+            peer,
+            Arc::clone(&self.inbound_protocols),
+            self.config.clone(),
+        );
+        self.preload_new_handler(&mut handler, peer);
+        self.connected.entry(peer).or_default().push(connection_id);
+        Ok(handler)
+    }
+
+    fn handle_pending_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        maybe_peer: Option<PeerId>,
+        _addresses: &[Multiaddr],
+        _effective_role: Endpoint,
+    ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        Ok(match maybe_peer {
+            Some(peer) => self.addresses.get(&peer).collect(),
+            None => Vec::new(),
+        })
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm) {
+        self.addresses.on_swarm_event(&event);
+        match event {
+            FromSwarm::ConnectionClosed(closed) => {
+                if let Some(connections) = self.connected.get_mut(&closed.peer_id) {
+                    connections.retain(|&id| id != closed.connection_id);
+                    if connections.is_empty() {
+                        self.connected.remove(&closed.peer_id);
+                    }
+                }
+                // In-flight exchanges on the closed connection resolve
+                // themselves: each worker owns its stream and oneshot, and the
+                // stream erroring out resolves the caller with a wire error.
+            }
+            FromSwarm::DialFailure(DialFailure { peer_id, error, .. }) => {
+                // A dial cancelled by its own peer condition means another
+                // dial to the same peer is already in flight — the parked
+                // requests are still going to get their connection.
+                if matches!(error, libp2p::swarm::DialError::DialPeerConditionFalse(_)) {
+                    return;
+                }
+                if let Some(peer) = peer_id {
+                    // Parked requests exist only while disconnected, so a
+                    // failed dial to this peer fails them all (mirrors
+                    // request_response's reasoning).
+                    if let Some(pending) = self.pending_outbound_requests.remove(&peer) {
+                        let text = error.to_string();
+                        for message in pending {
+                            let _ = message
+                                .reply
+                                .send(Err(UnaryError::DialFailure(text.clone())));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer: PeerId,
+        _connection: ConnectionId,
+        event: THandlerOutEvent<Self>,
+    ) {
+        let InboundStreamRequestEvent(request) = event;
+        self.pending_events
+            .push_back(ToSwarm::GenerateEvent(Event::InboundRequest {
+                peer,
+                request: InboundRequest {
+                    proto: request.proto,
+                    data: request.data,
+                    responder: request.responder,
+                },
+            }));
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        if let Some(event) = self.pending_events.pop_front() {
+            return Poll::Ready(event);
+        }
+        Poll::Pending
+    }
+}

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -262,8 +262,18 @@ pub struct Handler {
 
     /// Outbound requests not yet emitted as substream requests.
     pending_outbound: VecDeque<OutboundMessage>,
-    /// Emitted substream requests awaiting negotiation, in emission order —
-    /// `FullyNegotiatedOutbound`/`DialUpgradeError` arrive in the same order.
+    /// Emitted substream requests awaiting negotiation.
+    ///
+    /// **Not** correlated by position: with several calls in flight on one
+    /// connection, `FullyNegotiatedOutbound` events arrive in completion order,
+    /// which is not emission order — each negotiation is an independent
+    /// round-trip. Streams are therefore matched to their request by *negotiated
+    /// protocol* (see [`Handler::take_requested`]), which is exact here because
+    /// each substream request proposes exactly one protocol.
+    ///
+    /// Two concurrent calls to the *same* protocol are still matched
+    /// positionally among themselves, which is correct: they are
+    /// interchangeable, each carrying its own reply channel.
     requested_outbound: VecDeque<OutboundMessage>,
 
     /// Stream workers. Timeouts live inside each future so every worker
@@ -351,12 +361,29 @@ impl Handler {
         );
     }
 
-    fn on_fully_negotiated_outbound(&mut self, mut stream: Stream, proto: UnaryProtocol) {
-        let message = self
+    /// Claim the pending request that `proto` belongs to.
+    ///
+    /// Falls back to the oldest request when the protocol does not match any —
+    /// which should not happen, but losing the correlation must not strand a
+    /// caller's reply channel forever.
+    fn take_requested(&mut self, proto: &UnaryProtocol) -> Option<OutboundMessage> {
+        let index = self
             .requested_outbound
-            .pop_front()
-            .expect("negotiated an outbound stream without a pending message");
-        debug_assert_eq!(message.proto, proto, "outbound negotiation out of order");
+            .iter()
+            .position(|m| &m.proto == proto)
+            .or(if self.requested_outbound.is_empty() {
+                None
+            } else {
+                Some(0)
+            })?;
+        self.requested_outbound.remove(index)
+    }
+
+    fn on_fully_negotiated_outbound(&mut self, mut stream: Stream, proto: UnaryProtocol) {
+        let Some(message) = self.take_requested(&proto) else {
+            debug!(%proto, "negotiated an outbound stream without a pending message");
+            return;
+        };
 
         let callee = self.remote.to_bytes();
         let timeout = self.config.request_timeout;
@@ -404,11 +431,17 @@ impl Handler {
         );
     }
 
+    /// A failed upgrade carries no negotiated protocol — there is none — so the
+    /// oldest pending request is claimed. With several *different* protocols in
+    /// flight this can attribute a refusal to the wrong call, but both calls are
+    /// to the same peer and only one of them can be the failing one; the other
+    /// then fails on its own path. Reporting the wrong protocol name in the
+    /// error text is strictly better than panicking or leaking a reply channel.
     fn on_dial_upgrade_error(&mut self, error: StreamUpgradeError<std::convert::Infallible>) {
-        let message = self
-            .requested_outbound
-            .pop_front()
-            .expect("upgrade error for an outbound stream without a pending message");
+        let Some(message) = self.requested_outbound.pop_front() else {
+            debug!("upgrade error for an outbound stream without a pending message");
+            return;
+        };
 
         let error = match error {
             StreamUpgradeError::Timeout => UnaryError::Timeout,

--- a/core/crates/kwaai-p2p/tests/service_unary.rs
+++ b/core/crates/kwaai-p2p/tests/service_unary.rs
@@ -1,0 +1,411 @@
+//! Unary RPC through the full [`NetworkService`] stack.
+//!
+//! `tests/unary.rs` drives `unary::Behaviour` standalone; this tier exercises
+//! the same protocol through the composed `KwaaiBehaviour` and the service's
+//! select loop, which is where handler dispatch actually lives. What it proves
+//! that the behaviour-level tests cannot:
+//!
+//! - `NetworkHandle::add_unary_handler` registers the protocol *and* the
+//!   dispatch route in one round trip,
+//! - the service maps `unary::UnaryError` onto `P2PError` as documented,
+//! - dispatch survives the interesting failure modes: no handler registered, a
+//!   handler that returns its error arm, a handler removed mid-life,
+//! - a slow handler blocks neither the event loop nor other calls.
+//!
+//! Both swarms are loopback-only with freshly generated keys, so nothing here
+//! can collide with a node running on the same machine.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use kwaai_p2p::{NetworkConfig, NetworkHandle, NetworkService, P2PError, PeerId};
+use libp2p::identity::Keypair;
+
+const PROTO: &str = "DHTProtocol.rpc_ping";
+
+/// A per-call cap so a lost reply fails the test rather than hanging it.
+const TEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Spawn a loopback service, keeping the task handle alive for the test.
+fn spawn_service() -> (NetworkHandle, tokio::task::JoinHandle<()>, PeerId) {
+    let keypair = Keypair::generate_ed25519();
+    let peer_id = keypair.public().to_peer_id();
+    let (handle, task) =
+        NetworkService::spawn(NetworkConfig::for_tests(), keypair).expect("service should start");
+    (handle, task, peer_id)
+}
+
+/// The first listen address of `handle`, with `/p2p/<peer-id>` appended so it is
+/// directly dialable.
+async fn dialable_addr(handle: &NetworkHandle, peer_id: PeerId) -> String {
+    let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
+    loop {
+        if let Some(addr) = handle
+            .listen_addrs()
+            .await
+            .ok()
+            .and_then(|a| a.into_iter().next())
+        {
+            return format!("{addr}/p2p/{peer_id}");
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for a listen address"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Two connected services: `caller` has dialed `responder`.
+async fn connected_pair() -> (
+    NetworkHandle,
+    NetworkHandle,
+    PeerId,
+    Vec<tokio::task::JoinHandle<()>>,
+) {
+    let (caller, caller_task, _caller_id) = spawn_service();
+    let (responder, responder_task, responder_id) = spawn_service();
+
+    let addr = dialable_addr(&responder, responder_id).await;
+    let connected = caller
+        .connect_peer(&addr)
+        .await
+        .expect("loopback dial should succeed");
+    assert_eq!(connected, responder_id);
+
+    (
+        caller,
+        responder,
+        responder_id,
+        vec![caller_task, responder_task],
+    )
+}
+
+/// Run `f`, failing the test rather than hanging if it stalls.
+async fn within<T>(what: &str, f: impl std::future::Future<Output = T>) -> T {
+    tokio::time::timeout(TEST_TIMEOUT, f)
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for: {what}"))
+}
+
+// ---------------------------------------------------------------------------
+// Round trip
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn handle_round_trips_a_unary_call() {
+    let (caller, responder, responder_id, _tasks) = connected_pair().await;
+
+    responder
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move {
+            let mut out = b"echo:".to_vec();
+            out.extend_from_slice(&data);
+            Ok(out)
+        })
+        .await
+        .expect("registering a handler should succeed");
+
+    let response = within(
+        "the echo round trip",
+        caller.call_unary_handler(responder_id, PROTO, b"hello"),
+    )
+    .await
+    .expect("a registered handler must answer");
+    assert_eq!(response, b"echo:hello");
+}
+
+/// The caller never dialed the responder: the behaviour must dial on demand
+/// using the address Kademlia was seeded with, matching Go's `host.NewStream`.
+#[tokio::test]
+async fn call_dials_on_demand_when_not_connected() {
+    let (caller, _caller_task, _caller_id) = spawn_service();
+    let (responder, _responder_task, responder_id) = spawn_service();
+
+    responder
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("register handler");
+
+    // Seed only the routing table — no `connect_peer`.
+    let addr = dialable_addr(&responder, responder_id).await;
+    let stripped: libp2p::Multiaddr = addr
+        .parse::<libp2p::Multiaddr>()
+        .expect("valid multiaddr")
+        .iter()
+        .filter(|p| !matches!(p, libp2p::multiaddr::Protocol::P2p(_)))
+        .collect();
+    caller
+        .add_kad_address(responder_id, stripped)
+        .await
+        .expect("seed the routing table");
+
+    assert!(
+        caller
+            .list_peers()
+            .await
+            .expect("list_peers")
+            .iter()
+            .all(|p| p.peer_id != responder_id),
+        "precondition: the caller must not already be connected"
+    );
+
+    let response = within(
+        "a dial-on-demand unary call",
+        caller.call_unary_handler(responder_id, PROTO, b"cold"),
+    )
+    .await
+    .expect("the call must dial the peer itself");
+    assert_eq!(response, b"cold");
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+/// A handler's error arm must arrive as `P2PError::Protocol` carrying the
+/// remote's text — callers key their retry logic on that string.
+#[tokio::test]
+async fn remote_handler_error_maps_to_protocol_error() {
+    let (caller, responder, responder_id, _tasks) = connected_pair().await;
+
+    responder
+        .add_unary_handler(PROTO, |_data: Vec<u8>| async move {
+            Err("expert not loaded".to_string())
+        })
+        .await
+        .expect("register handler");
+
+    let error = within(
+        "the remote error arm",
+        caller.call_unary_handler(responder_id, PROTO, b"x"),
+    )
+    .await
+    .expect_err("a handler returning Err must surface as an error");
+
+    match &error {
+        P2PError::Protocol(text) => assert!(
+            text.contains("expert not loaded"),
+            "the remote's text must be preserved, got {text}"
+        ),
+        other => panic!("expected P2PError::Protocol, got {other:?}"),
+    }
+}
+
+/// Calling a protocol nobody registered is refused during negotiation, so it
+/// surfaces as `UnsupportedProtocol` → `P2PError::Protocol` — never as a hang.
+#[tokio::test]
+async fn calling_an_unregistered_protocol_is_refused() {
+    let (caller, responder, responder_id, _tasks) = connected_pair().await;
+
+    // A different protocol is served, proving the refusal is per-protocol.
+    responder
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("register handler");
+
+    let error = within(
+        "the refusal of an unserved protocol",
+        caller.call_unary_handler(responder_id, "DHTProtocol.rpc_nonexistent", b"x"),
+    )
+    .await
+    .expect_err("an unserved protocol must be refused");
+
+    match &error {
+        P2PError::Protocol(text) => assert!(
+            text.contains("does not support"),
+            "expected an unsupported-protocol message, got {text}"
+        ),
+        other => panic!("expected P2PError::Protocol, got {other:?}"),
+    }
+
+    // The connection must survive the refusal.
+    let response = within(
+        "a call after the refusal",
+        caller.call_unary_handler(responder_id, PROTO, b"still-alive"),
+    )
+    .await
+    .expect("the connection must remain usable");
+    assert_eq!(response, b"still-alive");
+}
+
+/// Dialing a peer with no known address fails as `DialFailed` rather than
+/// waiting out the request timeout.
+#[tokio::test]
+async fn calling_an_unreachable_peer_maps_to_dial_failed() {
+    let (caller, _task, _id) = spawn_service();
+    let stranger = Keypair::generate_ed25519().public().to_peer_id();
+
+    let error = within(
+        "the dial failure",
+        caller.call_unary_handler(stranger, PROTO, b"x"),
+    )
+    .await
+    .expect_err("a peer with no address must not resolve");
+    assert!(
+        matches!(error, P2PError::DialFailed(_)),
+        "expected P2PError::DialFailed, got {error:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Registration lifecycle
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn removing_a_handler_causes_a_clean_refusal() {
+    let (caller, responder, responder_id, _tasks) = connected_pair().await;
+
+    responder
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("register handler");
+
+    let response = within(
+        "the call before removal",
+        caller.call_unary_handler(responder_id, PROTO, b"before"),
+    )
+    .await
+    .expect("the handler is registered");
+    assert_eq!(response, b"before");
+
+    assert!(
+        responder
+            .remove_unary_handler(PROTO)
+            .await
+            .expect("remove should reach the service"),
+        "removing a registered handler reports true"
+    );
+
+    let error = within(
+        "the refusal after removal",
+        caller.call_unary_handler(responder_id, PROTO, b"after"),
+    )
+    .await
+    .expect_err("a removed handler must no longer answer");
+    match &error {
+        P2PError::Protocol(text) => assert!(
+            text.contains("does not support"),
+            "removal must produce a negotiation refusal, got {text}"
+        ),
+        other => panic!("expected P2PError::Protocol, got {other:?}"),
+    }
+
+    // Idempotent: removing again is not an error, just `false`.
+    assert!(
+        !responder
+            .remove_unary_handler(PROTO)
+            .await
+            .expect("remove should reach the service"),
+        "removing an unregistered handler reports false"
+    );
+}
+
+/// Re-registering a protocol swaps the handler rather than stacking two.
+#[tokio::test]
+async fn re_registering_replaces_the_handler() {
+    let (caller, responder, responder_id, _tasks) = connected_pair().await;
+
+    responder
+        .add_unary_handler(PROTO, |_: Vec<u8>| async move { Ok(b"first".to_vec()) })
+        .await
+        .expect("register the first handler");
+    responder
+        .add_unary_handler(PROTO, |_: Vec<u8>| async move { Ok(b"second".to_vec()) })
+        .await
+        .expect("register the replacement");
+
+    let response = within(
+        "the replacement handler's answer",
+        caller.call_unary_handler(responder_id, PROTO, b"x"),
+    )
+    .await
+    .expect("the protocol is still served");
+    assert_eq!(response, b"second", "the most recent registration must win");
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+/// One task per call, not one per handler: a slow call must not delay calls
+/// that arrive behind it, and must not stall the event loop.
+#[tokio::test]
+async fn a_slow_handler_does_not_serialize_other_calls() {
+    let (caller, responder, responder_id, _tasks) = connected_pair().await;
+
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let max_in_flight = Arc::new(AtomicUsize::new(0));
+    let (seen, max_seen) = (Arc::clone(&in_flight), Arc::clone(&max_in_flight));
+
+    responder
+        .add_unary_handler(PROTO, move |data: Vec<u8>| {
+            let seen = Arc::clone(&seen);
+            let max_seen = Arc::clone(&max_seen);
+            async move {
+                let now = seen.fetch_add(1, Ordering::SeqCst) + 1;
+                max_seen.fetch_max(now, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                seen.fetch_sub(1, Ordering::SeqCst);
+                Ok(data)
+            }
+        })
+        .await
+        .expect("register handler");
+
+    const CALLS: usize = 5;
+    let calls = (0..CALLS).map(|i| {
+        let caller = caller.clone();
+        async move {
+            caller
+                .call_unary_handler(responder_id, PROTO, &[i as u8])
+                .await
+        }
+    });
+
+    let results = within("all concurrent calls", futures::future::join_all(calls)).await;
+    for (i, result) in results.into_iter().enumerate() {
+        assert_eq!(
+            result.expect("every concurrent call must succeed"),
+            vec![i as u8]
+        );
+    }
+
+    assert!(
+        max_in_flight.load(Ordering::SeqCst) > 1,
+        "calls were serialized: peak concurrency was {}",
+        max_in_flight.load(Ordering::SeqCst)
+    );
+
+    // The event loop is still responsive.
+    assert!(responder.list_peers().await.is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn calls_after_shutdown_error_rather_than_hang() {
+    let (caller, task, _id) = spawn_service();
+    let stranger = Keypair::generate_ed25519().public().to_peer_id();
+
+    caller.shutdown().await.expect("shutdown ack");
+    within("the event loop to exit", task)
+        .await
+        .expect("the event loop must not panic");
+
+    let error = within(
+        "a call against a stopped service",
+        caller.call_unary_handler(stranger, PROTO, b"x"),
+    )
+    .await
+    .expect_err("a stopped service cannot serve calls");
+    assert!(matches!(error, P2PError::NotInitialized));
+
+    assert!(caller
+        .add_unary_handler(PROTO, |d: Vec<u8>| async move { Ok(d) })
+        .await
+        .is_err());
+    assert!(caller.remove_unary_handler(PROTO).await.is_err());
+}

--- a/core/crates/kwaai-p2p/tests/service_unary.rs
+++ b/core/crates/kwaai-p2p/tests/service_unary.rs
@@ -381,6 +381,48 @@ async fn a_slow_handler_does_not_serialize_other_calls() {
     assert!(responder.list_peers().await.is_ok());
 }
 
+/// Concurrent calls to **different** protocols on one connection must each get
+/// their own answer.
+///
+/// Regression test: `FullyNegotiatedOutbound` events arrive in completion
+/// order, not emission order, so replies must be correlated by request id.
+/// Calls sharing one protocol cannot catch this — two protocols in flight can,
+/// which is the `shard serve` + `storage serve` deployment.
+#[tokio::test]
+async fn concurrent_calls_to_different_protocols_do_not_cross_talk() {
+    const PROTO_A: &str = "DHTProtocol.rpc_store";
+    const PROTO_B: &str = "DHTProtocol.rpc_find";
+
+    let (caller, responder, responder_id, _tasks) = connected_pair().await;
+
+    for (proto, tag) in [(PROTO_A, &b"A:"[..]), (PROTO_B, &b"B:"[..])] {
+        let tag = tag.to_vec();
+        responder
+            .add_unary_handler(proto, move |data: Vec<u8>| {
+                let tag = tag.clone();
+                async move {
+                    let mut out = tag.clone();
+                    out.extend_from_slice(&data);
+                    Ok(out)
+                }
+            })
+            .await
+            .expect("register handler");
+    }
+
+    let (a, b) = tokio::join!(
+        caller.call_unary_handler(responder_id, PROTO_A, b"one"),
+        caller.call_unary_handler(responder_id, PROTO_B, b"two"),
+    );
+
+    assert_eq!(
+        a.expect("the rpc_store call must succeed"),
+        b"A:one",
+        "each concurrent call must receive its own protocol's response"
+    );
+    assert_eq!(b.expect("the rpc_find call must succeed"), b"B:two");
+}
+
 // ---------------------------------------------------------------------------
 // Shutdown
 // ---------------------------------------------------------------------------

--- a/core/crates/kwaai-p2p/tests/unary.rs
+++ b/core/crates/kwaai-p2p/tests/unary.rs
@@ -471,3 +471,65 @@ async fn inbound_overflow_gets_a_capacity_refusal() {
         .expect("first call succeeds");
     assert_eq!(response, b"released");
 }
+
+/// Liveness: with a single outbound slot, a call queued behind one that FAILS
+/// negotiation must still get its turn — the slot is freed by
+/// `DialUpgradeError`, not worker completion, so it exercises the explicit
+/// wake path rather than `FuturesUnordered`'s own wakes.
+#[tokio::test]
+async fn queued_call_survives_a_negotiation_failure_ahead_of_it() {
+    let responder = Responder::spawn(|data| Some(Ok(data))).await;
+
+    let mut swarm = new_swarm(unary::Config {
+        max_concurrent_streams: 1,
+        ..unary::Config::default()
+    });
+    swarm.add_peer_address(responder.peer_id, responder.addr.clone());
+    let (tx, mut rx) =
+        mpsc::unbounded_channel::<(PeerId, String, Vec<u8>, oneshot::Sender<UnaryResult>)>();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                request = rx.recv() => match request {
+                    Some((peer, proto, data, reply)) => swarm.behaviour_mut().send_request(
+                        peer,
+                        UnaryProtocol::new(proto),
+                        data,
+                        reply,
+                    ),
+                    None => break,
+                },
+                _event = swarm.select_next_some() => {}
+            }
+        }
+    });
+
+    // A occupies the only slot and will be refused at negotiation.
+    let (a_tx, a_rx) = oneshot::channel();
+    tx.send((
+        responder.peer_id,
+        "DHTProtocol.rpc_unserved".to_string(),
+        b"a".to_vec(),
+        a_tx,
+    ))
+    .expect("caller task alive");
+    // B queues behind A on a served protocol.
+    let (b_tx, b_rx) = oneshot::channel();
+    tx.send((responder.peer_id, PROTO.to_string(), b"b".to_vec(), b_tx))
+        .expect("caller task alive");
+
+    let a = tokio::time::timeout(TEST_TIMEOUT, a_rx)
+        .await
+        .expect("A resolves")
+        .expect("A channel intact");
+    assert!(
+        matches!(a, Err(UnaryError::UnsupportedProtocol(_))),
+        "A must be refused, got {a:?}"
+    );
+    let b = tokio::time::timeout(TEST_TIMEOUT, b_rx)
+        .await
+        .expect("B must not hang behind A's freed slot")
+        .expect("B channel intact")
+        .expect("B should succeed");
+    assert_eq!(b, b"b");
+}

--- a/core/crates/kwaai-p2p/tests/unary.rs
+++ b/core/crates/kwaai-p2p/tests/unary.rs
@@ -1,0 +1,339 @@
+//! In-process tests for the hivemind unary RPC behaviour.
+//!
+//! Two real swarms over TCP+noise+yamux on 127.0.0.1 — the production
+//! transport — with `unary::Behaviour` standalone (no kad), so every dial goes
+//! through `Swarm::add_peer_address` + the behaviour's dial-on-demand path,
+//! exactly the sequence a `call_unary_handler` to a not-yet-connected peer
+//! takes. Cross-implementation coverage against a real go-libp2p daemon lives
+//! in `kwaai-network-tests` (`07_wire_interop.rs` for the raw wire; the swarm
+//! interop tier arrives with the service integration).
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use kwaai_p2p::unary::{self, UnaryError, UnaryProtocol, UnaryResult};
+use libp2p::{swarm::SwarmEvent, Multiaddr, PeerId, Swarm, SwarmBuilder};
+use tokio::sync::{mpsc, oneshot};
+
+const PROTO: &str = "DHTProtocol.rpc_ping";
+
+/// A per-test cap so a lost reply oneshot fails the test rather than hanging it.
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ============================================================================
+// Harness
+// ============================================================================
+
+fn new_swarm(config: unary::Config) -> Swarm<unary::Behaviour> {
+    SwarmBuilder::with_new_identity()
+        .with_tokio()
+        .with_tcp(
+            libp2p::tcp::Config::default().nodelay(true),
+            libp2p::noise::Config::new,
+            libp2p::yamux::Config::default,
+        )
+        .expect("tcp transport")
+        .with_behaviour(|_| unary::Behaviour::new(config))
+        .expect("behaviour")
+        .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(60)))
+        .build()
+}
+
+/// Start listening and return the first bound address.
+async fn listen(swarm: &mut Swarm<unary::Behaviour>) -> Multiaddr {
+    swarm
+        .listen_on("/ip4/127.0.0.1/tcp/0".parse().expect("valid multiaddr"))
+        .expect("listen");
+    loop {
+        if let SwarmEvent::NewListenAddr { address, .. } = swarm.select_next_some().await {
+            return address;
+        }
+    }
+}
+
+/// A responder node: serves `PROTO` with `handler` on its own task.
+///
+/// `handler` maps the request payload to the responder outcome; returning
+/// `None` *drops* the responder oneshot instead of answering, exercising the
+/// handler-dropped path.
+struct Responder {
+    peer_id: PeerId,
+    addr: Multiaddr,
+}
+
+impl Responder {
+    async fn spawn(
+        handler: impl Fn(Vec<u8>) -> Option<Result<Vec<u8>, String>> + Send + 'static,
+    ) -> Self {
+        let mut swarm = new_swarm(unary::Config::default());
+        swarm
+            .behaviour_mut()
+            .register_protocol(UnaryProtocol::new(PROTO));
+        let peer_id = *swarm.local_peer_id();
+        let addr = listen(&mut swarm).await;
+
+        tokio::spawn(async move {
+            loop {
+                if let SwarmEvent::Behaviour(unary::Event::InboundRequest { request, .. }) =
+                    swarm.select_next_some().await
+                {
+                    match handler(request.data) {
+                        Some(result) => {
+                            let _ = request.responder.send(result);
+                        }
+                        None => drop(request.responder),
+                    }
+                }
+            }
+        });
+
+        Self { peer_id, addr }
+    }
+}
+
+/// A caller node: drives its swarm on its own task, taking calls via a channel.
+struct Caller {
+    requests: mpsc::UnboundedSender<(PeerId, String, Vec<u8>, oneshot::Sender<UnaryResult>)>,
+}
+
+impl Caller {
+    /// Spawn a caller that knows `responder`'s address (so dial-on-demand can
+    /// resolve it, standing in for the Kademlia routing table).
+    fn spawn(responder: &Responder) -> Self {
+        let mut swarm = new_swarm(unary::Config::default());
+        swarm.add_peer_address(responder.peer_id, responder.addr.clone());
+
+        let (tx, mut rx) =
+            mpsc::unbounded_channel::<(PeerId, String, Vec<u8>, oneshot::Sender<UnaryResult>)>();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    request = rx.recv() => match request {
+                        Some((peer, proto, data, reply)) => {
+                            swarm.behaviour_mut().send_request(
+                                peer,
+                                UnaryProtocol::new(proto),
+                                data,
+                                reply,
+                            );
+                        }
+                        None => break,
+                    },
+                    _event = swarm.select_next_some() => {}
+                }
+            }
+        });
+
+        Self { requests: tx }
+    }
+
+    async fn call(&self, peer: PeerId, proto: &str, data: &[u8]) -> UnaryResult {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.requests
+            .send((peer, proto.to_string(), data.to_vec(), reply_tx))
+            .expect("caller task alive");
+        tokio::time::timeout(TEST_TIMEOUT, reply_rx)
+            .await
+            .expect("call must resolve within the test timeout")
+            .expect("reply oneshot must not be dropped")
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// The core path: dial-on-demand to a never-connected peer, slash-less
+/// negotiation, one frame each way, payload intact.
+#[tokio::test]
+async fn round_trip_with_dial_on_demand() {
+    let responder = Responder::spawn(|data| {
+        let mut out = b"echo:".to_vec();
+        out.extend_from_slice(&data);
+        Some(Ok(out))
+    })
+    .await;
+    let caller = Caller::spawn(&responder);
+
+    let response = caller
+        .call(responder.peer_id, PROTO, b"ping-payload")
+        .await
+        .expect("call should succeed");
+    assert_eq!(response, b"echo:ping-payload");
+}
+
+/// The error arm must arrive as `UnaryError::Remote` with the handler's text.
+#[tokio::test]
+async fn error_arm_propagates() {
+    let responder = Responder::spawn(|_| Some(Err("deliberate handler failure".to_string()))).await;
+    let caller = Caller::spawn(&responder);
+
+    let error = caller
+        .call(responder.peer_id, PROTO, b"x")
+        .await
+        .expect_err("handler error must surface");
+    match error {
+        UnaryError::Remote(text) => assert_eq!(text, "deliberate handler failure"),
+        other => panic!("expected Remote, got {other:?}"),
+    }
+}
+
+/// Calling a protocol the peer does not serve must fail with
+/// `UnsupportedProtocols` — the clean refusal the health probe depends on —
+/// and must NOT tear down the connection: a subsequent call on a served
+/// protocol succeeds.
+#[tokio::test]
+async fn unsupported_protocol_is_a_clean_refusal() {
+    let responder = Responder::spawn(|data| Some(Ok(data))).await;
+    let caller = Caller::spawn(&responder);
+
+    let error = caller
+        .call(responder.peer_id, "DHTProtocol.rpc_nonexistent", b"x")
+        .await
+        .expect_err("unserved protocol must be refused");
+    assert!(
+        matches!(error, UnaryError::UnsupportedProtocol(ref p) if p == "DHTProtocol.rpc_nonexistent"),
+        "expected UnsupportedProtocol, got {error:?}"
+    );
+
+    let response = caller
+        .call(responder.peer_id, PROTO, b"still-alive")
+        .await
+        .expect("the connection must survive a refused protocol");
+    assert_eq!(response, b"still-alive");
+}
+
+/// A handler that drops its responder (crash-analog) must produce the error
+/// arm on the wire, not a hang.
+#[tokio::test]
+async fn dropped_responder_becomes_an_error_reply() {
+    let responder = Responder::spawn(|_| None).await;
+    let caller = Caller::spawn(&responder);
+
+    let error = caller
+        .call(responder.peer_id, PROTO, b"x")
+        .await
+        .expect_err("dropped responder must surface as an error");
+    match error {
+        UnaryError::Remote(text) => assert!(
+            text.contains("dropped"),
+            "expected the dropped-handler message, got: {text}"
+        ),
+        other => panic!("expected Remote, got {other:?}"),
+    }
+}
+
+/// Dialing a peer with no known addresses fails the parked request with
+/// `DialFailure` instead of leaving it queued forever.
+#[tokio::test]
+async fn unreachable_peer_fails_the_request() {
+    let responder = Responder::spawn(|data| Some(Ok(data))).await;
+    let caller = Caller::spawn(&responder);
+
+    // A peer ID nobody has an address for.
+    let stranger = PeerId::random();
+    let error = caller
+        .call(stranger, PROTO, b"x")
+        .await
+        .expect_err("no route to the peer");
+    assert!(
+        matches!(error, UnaryError::DialFailure(_)),
+        "expected DialFailure, got {error:?}"
+    );
+}
+
+/// Concurrent calls on one connection must all resolve with their own payloads
+/// (per-stream isolation, no callId cross-talk).
+#[tokio::test]
+async fn concurrent_calls_resolve_independently() {
+    let responder = Responder::spawn(|data| {
+        let mut out = b"echo:".to_vec();
+        out.extend_from_slice(&data);
+        Some(Ok(out))
+    })
+    .await;
+    let caller = Caller::spawn(&responder);
+
+    let calls = (0u8..8).map(|i| {
+        let caller = &caller;
+        let peer = responder.peer_id;
+        async move { caller.call(peer, PROTO, &[i; 16]).await }
+    });
+    let results = futures::future::join_all(calls).await;
+
+    for (i, result) in results.into_iter().enumerate() {
+        let response = result.expect("concurrent call should succeed");
+        let mut expected = b"echo:".to_vec();
+        expected.extend_from_slice(&[i as u8; 16]);
+        assert_eq!(response, expected, "call {i} got the wrong payload back");
+    }
+}
+
+/// A protocol registered *after* a connection is already established must be
+/// callable on that same connection — the dynamic-registration property
+/// Phase 3's IPC `add_unary_handler` depends on.
+#[tokio::test]
+async fn late_registration_reaches_existing_connections() {
+    // Responder with full swarm access kept in the test body: register PROTO,
+    // serve one call, then register LATE and keep serving.
+    const LATE: &str = "hello";
+
+    let mut swarm = new_swarm(unary::Config::default());
+    swarm
+        .behaviour_mut()
+        .register_protocol(UnaryProtocol::new(PROTO));
+    let peer_id = *swarm.local_peer_id();
+    let addr = listen(&mut swarm).await;
+
+    let (registered_tx, registered_rx) = oneshot::channel::<()>();
+    let (register_late_tx, mut register_late_rx) = mpsc::unbounded_channel::<()>();
+    tokio::spawn(async move {
+        let mut registered_tx = Some(registered_tx);
+        loop {
+            tokio::select! {
+                Some(()) = register_late_rx.recv() => {
+                    swarm.behaviour_mut().register_protocol(UnaryProtocol::new(LATE));
+                    if let Some(tx) = registered_tx.take() {
+                        let _ = tx.send(());
+                    }
+                }
+                event = swarm.select_next_some() => {
+                    if let SwarmEvent::Behaviour(unary::Event::InboundRequest { request, .. }) = event {
+                        let _ = request.responder.send(Ok(request.proto.to_string().into_bytes()));
+                    }
+                }
+            }
+        }
+    });
+
+    let responder = Responder { peer_id, addr };
+    let caller = Caller::spawn(&responder);
+
+    // Establish the connection via a call on the initially-registered protocol.
+    let response = caller
+        .call(peer_id, PROTO, b"")
+        .await
+        .expect("initial protocol should work");
+    assert_eq!(response, PROTO.as_bytes());
+
+    // LATE is not yet registered: refused on the live connection.
+    let error = caller
+        .call(peer_id, LATE, b"")
+        .await
+        .expect_err("not yet registered");
+    assert!(matches!(error, UnaryError::UnsupportedProtocol(_)));
+
+    // Register it and call again — same connection, no reconnect.
+    register_late_tx.send(()).expect("responder task alive");
+    tokio::time::timeout(TEST_TIMEOUT, registered_rx)
+        .await
+        .expect("registration must be acknowledged")
+        .expect("registration ack");
+
+    let response = caller
+        .call(peer_id, LATE, b"")
+        .await
+        .expect("late-registered protocol must be reachable on the existing connection");
+    assert_eq!(response, LATE.as_bytes());
+}

--- a/core/crates/kwaai-p2p/tests/unary.rs
+++ b/core/crates/kwaai-p2p/tests/unary.rs
@@ -337,3 +337,137 @@ async fn late_registration_reaches_existing_connections() {
         .expect("late-registered protocol must be reachable on the existing connection");
     assert_eq!(response, LATE.as_bytes());
 }
+
+/// With `max_concurrent_streams: 1` on the caller, a burst of calls must be
+/// throttled through the single slot and still ALL complete — emission
+/// back-pressure, not failure.
+#[tokio::test]
+async fn outbound_burst_is_throttled_not_failed() {
+    let responder = Responder::spawn(|data| Some(Ok(data))).await;
+
+    // Bespoke caller with a cap of one in-flight outbound stream.
+    let mut swarm = new_swarm(unary::Config {
+        max_concurrent_streams: 1,
+        ..unary::Config::default()
+    });
+    swarm.add_peer_address(responder.peer_id, responder.addr.clone());
+    let (tx, mut rx) =
+        mpsc::unbounded_channel::<(PeerId, String, Vec<u8>, oneshot::Sender<UnaryResult>)>();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                request = rx.recv() => match request {
+                    Some((peer, proto, data, reply)) => swarm.behaviour_mut().send_request(
+                        peer,
+                        UnaryProtocol::new(proto),
+                        data,
+                        reply,
+                    ),
+                    None => break,
+                },
+                _event = swarm.select_next_some() => {}
+            }
+        }
+    });
+
+    let mut replies = Vec::new();
+    for i in 0u8..4 {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send((responder.peer_id, PROTO.to_string(), vec![i; 8], reply_tx))
+            .expect("caller task alive");
+        replies.push(reply_rx);
+    }
+    for (i, reply) in replies.into_iter().enumerate() {
+        let response = tokio::time::timeout(TEST_TIMEOUT, reply)
+            .await
+            .expect("throttled call must still resolve")
+            .expect("reply channel intact")
+            .expect("call should succeed");
+        assert_eq!(response, vec![i as u8; 8], "call {i} payload survived");
+    }
+}
+
+/// A responder at its inbound cap must answer the overflow call with the
+/// "at capacity" error arm — a clean refusal the caller can act on — rather
+/// than resetting the stream or timing it out.
+#[tokio::test]
+async fn inbound_overflow_gets_a_capacity_refusal() {
+    use std::sync::{Arc, Mutex};
+
+    // Responder with a single inbound slot that parks requests instead of
+    // answering, so the test controls when the slot frees up.
+    let mut swarm = new_swarm(unary::Config {
+        max_concurrent_streams: 1,
+        ..unary::Config::default()
+    });
+    swarm
+        .behaviour_mut()
+        .register_protocol(UnaryProtocol::new(PROTO));
+    let peer_id = *swarm.local_peer_id();
+    let addr = listen(&mut swarm).await;
+
+    let parked: Arc<Mutex<Vec<tokio::sync::oneshot::Sender<Result<Vec<u8>, String>>>>> =
+        Arc::new(Mutex::new(Vec::new()));
+    let parked_in_loop = Arc::clone(&parked);
+    tokio::spawn(async move {
+        loop {
+            if let SwarmEvent::Behaviour(unary::Event::InboundRequest { request, .. }) =
+                swarm.select_next_some().await
+            {
+                parked_in_loop
+                    .lock()
+                    .expect("parked lock")
+                    .push(request.responder);
+            }
+        }
+    });
+
+    let responder = Responder { peer_id, addr };
+    let caller = Caller::spawn(&responder);
+
+    // Occupy the only slot, waiting until the request has actually reached
+    // the app layer (the worker is now parked awaiting `parked[0]`).
+    let (first_tx, first_rx) = oneshot::channel();
+    caller
+        .requests
+        .send((peer_id, PROTO.to_string(), b"first".to_vec(), first_tx))
+        .expect("caller task alive");
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        loop {
+            if !parked.lock().expect("parked lock").is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("first call must reach the responder's app layer");
+
+    // The overflow call gets the refusal error arm.
+    let error = caller
+        .call(peer_id, PROTO, b"second")
+        .await
+        .expect_err("overflow must be refused");
+    match error {
+        UnaryError::Remote(text) => assert!(
+            text.contains("capacity"),
+            "expected the at-capacity refusal, got: {text}"
+        ),
+        other => panic!("expected Remote refusal, got {other:?}"),
+    }
+
+    // Free the slot; the parked first call completes normally.
+    parked
+        .lock()
+        .expect("parked lock")
+        .pop()
+        .expect("first responder parked")
+        .send(Ok(b"released".to_vec()))
+        .expect("worker still awaiting");
+    let response = tokio::time::timeout(TEST_TIMEOUT, first_rx)
+        .await
+        .expect("first call resolves after release")
+        .expect("reply channel intact")
+        .expect("first call succeeds");
+    assert_eq!(response, b"released");
+}

--- a/docs/NATIVE_P2P_MIGRATION.md
+++ b/docs/NATIVE_P2P_MIGRATION.md
@@ -92,12 +92,19 @@ p2pd.
 
 2. **Behaviour composition**: ping, identify, kad(MemoryStore, auto client/server mode +
    `dht_server` config override), autonat(v1), relay client, `Toggle<relay server>`
-   (`!config.no_relay`), dcutr, `Toggle<upnp>`, `request_response<HivemindUnaryCodec>` for
-   ALL unary protocols (slash-less hivemind names via a custom `UnaryProtocol(Arc<str>)`
-   protocol type — `StreamProtocol::new` panics on slash-less, `request_response` only
-   needs `AsRef<str>`), `libp2p_stream` for slashed raw-stream protocols (inference-mux,
+   (`!config.no_relay`), dcutr, `Toggle<upnp>`, a **hand-rolled `unary::Behaviour`** for
+   ALL unary protocols, `libp2p_stream` for slashed raw-stream protocols (inference-mux,
    block_rpc). Transport: SwarmBuilder TCP+noise+yamux + dns + relay client. TCP-only
    (fleet is TCP). Workspace libp2p features add: `ping, dcutr, autonat, upnp, dns`.
+
+   *(Revised in Phase 2 — the original plan said `request_response<HivemindUnaryCodec>`,
+   which turned out to be structurally wrong for hivemind: its protocol list is fixed at
+   construction and `send_request` cannot pick a protocol per request, while a hivemind
+   call IS its protocol and Phase 3 registers handlers at runtime. `kwaai-p2p/src/unary.rs`
+   keeps `request_response`'s architecture — pending queues, dial-on-demand, worker
+   futures — with per-request negotiation via `UnaryProtocol(Arc<str>)` and a shared
+   dynamic inbound protocol set. Slash-less negotiation additionally needs the vendored
+   `multistream-select` patch; see Resolved verification items.)*
 
 3. **IPC for external processes — node-hosted p2pd-protocol control socket.** The node
    serves the existing p2pd protobuf control protocol on the same socket path
@@ -201,6 +208,19 @@ starvation mistakes (blocking calls inside the select loop); channel deadlocks b
 
 `request_response<HivemindUnaryCodec>` behaviour + handler dispatch; DHT serving + announce
 via `NetworkHandle`.
+
+*Done so far:* `unary::Behaviour` (see the revision note under design decision 2) and its
+**handler dispatch through `NetworkHandle`**. `KwaaiBehaviour` composes a `unary` field
+built from `NetworkConfig::request_timeout`; the service loop owns a protocol → sender
+dispatch map kept in lockstep with the behaviour's inbound protocol set, and the handle
+exposes `call_unary_handler` / `add_unary_handler` / `remove_unary_handler` under their
+`P2PClient` names. Outbound calls need no pending-map entry — `send_request` owns the
+oneshot and resolves it on every path — and inbound dispatch uses an unbounded channel plus
+one task per call, so neither a slow handler nor a dead one can stall the select loop.
+Gated by `kwaai-p2p/tests/service_unary.rs` and `09_service_unary_interop.rs` (a full
+`NetworkService` against a real p2pd, both directions).
+
+*Still open in this phase:* DHT serving and the announce/re-announce lifecycle.
 
 *Testable:* node announces to bootstraps and shows on the health map; `rpc_find` against a
 Python bootstrap returns our record; a p2pd-based caller successfully calls our `rpc_ping`
@@ -308,7 +328,11 @@ gates).
 ## Resolved verification items (Phase 0, `07_wire_interop` against a real p2pd)
 
 - Slash-less protocol IDs negotiate fine on the go-libp2p wire
-  (`slashless_protocol_negotiates`) — Phase 2's `UnaryProtocol(Arc<str>)` is viable.
+  (`slashless_protocol_negotiates`) — but rust-libp2p's *local* validation rejects them
+  at three points in `multistream-select` (dial-side and listen-side `Protocol::try_from`
+  plus the proposal-recognition rule in `Message::decode`). Resolved by a vendored
+  two-file patch: `core/patches/multistream-select/` via `[patch.crates-io]`. The wire
+  format itself is unaffected.
 - The wire wrapper is exactly as described above (both directions proven; the old
   `PersistentConnectionResponse` reply shape is provably rejected by Go callers).
 - **proto2 `required` is enforced by Go on unmarshal**: a frame omitting an empty


### PR DESCRIPTION
**Stack** (review in order; each PR shows only its own diff):
| # | PR | What |
|---|----|------|
| 0 | #91 | build: patched deps via fetch script |
| 1 | #80 | hivemind unary wire codec |
| 2 | #81 | in-process rust-libp2p swarm |
| 3 | #82 | hivemind unary RPC |
| 4 | #83 | native hivemind DHT serving |
| 5 | #84 | p2pd control socket + pipe mode |
| 6 | #85 | run_node native path behind the flag |
| 7 | #86 | NAT traversal + libp2p 0.56 |

Rebuilt from the 73-commit `feat/native-p2p` branch into 57 commits. Tip is functionally identical to that branch.

---

## What this adds

Native hivemind unary RPC: a hand-rolled `NetworkBehaviour` + `ConnectionHandler` that speaks PR1's wire format directly on libp2p streams, exposed through `NetworkHandle` so a node can both call and serve hivemind handlers without the Go daemon.

## Why

Unary RPC is how hivemind does everything that matters — `DHTProtocol.rpc_{ping,store,find}`, and KwaaiNet's own `hello` / ollama-proxy / shard-proxy handlers. It is the first capability where the native stack has to be indistinguishable from p2pd on the wire, in both directions. The migration plan called for `request_response<HivemindUnaryCodec>`, but two of that behaviour's design constants are structurally wrong for hivemind, so this keeps its architecture (pending queues, handler preloading, dial-on-demand, worker futures) while fixing both. This is also the first PR where PR0's slash-less patch is exercised against a real Go peer end to end.

## What's in it

**`core/crates/kwaai-p2p/src/unary.rs` — the behaviour**

One request and one uvarint-framed `PersistentConnectionRequest` each way, then close. Two departures from `request_response`:

- **Per-request protocol.** `request_response` negotiates from one list fixed at construction and `send_request` cannot pick per request. A hivemind call *is* its protocol, so each outbound stream negotiates exactly the requested handler name — via `UnaryProtocol`, an `Arc<str>` that permits the slash-less names `StreamProtocol` refuses.
- **Dynamic inbound registration.** The advertised protocol set lives behind a shared `Arc<RwLock<…>>` read per `listen_protocol()` call, so a handler registered at runtime is negotiable on connections that already exist.

Call outcomes travel through the oneshot each request carries — dial failure, clean protocol refusal (`UnsupportedProtocol`, which the health probe depends on), timeout, remote error arm, wire failure — so no request-ID bookkeeping reaches the service loop. Inbound requests surface as `Event::InboundRequest` carrying the caller's **connection-derived** `PeerId` (`callUnary.peer` is untrusted, per PR1's finding) plus a responder oneshot; a dropped or timed-out responder becomes an error frame, never a hang.

**Service and handle integration** (`behaviour.rs`, `service.rs`, `handle.rs`)

- `KwaaiBehaviour` gains a `unary` field, built from `NetworkConfig`'s `request_timeout`. `max_concurrent_streams` keeps unary's own default, being a per-connection resource guard rather than anything config expresses.
- `Command::{CallUnary, AddUnaryHandler, RemoveUnaryHandler}`. `CallUnary` needs no pending map — `send_request` owns the oneshot and resolves it on every path.
- The service keeps a protocol → unbounded-sender dispatch map in lockstep with the behaviour's inbound protocol set. `InboundRequest` is routed by the *negotiated* protocol; a dead handler task deregisters the protocol so later calls get a clean refusal rather than a black hole.
- `NetworkHandle::{call_unary_handler, add_unary_handler, add_unary_handler_boxed, remove_unary_handler}`, named after their `P2PClient` counterparts. `add_unary_handler` spawns one dispatch task per protocol and one task per call, so a slow handler delays only its own caller. The `UnaryError` → `P2PError` mapping is documented on `call_unary_handler`.

**Three correctness fixes made during review of the above** — each worth reading, since they are the concurrency hazards that would otherwise surface only under production load:

1. **Outbound streams correlated by protocol, not position.** `requested_outbound` was a FIFO matched by position, on the assumption that `FullyNegotiatedOutbound` arrives in request order. It does not — each negotiation is an independent round trip — so two concurrent calls to *different* protocols on one connection could deliver one caller the other's response. This is exactly the deployment shape where `shard serve` and `storage serve` each serve a different protocol through one node.
2. **Then correlated by exact request id.** Protocol matching fixed the successes but left `DialUpgradeError` positional, so a refusal arriving before a success could still misattribute. Correlation now rides `OutboundOpenInfo` (a `u64` the swarm echoes back verbatim on *both* the success and failure events), which is exact on every path. Same commit: worker pools split into inbound vs outbound (both bounded by `max_concurrent_streams`) so an outbound burst cannot starve inbound serving; inbound overflow answers with the "node at capacity" error arm rather than resetting an already-negotiated stream; and dropping the handler resolves every queued request with a definite `Wire("connection closed")` instead of a silently dropped channel.
3. **Waking the throttle when a negotiation failure frees a slot.** The emission throttle counted `requested_outbound` in its gate, but nothing re-entered `poll` when `DialUpgradeError` shrank that map — worker completion wakes via `FuturesUnordered`, map mutation does not. With the cap saturated, a routine negotiation refusal freed the last slot silently and the next queued call hung forever. The handler now stores the poll waker and wakes it whenever a slot frees outside the worker pools. Refusal-frame writers also move to their own pool, since they previously counted against the same allowance that admits them.

## Risk

**No default runtime behaviour changes.** Nothing calls `call_unary_handler` or `add_unary_handler` outside tests at this commit — the node still runs on p2pd, and the `native_p2p` flag that selects this path does not exist until PR6. All changes are additive to `kwaai-p2p`; no existing module's behaviour is altered.

Worth looking at closely:

- `unary.rs`'s `ConnectionHandler::poll` — the waker discipline in fix (3) and the split worker pools in fix (2). These are the paths where a mistake shows up as a hang rather than an error, and the three fixes above are all in this one function's neighbourhood.
- The service's dispatch map staying in lockstep with the behaviour's protocol set; a divergence would surface as a black hole rather than a refusal.

## Test coverage

**In-process, `kwaai-p2p/tests/unary.rs`** — round trip via dial-on-demand, error arm, refusal-then-reuse of the connection, dropped responder, unreachable peer, 8 concurrent calls, late registration reaching an existing connection. Plus targeted regressions for each fix above: two concurrent calls on *different* protocols (fix 1 — the original test used one protocol and missed it), an outbound burst through a single-slot cap all completing, the at-capacity refusal arriving as a clean error arm while the occupied slot completes after release, and a queued call behind a refused one through a single-slot cap (fix 3).

**In-process, `kwaai-p2p/tests/service_unary.rs`** (9 tests) — echo round trip, dial-on-demand, remote error arm, unserved-protocol refusal, unreachable peer, removal and re-registration, per-call concurrency, post-shutdown behaviour.

**Tier 08 — `08_unary_swarm_interop.rs`** (3 tests): `kwaai_p2p::unary::Behaviour` in a real swarm against a real go-libp2p daemon — the first time the native stack negotiates TCP + noise + yamux + slash-less multistream-select against Go end to end. Swarm calls a daemon-served handler (proves PR0's patch dialer-side against Go's listener); daemon calls a swarm-served handler (listener-side, plus the responder frame end to end); an unserved protocol comes back as a clean `UnsupportedProtocol` refusal with the connection surviving for a follow-up call.

**Tier 09 — `09_service_unary_interop.rs`** (4 tests): raises the left-hand side to what production will run — a full `NetworkService` behind a `NetworkHandle`, exchanging unary calls with a real p2pd both ways. Over and above tier 08 this covers the handle's `UnaryError` → `P2PError` mapping, the service's inbound dispatch map, and the fact that identify/kad sharing the connection does not disturb unary negotiation against go-libp2p. Includes `remove_unary_handler` being visible to a foreign stack — the deregistration path PR5 depends on.

Tiers 08/09 are gated behind `KWAAI_INTEGRATION_TESTS=1` and require a real p2pd binary; daemons are owned by `TestNode` and killed by PID on drop.

## Stacked on

`native-p2p-pr2-swarm`

---

## Verification run for this PR

- `cargo build --workspace --all-targets` at this branch head: clean.
- `cargo test --workspace`: **697 passing, 0 failures.**
- Daemon run, `native_p2p: false` (the flag does not exist before PR6, so only the p2pd path is meaningful here): starts, connects to bootstraps, no panic, clean shutdown.

This PR is one of a stack rebuilt from the 73-commit `feat/native-p2p` branch. The stack tip is functionally identical to that branch: the only difference in the whole tree is comment text in `core/Cargo.toml`.

---

**Rebased onto `main` @ v0.5.5 (2026-08-06).** Upstream landed Capacity Lease admission control (#a0a4065), which touched files this stack moves or refactors. Two conflicts were resolved, both carrying upstream's change forward rather than dropping it:

- **#83** — upstream added `lease_v1` to `DHTServerInfo`, which this PR relocates to `announce.rs`. The field, its encoder entry and its doc comment moved with the type; upstream's own `to_msgpack_announces_lease_v1_true` test passes against the relocated struct.
- **#85** — upstream added the lease admission gate to the mux frame loop, which this PR extracts into `serve_mux_frames`. `lease_table` and `connection_id` are threaded through, and the native mux path registers the capacity-lease handler, so the native transport is gated identically to the p2pd one rather than bypassing it.

Per-branch verification after the rebase (all clean, 0 failures): 659 / 689 / 696 / 723 / 784 / 824 / 829 / 916 tests.

