### PR TITLE
feat(cli): run_node takes the native path behind native_p2p (native-p2p 6/7)

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3292,6 +3292,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tracing",
  "tracing-subscriber",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3109,6 +3109,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "tempfile",
  "tokio",

--- a/core/crates/kwaai-cli/Cargo.toml
+++ b/core/crates/kwaai-cli/Cargo.toml
@@ -34,6 +34,9 @@ sysinfo = { workspace = true }
 # Async
 tokio = { workspace = true }
 futures = { workspace = true }
+# `compat` bridges libp2p's `futures::io` raw streams onto tokio's traits, which
+# is what lets the native inference-mux path reuse the tokio-based frame loop.
+tokio-util = { version = "0.7", features = ["compat"] }
 
 # HTTP (IP detection, health check, update check)
 reqwest = { workspace = true }

--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -286,7 +286,7 @@ pub enum ConfigAction {
     ///
     /// Valid keys:
     ///   model, blocks, start_block, port, use_gpu, log_level,
-    ///   public_name, public_ip, announce_addr, no_relay,
+    ///   public_name, public_ip, announce_addr, no_relay, native_p2p,
     ///   vpk_enabled, vpk_mode, vpk_local_port,
     ///   auto_rebalance, rebalance_interval_secs, rebalance_min_redundancy
     ///

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -126,6 +126,23 @@ pub struct KwaaiNetConfig {
     #[serde(default = "default_force_private")]
     pub force_private: bool,
 
+    /// Run the node on the in-process rust-libp2p stack instead of spawning the
+    /// Go `p2pd` child process.
+    ///
+    /// The native path reuses every other setting on this struct — `port`,
+    /// `initial_peers`, `identity_key` (so the PeerId is identical either way)
+    /// and `KWAAINET_SOCKET` — and serves the same p2pd control socket, so
+    /// external clients (the GUI, `kwaainet p2p …`, `shard serve`) cannot tell
+    /// the two apart. What it does **not** do yet is NAT traversal: AutoNAT,
+    /// circuit relay, DCUtR and UPnP are still p2pd-only, so a node behind a NAT
+    /// is only reachable on the p2pd path. `no_relay`, `force_private` and
+    /// `trusted_relays` are therefore ignored while this is true.
+    ///
+    /// Defaults to false — the p2pd path stays the default until the NAT slice
+    /// lands and the cutover in Phase 5 flips it.
+    #[serde(default)]
+    pub native_p2p: bool,
+
     #[serde(default)]
     pub health_monitoring: HealthConfig,
 
@@ -633,6 +650,7 @@ impl Default for KwaaiNetConfig {
             initial_peers: default_peers(),
             trusted_relays: default_trusted_relays(),
             force_private: default_force_private(),
+            native_p2p: false,
             health_monitoring: HealthConfig::default(),
             model_dht_prefix: None,
             model_repository: None,
@@ -851,6 +869,7 @@ impl KwaaiNetConfig {
             }
             "announce_addr" => self.announce_addr = Some(value.to_string()),
             "no_relay" => self.no_relay = parse_bool(value)?,
+            "native_p2p" => self.native_p2p = parse_bool(value)?,
             "start_block" => {
                 self.start_block = value
                     .parse()

--- a/core/crates/kwaai-cli/src/inference_mux.rs
+++ b/core/crates/kwaai-cli/src/inference_mux.rs
@@ -228,16 +228,36 @@ async fn handle_mux_stream_server(
     connection_id: ConnectionId,
 ) {
     let (mut reader, writer) = stream.into_split();
-    let writer = Arc::new(Mutex::new(writer));
 
     // go-libp2p-daemon sends a gogo-protobuf StreamInfo message before piping data.
-    // Consume it before entering the mux frame loop.
+    // Consume it before entering the mux frame loop. Only the p2pd path has this
+    // prologue: it is the daemon describing the stream it is about to forward
+    // over a *separate* TCP connection. The native path receives the libp2p
+    // stream itself, so there is nothing in front of the first mux frame.
     if let Err(e) = read_p2pd_stream_info(&mut reader).await {
         warn!("inference-mux server: failed to read p2pd StreamInfo prologue: {e}");
         return;
     }
     debug!("inference-mux server: StreamInfo prologue consumed — entering mux frame loop");
 
+    serve_mux_frames(reader, writer, lease_table, connection_id).await;
+}
+
+/// The mux frame loop, over any split stream: one task per request, replies
+/// written back in completion order under a shared writer lock.
+///
+/// `lease_table` is the one process-wide table, so a native caller and a p2pd
+/// caller contend for the same Capacity Lease slots.
+async fn serve_mux_frames<R, W>(
+    mut reader: R,
+    writer: W,
+    lease_table: Arc<LeaseTable>,
+    connection_id: ConnectionId,
+) where
+    R: AsyncReadExt + Unpin + Send + 'static,
+    W: AsyncWriteExt + Unpin + Send + 'static,
+{
+    let writer = Arc::new(Mutex::new(writer));
     let ttl = Duration::from_secs(LEASE_TTL_SECS);
 
     loop {
@@ -313,10 +333,11 @@ async fn handle_mux_stream_server(
     }
 }
 
-/// Encode and write one `MuxFrame`, logging (not panicking) on failure —
-/// mirrors the original inline write-response logic, now shared across the
-/// several places the server writes a frame back.
-async fn write_mux_frame(writer: &Arc<Mutex<tokio::net::tcp::OwnedWriteHalf>>, frame: MuxFrame) {
+/// Encode and write one `MuxFrame`, logging (not panicking) on failure.
+async fn write_mux_frame<W>(writer: &Arc<Mutex<W>>, frame: MuxFrame)
+where
+    W: AsyncWriteExt + Unpin,
+{
     match rmp_serde::to_vec_named(&frame) {
         Ok(payload) => {
             let mut w = writer.lock().await;
@@ -326,6 +347,57 @@ async fn write_mux_frame(writer: &Arc<Mutex<tokio::net::tcp::OwnedWriteHalf>>, f
         }
         Err(e) => warn!("inference-mux server: encode frame: {e}"),
     }
+}
+
+/// Serve `MUX_PROTO` over a [`NetworkHandle`] instead of a p2pd stream handler.
+///
+/// The p2pd path ([`start_inference_mux_server`]) binds a local TCP listener and
+/// tells the daemon to forward inbound streams to it; the daemon writes a
+/// `StreamInfo` prologue and then pipes bytes. Natively there is no forwarding
+/// hop at all — [`kwaai_p2p::NetworkHandle::accept_streams`] hands us the
+/// negotiated libp2p stream — so there is no listener to bind, no prologue to
+/// consume, and one fewer place for backpressure to be lost.
+///
+/// Returns the accept-loop task. It ends when the network service shuts down and
+/// drops its sender.
+pub async fn start_native_inference_mux_server(
+    handle: &kwaai_p2p::NetworkHandle,
+    lease_table: Arc<LeaseTable>,
+) -> Result<JoinHandle<()>> {
+    let (mut inbound, refused) = handle
+        .accept_streams(vec![MUX_PROTO.to_string()])
+        .await
+        .context("register native inference-mux stream handler")?;
+    if !refused.is_empty() {
+        anyhow::bail!("inference-mux protocol already served by another handler");
+    }
+
+    info!("inference-mux: serving {MUX_PROTO} natively");
+
+    // Same per-connection id scheme as the p2pd path — scopes
+    // `release_connection()` on stream death. The two loops keep separate
+    // counters, which is fine: ids are only ever compared within one table
+    // entry's own connection, never across paths.
+    let next_connection_id = Arc::new(AtomicU64::new(1));
+
+    Ok(tokio::spawn(async move {
+        use tokio_util::compat::FuturesAsyncReadCompatExt;
+        while let Some(stream) = inbound.recv().await {
+            debug!(
+                "inference-mux server: accepted native stream from {}",
+                stream.peer
+            );
+            let (reader, writer) = tokio::io::split(stream.stream.compat());
+            let connection_id = next_connection_id.fetch_add(1, Ordering::Relaxed);
+            tokio::spawn(serve_mux_frames(
+                reader,
+                writer,
+                lease_table.clone(),
+                connection_id,
+            ));
+        }
+        debug!("inference-mux server: native accept loop ended");
+    }))
 }
 
 static OLLAMA_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -19,6 +19,7 @@ mod llama_local;
 mod map;
 mod monitor;
 mod node;
+mod node_native;
 mod ollama;
 mod ollama_proxy;
 mod p2p_cmd;

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -42,19 +42,9 @@ use crate::announce::{dht_id, DHTServerInfo, ModelInfo, VpkInfo};
 // ---------------------------------------------------------------------------
 
 pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
-    // Register SIGHUP handler BEFORE writing the PID file.  The shard
-    // auto-rebalance path sends SIGHUP to the daemon PID to trigger a
-    // re-announce.  If an old shard is still running when a new daemon starts,
-    // it reads the new PID immediately and may send SIGHUP during startup
-    // (before the event-loop handler at the bottom of this function is
-    // installed).  Without an early registration, the OS default fires —
-    // terminating the process.  Registering here queues the signals; they are
-    // consumed by the event-loop select! once startup finishes.
-    #[cfg(unix)]
-    let mut sighup = {
-        use tokio::signal::unix::{signal, SignalKind};
-        signal(SignalKind::hangup()).expect("SIGHUP handler")
-    };
+    // Register the SIGHUP handler BEFORE writing the PID file — see
+    // [`SigHup::register`] for why the ordering is load-bearing.
+    let mut sighup = SigHup::register();
 
     // PID tracking
     let daemon_mgr = DaemonManager::new();
@@ -148,6 +138,25 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     } else {
         config.initial_peers.clone()
     };
+
+    // The native stack has its own whole lifecycle — no child process to spawn,
+    // watch, restart or shut down — so it lives in `node_native`.
+    if config.native_p2p {
+        info!("native_p2p enabled — running without the Go p2p daemon");
+        let pending_update_version = crate::node_native::run_native_node(
+            config,
+            &bootstrap_peers,
+            &public_name,
+            trust_attestations,
+            &mut sighup,
+        )
+        .await?;
+
+        daemon_mgr.remove_pid();
+        respawn_after_update(pending_update_version);
+        info!("KwaaiNet node stopped");
+        return Ok(());
+    }
 
     // -----------------------------------------------------------------------
     // Step 1: Start p2pd
@@ -613,62 +622,9 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     let mut relay_keepalive = tokio::time::interval(Duration::from_secs(60));
     relay_keepalive.tick().await;
 
-    // Ollama health watcher: spawn a background task that polls
-    // http://localhost:<port>/api/tags every 15 s. Sends `true` on each recovery
-    // (down→up transition) so the main loop can re-announce immediately.
-    let (ollama_recovery_tx, mut ollama_recovery_rx) = tokio::sync::mpsc::channel::<()>(1);
-    {
-        let ollama_port = config.ollama_port;
-        let ollama_manage = config.ollama_manage;
-        tokio::spawn(async move {
-            let client = reqwest::Client::builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_default();
-            let url = format!("http://localhost:{}/api/tags", ollama_port);
-            let mut was_up = true; // assume up at start to avoid spurious recovery signal
-            let mut fail_count: u32 = 0;
-            loop {
-                tokio::time::sleep(Duration::from_secs(15)).await;
-                let ok = client
-                    .get(&url)
-                    .send()
-                    .await
-                    .map(|r| r.status().is_success())
-                    .unwrap_or(false);
-                if ok {
-                    if !was_up {
-                        info!(
-                            "✅ Ollama recovered on port {} — signalling re-announce",
-                            ollama_port
-                        );
-                        let _ = ollama_recovery_tx.try_send(());
-                    }
-                    was_up = true;
-                    fail_count = 0;
-                } else {
-                    fail_count += 1;
-                    if fail_count == 3 {
-                        warn!(
-                            "⚠️  Ollama unreachable on port {} (3 consecutive failures)",
-                            ollama_port
-                        );
-                        if ollama_manage {
-                            info!("ollama_manage=true — attempting to start Ollama…");
-                            let _ = tokio::process::Command::new("ollama").arg("serve").spawn();
-                        }
-                    } else if fail_count > 3 && fail_count.is_multiple_of(12) {
-                        // Log every ~3 min while still down
-                        warn!(
-                            "⚠️  Ollama still unreachable on port {} ({}× checks)",
-                            ollama_port, fail_count
-                        );
-                    }
-                    was_up = false;
-                }
-            }
-        });
-    }
+    // Ollama health watcher: polls http://localhost:<port>/api/tags every 15 s
+    // and signals on each recovery so the main loop can re-announce immediately.
+    let mut ollama_recovery_rx = spawn_ollama_watcher(&config);
 
     // Set when maybe_auto_update() installs a new binary — the actual respawn
     // is deferred until after this process's own cleanup completes (see the
@@ -698,12 +654,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             }
 
             // SIGHUP (Unix) / never (Windows) — re-read config and re-announce.
-            // Uses #[cfg] inside the arm expression to avoid a conditional arm,
-            // which is unsupported by tokio::select!.
-            _ = async {
-                #[cfg(unix)] { sighup.recv().await; }
-                #[cfg(not(unix))] { std::future::pending::<Option<()>>().await; }
-            } => {
+            _ = sighup.recv() => {
                 info!("SIGHUP received — re-reading config and re-announcing");
                 if let Ok(fresh) = KwaaiNetConfig::load_or_create() {
                     if fresh.start_block != config.start_block || fresh.blocks != config.blocks {
@@ -974,58 +925,59 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     let _ = daemon.shutdown().await;
     daemon_mgr.remove_pid();
 
-    // Respawn AFTER this process's own cleanup has fully completed — the PID
-    // file is gone and p2pd is down. Previously the new `start --daemon`
-    // process was spawned immediately inside maybe_auto_update(), before any
-    // of the above ran. That raced this process's PID-file removal against
-    // the new process's own "is another instance already running?" check
-    // (which reads the PID file before doing anything else): if the new
-    // process's network-map fetch + is_running() check completed faster than
-    // this process's unannounce+p2pd-shutdown+remove_pid sequence, the new
-    // process would see the still-present PID file, conclude a daemon was
-    // already running, and exit(1) immediately — leaving no daemon running
-    // at all. Spawning only here, after remove_pid() has synchronously
-    // deleted the file, closes that window entirely.
-    if let Some(version) = pending_update_version {
-        // Resolve via PATH, not current_exe(): install_update() replaces the
-        // binary in place (unlink+rename on Unix, ETXTBSY-safe while this
-        // process still has it open; a rename over the running EXE on
-        // Windows, safe because the OS loader opens EXEs with
-        // FILE_SHARE_DELETE). Either way, current_exe() can point at a stale
-        // path after the swap (Linux's /proc/self/exe keeps resolving to the
-        // old, now-deleted inode) — so spawning via current_exe() here could
-        // silently relaunch the old binary, making the "respawned with new
-        // binary" log line a lie. PATH lookup re-resolves the path fresh,
-        // picking up the new file.
-        #[cfg(windows)]
-        let bin_name = "kwaainet.exe";
-        #[cfg(not(windows))]
-        let bin_name = "kwaainet";
-
-        let new_bin = crate::setup::find_in_path(bin_name)
-            .or_else(|| std::env::current_exe().ok())
-            .unwrap_or_else(|| std::path::PathBuf::from(bin_name));
-        match std::process::Command::new(&new_bin)
-            .args(["start", "--daemon"])
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-        {
-            Ok(_) => info!(
-                "Auto-update: v{} installed — respawned daemon with new binary.",
-                version
-            ),
-            Err(e) => warn!(
-                "Auto-update: v{} installed but respawn failed ({e}). \
-                 Run `kwaainet start --daemon` manually.",
-                version
-            ),
-        }
-    }
+    respawn_after_update(pending_update_version);
 
     info!("KwaaiNet node stopped");
     Ok(())
+}
+
+/// Relaunch `kwaainet start --daemon` after an auto-update installed a new
+/// binary, or do nothing when none was.
+///
+/// **Call only after this process's own cleanup has fully completed** — the PID
+/// file gone, the transport down. The new process reads the PID file before
+/// doing anything else, so spawning any earlier makes it see a live daemon and
+/// exit(1), leaving no daemon running at all.
+fn respawn_after_update(pending_update_version: Option<String>) {
+    let Some(version) = pending_update_version else {
+        return;
+    };
+
+    // Resolve via PATH, not current_exe(): install_update() replaces the
+    // binary in place (unlink+rename on Unix, ETXTBSY-safe while this
+    // process still has it open; a rename over the running EXE on
+    // Windows, safe because the OS loader opens EXEs with
+    // FILE_SHARE_DELETE). Either way, current_exe() can point at a stale
+    // path after the swap (Linux's /proc/self/exe keeps resolving to the
+    // old, now-deleted inode) — so spawning via current_exe() here could
+    // silently relaunch the old binary, making the "respawned with new
+    // binary" log line a lie. PATH lookup re-resolves the path fresh,
+    // picking up the new file.
+    #[cfg(windows)]
+    let bin_name = "kwaainet.exe";
+    #[cfg(not(windows))]
+    let bin_name = "kwaainet";
+
+    let new_bin = crate::setup::find_in_path(bin_name)
+        .or_else(|| std::env::current_exe().ok())
+        .unwrap_or_else(|| std::path::PathBuf::from(bin_name));
+    match std::process::Command::new(&new_bin)
+        .args(["start", "--daemon"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(_) => info!(
+            "Auto-update: v{} installed — respawned daemon with new binary.",
+            version
+        ),
+        Err(e) => warn!(
+            "Auto-update: v{} installed but respawn failed ({e}). \
+             Run `kwaainet start --daemon` manually.",
+            version
+        ),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2038,7 +1990,7 @@ async fn read_rpc_message(tcp: &mut tokio::net::TcpStream) -> Result<(Vec<u8>, b
 /// connectivity in the reputation store. Called every 120 s from the event loop.
 /// Return `base ± spread` seconds using a fast LCG over the current nanosecond
 /// timestamp. No `rand` crate needed. Range: `[base - spread, base + spread]`.
-fn jitter_secs(base: u64, spread: u64) -> u64 {
+pub(crate) fn jitter_secs(base: u64, spread: u64) -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     let ns = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -2069,7 +2021,7 @@ fn jitter_secs(base: u64, spread: u64) -> u64 {
 /// instance already running?" check, and could leave no daemon running at
 /// all if the new process's startup won that race. See the respawn site at
 /// the bottom of `run_node` for the fix and full explanation.
-async fn maybe_auto_update() -> Option<String> {
+pub(crate) async fn maybe_auto_update() -> Option<String> {
     // Developer escape hatch: a long-running local debug daemon shouldn't
     // get silently replaced by the upstream release binary (which won't
     // contain whatever in-flight feature work is being tested). Setting
@@ -2112,7 +2064,7 @@ async fn maybe_auto_update() -> Option<String> {
 // Signal handling
 // ---------------------------------------------------------------------------
 
-async fn shutdown_signal() {
+pub(crate) async fn shutdown_signal() {
     #[cfg(unix)]
     {
         let mut sigterm =
@@ -2159,6 +2111,121 @@ fn find_free_port(preferred: u16) -> Option<u16> {
 #[allow(dead_code)]
 fn port_is_free(port: u16) -> bool {
     std::net::TcpListener::bind(("0.0.0.0", port)).is_ok()
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle plumbing — shared by the p2pd and native paths
+// ---------------------------------------------------------------------------
+
+/// A SIGHUP source that is a no-op on platforms without signals.
+///
+/// `tokio::select!` cannot take a `#[cfg]`-conditional arm, so the conditional
+/// lives here instead.
+///
+/// The handler must be **registered before the PID file is written**. The shard
+/// auto-rebalance path sends SIGHUP to the daemon PID to trigger a re-announce,
+/// and an old shard still running when a new daemon starts reads the new PID
+/// immediately — it can fire during startup, before the event loop exists.
+/// Without an early registration the OS default fires and terminates the
+/// process. Registering early queues the signal instead; the loop consumes it
+/// once startup finishes.
+pub(crate) struct SigHup {
+    #[cfg(unix)]
+    inner: tokio::signal::unix::Signal,
+}
+
+impl SigHup {
+    /// Register the handler. Call before writing the PID file.
+    pub(crate) fn register() -> Self {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+            Self {
+                inner: signal(SignalKind::hangup()).expect("SIGHUP handler"),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            Self {}
+        }
+    }
+
+    /// Resolve on the next SIGHUP; never resolves on platforms without one.
+    pub(crate) async fn recv(&mut self) {
+        #[cfg(unix)]
+        {
+            self.inner.recv().await;
+        }
+        #[cfg(not(unix))]
+        {
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+/// Watch the local Ollama and signal on every down→up transition.
+///
+/// Starts out assuming Ollama is up so a node without Ollama does not fire a
+/// spurious recovery on its first tick.
+///
+/// The channel has capacity 1 and the send is a `try_send`: a recovery that
+/// arrives while one is already queued is dropped rather than backing up, since
+/// the queued one will trigger the same re-announce.
+pub(crate) fn spawn_ollama_watcher(config: &KwaaiNetConfig) -> tokio::sync::mpsc::Receiver<()> {
+    let (tx, rx) = tokio::sync::mpsc::channel::<()>(1);
+    let ollama_port = config.ollama_port;
+    let ollama_manage = config.ollama_manage;
+
+    tokio::spawn(async move {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap_or_default();
+        let url = format!("http://localhost:{}/api/tags", ollama_port);
+        let mut was_up = true; // assume up at start to avoid a spurious recovery signal
+        let mut fail_count: u32 = 0;
+        loop {
+            tokio::time::sleep(Duration::from_secs(15)).await;
+            let ok = client
+                .get(&url)
+                .send()
+                .await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false);
+            if ok {
+                if !was_up {
+                    info!(
+                        "✅ Ollama recovered on port {} — signalling re-announce",
+                        ollama_port
+                    );
+                    let _ = tx.try_send(());
+                }
+                was_up = true;
+                fail_count = 0;
+            } else {
+                fail_count += 1;
+                if fail_count == 3 {
+                    warn!(
+                        "⚠️  Ollama unreachable on port {} (3 consecutive failures)",
+                        ollama_port
+                    );
+                    if ollama_manage {
+                        info!("ollama_manage=true — attempting to start Ollama…");
+                        let _ = tokio::process::Command::new("ollama").arg("serve").spawn();
+                    }
+                } else if fail_count > 3 && fail_count.is_multiple_of(12) {
+                    // Log every ~3 min while still down
+                    warn!(
+                        "⚠️  Ollama still unreachable on port {} ({}× checks)",
+                        ollama_port, fail_count
+                    );
+                }
+                was_up = false;
+            }
+        }
+    });
+
+    rx
 }
 
 // ---------------------------------------------------------------------------

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -453,108 +453,20 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
 
     // Measure network bandwidth once at startup (1 MiB Cloudflare probe).
     // Stored so re-announcements can recompute effective_tps without re-probing.
-    let dl_bps: f64 = if crate::throughput::load(&config.model).is_some() {
-        info!("  Measuring network bandwidth (1 MiB probe)...");
-        let bps = crate::throughput::measure_download_bps().await;
-        if bps > 0.0 {
-            info!("  Network:  {:.1} Mbps download", bps / 1_000_000.0);
-        } else {
-            info!("  Network:  measurement failed — using compute limit only");
-        }
-        bps
-    } else {
-        0.0
-    };
-
-    let throughput = compute_effective_tps(&config.model, dl_bps, using_relay);
-    if let Some(ref entry) = crate::throughput::load(&config.model) {
-        info!(
-            "  Compute:  {:.1} tok/s (measured, hidden_dim={})",
-            entry.compute_tps, entry.hidden_size
-        );
-        info!(
-            "  Effective: {:.1} tok/s  connection={} (min({:.1}, {:.1}×{}))",
-            throughput,
-            if using_relay { "relay" } else { "direct" },
-            entry.compute_tps,
-            if dl_bps > 0.0 {
-                dl_bps / (entry.hidden_size as f64 * 16.0)
-            } else {
-                f64::INFINITY
-            },
-            if using_relay { "0.2" } else { "1.0" },
-        );
-    } else {
-        info!(
-            "  Throughput: {:.1} tok/s (default — run `kwaainet benchmark` to measure)",
-            throughput
-        );
-    }
+    let dl_bps = measure_download_bps_for(&config.model).await;
+    let throughput = report_effective_tps(&config.model, dl_bps, using_relay);
 
     // Use the canonical DHT prefix from the map (set during startup model selection).
     // Falls back to a computed prefix if the map wasn't consulted (e.g. --model override).
     let prefix = config.effective_dht_prefix();
-    let repository = config.model_repository.clone().unwrap_or_else(|| {
-        if config.model.contains('/') {
-            format!("https://huggingface.co/{}", config.model)
-        } else {
-            format!("https://huggingface.co/meta-llama/{}", config.model)
-        }
-    });
+    let repository = effective_repository(config);
 
     info!("  DHT prefix:  {}", prefix);
     info!("  Repository:  {}", repository);
     info!("  Using relay: {}", using_relay);
 
     // Check local VPK health when integration is enabled.
-    // Retries up to 5 times with 1 s gaps to avoid a race with the storage
-    // child process (spawned by `kwaainet start --daemon` just before us).
-    let vpk_info = if config.vpk_enabled {
-        let port = config.vpk_local_port.unwrap_or(7432);
-        info!("VPK enabled — checking local service on port {}", port);
-        let mut health_result = None;
-        for attempt in 0..5u32 {
-            if let Some(h) = check_vpk_health(port).await {
-                health_result = Some(h);
-                break;
-            }
-            if attempt < 4 {
-                info!("VPK not ready yet, retrying in 1 s… ({}/5)", attempt + 1);
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            }
-        }
-        match health_result {
-            Some(health) => {
-                let mode = config
-                    .vpk_mode
-                    .clone()
-                    .unwrap_or_else(|| "both".to_string());
-                let capacity_gb = health["capacity_gb_available"].as_f64().unwrap_or(0.0);
-                let tenant_count = health["tenant_count"].as_u64().unwrap_or(0) as u32;
-                let vpk_version = health["version"].as_str().unwrap_or("unknown").to_string();
-                info!(
-                    "VPK healthy: mode={} tenants={} capacity={:.1}GB v={}",
-                    mode, tenant_count, capacity_gb, vpk_version
-                );
-                Some(VpkInfo {
-                    mode,
-                    capacity_gb,
-                    tenant_count,
-                    vpk_version,
-                    public_name: public_name.clone(),
-                })
-            }
-            None => {
-                warn!(
-                    "VPK health check failed on port {} after 5 attempts — skipping DHT advertisement",
-                    port
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let vpk_info = initial_vpk_info(config, &public_name).await;
 
     // Always announce the configured block range so the node appears on the map.
     let announce_start = config.start_block as i32;
@@ -907,41 +819,11 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                 }
 
                 // Refresh throughput from cache.
-                let fresh_tps = compute_effective_tps(&config.model, dl_bps, using_relay);
-                if (fresh_tps - server_info.throughput).abs() > 0.05 {
-                    info!(
-                        "Throughput updated: {:.1} → {:.1} tok/s",
-                        server_info.throughput, fresh_tps
-                    );
-                    server_info.throughput = fresh_tps;
-                }
+                refresh_throughput(&mut server_info, &config.model, dl_bps, using_relay);
 
                 // Re-check VPK health so that storage serve started after the
                 // daemon comes online without requiring a full daemon restart.
-                if config.vpk_enabled {
-                    let port = config.vpk_local_port.unwrap_or(7432);
-                    let fresh_vpk = match check_vpk_health(port).await {
-                        Some(health) => {
-                            let mode = config.vpk_mode.clone().unwrap_or_else(|| "both".to_string());
-                            Some(VpkInfo {
-                                mode,
-                                capacity_gb: health["capacity_gb_available"].as_f64().unwrap_or(0.0),
-                                tenant_count: health["tenant_count"].as_u64().unwrap_or(0) as u32,
-                                vpk_version: health["version"].as_str().unwrap_or("unknown").to_string(),
-                                public_name: public_name.clone(),
-                            })
-                        }
-                        None => None,
-                    };
-                    if fresh_vpk.is_some() != server_info.vpk_info.is_some() {
-                        info!(
-                            "VPK state changed: {} → {}",
-                            if server_info.vpk_info.is_some() { "enabled" } else { "disabled" },
-                            if fresh_vpk.is_some() { "enabled" } else { "disabled" },
-                        );
-                    }
-                    server_info.vpk_info = fresh_vpk;
-                }
+                refresh_vpk_info(&mut server_info, &config, &public_name).await;
 
                 // Auto-update — installs new binary when available (pre-v1.0).
                 // If installed, break the event loop so the daemon exits cleanly
@@ -2279,6 +2161,174 @@ fn port_is_free(port: u16) -> bool {
     std::net::TcpListener::bind(("0.0.0.0", port)).is_ok()
 }
 
+// ---------------------------------------------------------------------------
+// Announce inputs — shared by the p2pd and native paths
+// ---------------------------------------------------------------------------
+
+/// Measure download bandwidth once at startup, for the Petals throughput
+/// formula. Returns 0.0 when no compute benchmark exists to combine it with —
+/// there is nothing to cap, so the probe would only cost startup latency.
+pub(crate) async fn measure_download_bps_for(model: &str) -> f64 {
+    if crate::throughput::load(model).is_none() {
+        return 0.0;
+    }
+    info!("  Measuring network bandwidth (1 MiB probe)...");
+    let bps = crate::throughput::measure_download_bps().await;
+    if bps > 0.0 {
+        info!("  Network:  {:.1} Mbps download", bps / 1_000_000.0);
+    } else {
+        info!("  Network:  measurement failed — using compute limit only");
+    }
+    bps
+}
+
+/// [`compute_effective_tps`] plus the startup log lines that explain the number.
+pub(crate) fn report_effective_tps(model: &str, dl_bps: f64, using_relay: bool) -> f64 {
+    let throughput = compute_effective_tps(model, dl_bps, using_relay);
+    if let Some(ref entry) = crate::throughput::load(model) {
+        info!(
+            "  Compute:  {:.1} tok/s (measured, hidden_dim={})",
+            entry.compute_tps, entry.hidden_size
+        );
+        info!(
+            "  Effective: {:.1} tok/s  connection={} (min({:.1}, {:.1}×{}))",
+            throughput,
+            if using_relay { "relay" } else { "direct" },
+            entry.compute_tps,
+            if dl_bps > 0.0 {
+                dl_bps / (entry.hidden_size as f64 * 16.0)
+            } else {
+                f64::INFINITY
+            },
+            if using_relay { "0.2" } else { "1.0" },
+        );
+    } else {
+        info!(
+            "  Throughput: {:.1} tok/s (default — run `kwaainet benchmark` to measure)",
+            throughput
+        );
+    }
+    throughput
+}
+
+/// The HuggingFace repository URL for the `_petals.models` registry entry.
+pub(crate) fn effective_repository(config: &KwaaiNetConfig) -> String {
+    config.model_repository.clone().unwrap_or_else(|| {
+        if config.model.contains('/') {
+            format!("https://huggingface.co/{}", config.model)
+        } else {
+            format!("https://huggingface.co/meta-llama/{}", config.model)
+        }
+    })
+}
+
+/// Poll the local VPK health endpoint at startup.
+///
+/// Retries up to 5 times with 1 s gaps to avoid a race with the storage child
+/// process, which `kwaainet start --daemon` spawns just before this one.
+pub(crate) async fn initial_vpk_info(
+    config: &KwaaiNetConfig,
+    public_name: &str,
+) -> Option<VpkInfo> {
+    if !config.vpk_enabled {
+        return None;
+    }
+    let port = config.vpk_local_port.unwrap_or(7432);
+    info!("VPK enabled — checking local service on port {}", port);
+
+    let mut health_result = None;
+    for attempt in 0..5u32 {
+        if let Some(h) = check_vpk_health(port).await {
+            health_result = Some(h);
+            break;
+        }
+        if attempt < 4 {
+            info!("VPK not ready yet, retrying in 1 s… ({}/5)", attempt + 1);
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    match health_result {
+        Some(health) => {
+            let info = vpk_info_from_health(&health, config, public_name);
+            info!(
+                "VPK healthy: mode={} tenants={} capacity={:.1}GB v={}",
+                info.mode, info.tenant_count, info.capacity_gb, info.vpk_version
+            );
+            Some(info)
+        }
+        None => {
+            warn!(
+                "VPK health check failed on port {} after 5 attempts — skipping DHT advertisement",
+                port
+            );
+            None
+        }
+    }
+}
+
+/// Decode one `/api/health` body into the announced [`VpkInfo`].
+fn vpk_info_from_health(
+    health: &serde_json::Value,
+    config: &KwaaiNetConfig,
+    public_name: &str,
+) -> VpkInfo {
+    VpkInfo {
+        mode: config
+            .vpk_mode
+            .clone()
+            .unwrap_or_else(|| "both".to_string()),
+        capacity_gb: health["capacity_gb_available"].as_f64().unwrap_or(0.0),
+        tenant_count: health["tenant_count"].as_u64().unwrap_or(0) as u32,
+        vpk_version: health["version"].as_str().unwrap_or("unknown").to_string(),
+        public_name: public_name.to_string(),
+    }
+}
+
+/// Recompute throughput from the benchmark cache before a re-announce, logging
+/// only a material change.
+pub(crate) fn refresh_throughput(
+    server_info: &mut DHTServerInfo,
+    model: &str,
+    dl_bps: f64,
+    using_relay: bool,
+) {
+    let fresh_tps = compute_effective_tps(model, dl_bps, using_relay);
+    if (fresh_tps - server_info.throughput).abs() > 0.05 {
+        info!(
+            "Throughput updated: {:.1} → {:.1} tok/s",
+            server_info.throughput, fresh_tps
+        );
+        server_info.throughput = fresh_tps;
+    }
+}
+
+/// Re-poll VPK health before a re-announce, so a `storage serve` started after
+/// the node came up is advertised without a restart.
+pub(crate) async fn refresh_vpk_info(
+    server_info: &mut DHTServerInfo,
+    config: &KwaaiNetConfig,
+    public_name: &str,
+) {
+    if !config.vpk_enabled {
+        return;
+    }
+    let port = config.vpk_local_port.unwrap_or(7432);
+    let fresh_vpk = check_vpk_health(port)
+        .await
+        .map(|health| vpk_info_from_health(&health, config, public_name));
+
+    if fresh_vpk.is_some() != server_info.vpk_info.is_some() {
+        let label = |present: bool| if present { "enabled" } else { "disabled" };
+        info!(
+            "VPK state changed: {} → {}",
+            label(server_info.vpk_info.is_some()),
+            label(fresh_vpk.is_some()),
+        );
+    }
+    server_info.vpk_info = fresh_vpk;
+}
+
 /// Compute effective throughput from the cached benchmark result.
 ///
 /// Re-reads `~/.kwaainet/throughput_cache.json` on every call so that a
@@ -2287,7 +2337,7 @@ fn port_is_free(port: u16) -> bool {
 ///
 /// `dl_bps` is the download bandwidth measured at startup and reused here
 /// to avoid a slow network probe on every re-announce.
-fn compute_effective_tps(model: &str, dl_bps: f64, using_relay: bool) -> f64 {
+pub(crate) fn compute_effective_tps(model: &str, dl_bps: f64, using_relay: bool) -> f64 {
     match crate::throughput::load(model) {
         Some(entry) => crate::throughput::effective_tps(&entry, dl_bps, using_relay),
         None => 10.0, // fallback until benchmark is run

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -1,0 +1,355 @@
+//! The native (in-process rust-libp2p) node runner.
+//!
+//! Selected by `native_p2p = true` in the node config. Assembles the pieces
+//! Phases 1–3 built into the same node `run_node` produces with the Go daemon:
+//!
+//! ```text
+//!                       ┌──────────────── kwaainet run-node ────────────────┐
+//!   external clients ──▶│ ControlServer ──┐                                 │
+//!   (GUI, shard serve,  │                 ├──▶ NetworkHandle ──▶ swarm ──── │──▶ libp2p
+//!    p2p subcommands)   │ node handlers ──┘         ▲                       │
+//!                       │ (hello, proxies, mux)     │                       │
+//!                       │ DHT service ──────────────┘                       │
+//!                       └───────────────────────────────────────────────────┘
+//! ```
+//!
+//! # What differs from the p2pd path
+//!
+//! * **No child process**, so no watchdog, no crash restart, no
+//!   `restart_p2pd*`, and no `find_p2pd_binary` — a native node runs with no
+//!   `p2pd` binary installed at all.
+//! * **The RPC listener is gone.** The p2pd path binds a loopback TCP listener
+//!   and registers it as a *stream handler* for the three `DHTProtocol.rpc_*`
+//!   names, so p2pd forwards each inbound DHT request over TCP with a
+//!   `StreamInfo` prologue and a `PersistentConnectionRequest` wrapper around
+//!   the payload. Natively, `spawn_dht_service` registers them as unary
+//!   handlers directly on the swarm — same protocol IDs, same `DHTStorage`,
+//!   two fewer hops and no wrapper to unwrap.
+//! * **No IDENTIFY-driven restart cycle.** The p2pd path re-spawns the daemon
+//!   to change its announce addresses. Address discovery and re-announce on
+//!   change belong to the NAT slice; until then a native node announces what
+//!   `announce_addr`/`public_ip` say, or nothing.
+//!
+//! # What is deliberately identical
+//!
+//! The **peer ID** (same key file, same libp2p protobuf encoding), the
+//! **control socket** (`ControlServer` on the path `KWAAINET_SOCKET` or
+//! `DEFAULT_SOCKET_NAME` names, which every external client already dials), the
+//! **announce records** (`announce.rs`, byte-for-byte), the **re-announce
+//! cadence** (300 s ± 30 s jitter, 360 s TTL), the **tombstone on shutdown**,
+//! and the **protocol IDs** of every handler.
+//!
+//! # Not yet here — the NAT slice
+//!
+//! AutoNAT, circuit relay, DCUtR and UPnP are p2pd-only. A native node is
+//! therefore reachable only if it is directly dialable: it can always *call*
+//! out (so it announces, stores and finds fine from behind a NAT), but inbound
+//! connections need a public address. `no_relay`, `force_private` and
+//! `trusted_relays` have no effect on this path.
+
+use anyhow::{Context, Result};
+use kwaai_hivemind_dht::DHTStorage;
+use kwaai_p2p::{NetworkConfig, NetworkHandle, NetworkService};
+use kwaai_p2p_daemon::ControlServer;
+use libp2p::PeerId;
+use std::time::Duration;
+use tracing::{info, warn};
+
+use crate::announce::{
+    build_announce_records, build_unannounce_records, send_records_via_handle, AnnounceContext,
+    DHTServerInfo,
+};
+use crate::config::KwaaiNetConfig;
+
+/// Per-request budget on outbound unary calls.
+///
+/// Matches the `tokio::time::timeout(30s, …)` the p2pd path wraps every
+/// `call_unary_handler` in. The native handle enforces it itself
+/// (`NetworkConfig::request_timeout`), so `send_records_via_handle` needs no
+/// timeout of its own.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Everything the native path starts, kept together so shutdown is one call and
+/// nothing can be forgotten.
+///
+/// Field order matters on drop only for the control socket, which is removed by
+/// `ControlServer`'s own `Drop`; the rest are tasks that end when the service
+/// drops their channels.
+pub struct NativeNode {
+    /// The swarm handle — the outbound half of everything.
+    pub handle: NetworkHandle,
+    /// This node's peer ID, identical to what the p2pd path would report.
+    pub peer_id: PeerId,
+    /// The DHT records this node serves to other peers.
+    pub storage: DHTStorage,
+    /// Background tasks: swarm loop, DHT maintenance, control socket, mux.
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl NativeNode {
+    /// Build the libp2p identity, start the swarm, serve the DHT, bind the
+    /// control socket, and register this node's own protocol handlers.
+    ///
+    /// Does **not** announce — the caller owns announce timing because it needs
+    /// throughput measurement, VPK health and block range first.
+    ///
+    /// # Identity
+    ///
+    /// The keypair comes from the same file the p2pd path passes to `-id`
+    /// (`config.identity_key`, else `~/.kwaainet/identity.key`) through the same
+    /// libp2p protobuf encoding, so the peer ID is identical on both paths. A
+    /// missing file is generated exactly as `NodeIdentity::load_or_create`
+    /// would; an explicitly configured path is *not* generated, so a typo fails
+    /// loudly instead of silently minting a new identity.
+    pub async fn start(config: &KwaaiNetConfig, bootstrap_peers: &[String]) -> Result<Self> {
+        let key_path = config
+            .identity_key
+            .clone()
+            .unwrap_or_else(crate::identity::NodeIdentity::key_file_path);
+        let keypair = if config.identity_key.is_some() {
+            kwaai_p2p::identity::load_keypair(&key_path)
+                .with_context(|| format!("loading node identity from {}", key_path.display()))?
+        } else {
+            kwaai_p2p::identity::load_or_generate(&key_path).context("loading node identity")?
+        };
+        let peer_id = keypair.public().to_peer_id();
+
+        // The same listen address the p2pd path passes as `-hostAddrs`.
+        let net_config = NetworkConfig {
+            listen_addrs: vec![format!("/ip4/0.0.0.0/tcp/{}", config.port)],
+            bootstrap_peers: bootstrap_peers.to_vec(),
+            request_timeout: REQUEST_TIMEOUT,
+            port: config.port,
+            initial_peers: bootstrap_peers.to_vec(),
+            // p2pd runs with `-b` (Kademlia bootstrap) on every node, which is
+            // what makes a node answer DHT queries rather than only issuing
+            // them. `dht_server` is the native equivalent.
+            dht_server: true,
+            ..NetworkConfig::default()
+        };
+
+        let (handle, swarm_task) =
+            NetworkService::spawn(net_config, keypair).context("starting the libp2p swarm")?;
+        info!("Peer ID: {}", peer_id.to_base58());
+
+        let mut tasks = vec![swarm_task];
+
+        // ── DHT serving ────────────────────────────────────────────────────
+        // Bootstrap-grade: this node answers rpc_store/rpc_find/rpc_ping for
+        // other peers, which is what p2pd's `-b` DHT serving provided.
+        let storage = DHTStorage::new(peer_id);
+        tasks.push(
+            kwaai_p2p::spawn_dht_service(handle.clone(), storage.clone())
+                .await
+                .context("starting the native DHT service")?,
+        );
+        info!("Hivemind DHT service registered (rpc_ping/rpc_store/rpc_find)");
+
+        // ── Bootstrap ──────────────────────────────────────────────────────
+        // Dials the configured peers and seeds Kademlia. Non-fatal: a node with
+        // no reachable bootstrap still serves its own DHT and control socket,
+        // and the announce loop retries every 300 s.
+        if bootstrap_peers.is_empty() {
+            warn!("No bootstrap peers configured — this node will not join the network");
+        } else {
+            let addrs = bootstrap_peers
+                .iter()
+                .filter_map(|a| match a.parse() {
+                    Ok(ma) => Some(ma),
+                    Err(e) => {
+                        warn!("Skipping unparseable bootstrap address {a}: {e}");
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            match handle.bootstrap(addrs).await {
+                Ok(()) => info!("Bootstrapped to {} peer(s)", bootstrap_peers.len()),
+                Err(e) => warn!("Bootstrap failed: {e} — will retry via the announce loop"),
+            }
+        }
+
+        // ── Node protocol handlers ─────────────────────────────────────────
+        // One Capacity Lease table per node process, exactly as the p2pd path
+        // builds in `node.rs` — shared by the ollama-proxy handler, the
+        // capacity-lease handler and the mux server, so all three contend for
+        // the same Ollama slots rather than each holding its own semaphore.
+        let lease_max_concurrent = std::env::var("OLLAMA_NUM_PARALLEL")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(crate::capacity_lease::DEFAULT_MAX_CONCURRENT);
+        let lease_table =
+            crate::capacity_lease::LeaseTable::new(config.model.clone(), lease_max_concurrent);
+        let _lease_sweep_handle =
+            lease_table.spawn_periodic_sweep(std::time::Duration::from_secs(5));
+
+        register_node_handlers(&handle, lease_table.clone()).await;
+        match crate::inference_mux::start_native_inference_mux_server(&handle, lease_table.clone())
+            .await
+        {
+            Ok(task) => tasks.push(task),
+            Err(e) => warn!("inference-mux server registration failed: {e:#}"),
+        }
+
+        // ── Control socket ─────────────────────────────────────────────────
+        // Last, so external clients never observe a node whose handlers are
+        // only half-registered. Bound at the same address p2pd would have used,
+        // so the GUI, `kwaainet p2p …`, `shard serve` and the map crawler are
+        // unchanged.
+        let socket_addr = control_socket_addr();
+        let server = ControlServer::bind(&socket_addr, handle.clone())
+            .await
+            .with_context(|| format!("binding the control socket at {socket_addr}"))?;
+        info!("Control socket listening at {socket_addr}");
+        tasks.push(tokio::spawn(server.run()));
+
+        Ok(Self {
+            handle,
+            peer_id,
+            storage,
+            tasks,
+        })
+    }
+
+    /// Push one announcement round to every bootstrap peer, and into our own
+    /// storage so we serve what we publish.
+    ///
+    /// Returns the per-bootstrap timings `node.rs` feeds to the reputation
+    /// store — the announce doubles as the reputation probe on both paths.
+    pub async fn announce(
+        &self,
+        ctx: &AnnounceContext<'_>,
+        server_info: &DHTServerInfo,
+        bootstrap_peers: &[String],
+    ) -> Result<Vec<crate::announce::StoreTiming>> {
+        let records = build_announce_records(ctx, server_info)?;
+        for record in &records {
+            self.storage.handle_store(record.clone());
+        }
+        let (ok, timings) = send_records_via_handle(&self.handle, bootstrap_peers, &records).await;
+        if ok {
+            info!(
+                "✅ Announced {} blocks",
+                server_info.end_block - server_info.start_block
+            );
+        } else {
+            warn!("❌ Announcement failed — node will not appear on map");
+        }
+        Ok(timings)
+    }
+
+    /// Write the `state = -1` tombstone so the map drops this node immediately
+    /// rather than waiting out the 360 s TTL.
+    pub async fn unannounce(
+        &self,
+        ctx: &AnnounceContext<'_>,
+        server_info: &DHTServerInfo,
+        bootstrap_peers: &[String],
+    ) {
+        let records = match build_unannounce_records(ctx, server_info) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Unannounce: failed to build records: {e}");
+                return;
+            }
+        };
+        for record in &records {
+            self.storage.handle_store(record.clone());
+        }
+        send_records_via_handle(&self.handle, bootstrap_peers, &records).await;
+        info!("Unannounced from DHT — node removed from map");
+    }
+
+    /// Stop the swarm and every task hanging off it.
+    ///
+    /// The control socket's listener is closed and its socket file removed by
+    /// `ControlServer`'s `Drop`; the DHT maintenance loop and the mux accept
+    /// loop end on their own once the service drops their channels.
+    pub async fn shutdown(self) {
+        if let Err(e) = self.handle.shutdown().await {
+            warn!("Network service shutdown: {e}");
+        }
+        for task in self.tasks {
+            task.abort();
+        }
+    }
+}
+
+/// The control-socket multiaddr this node binds.
+///
+/// Resolved exactly as every client resolves it — `KWAAINET_SOCKET` if set,
+/// else the platform default — so `KWAAINET_SOCKET=… kwaainet run-node` and
+/// `KWAAINET_SOCKET=… kwaainet p2p peers list` still meet on the same path, and
+/// two nodes on one machine still get separate sockets.
+fn control_socket_addr() -> String {
+    match std::env::var("KWAAINET_SOCKET") {
+        Ok(sock) => {
+            #[cfg(unix)]
+            {
+                format!("/unix/{sock}")
+            }
+            #[cfg(not(unix))]
+            {
+                sock
+            }
+        }
+        Err(_) => kwaai_p2p_daemon::default_socket_addr(),
+    }
+}
+
+/// Register the node's own "while we're alive, please answer these" protocols.
+///
+/// The same three the p2pd path registers over the control socket, with the
+/// same protocol IDs and the same handler bodies — only the registration call
+/// differs. Failures are warnings, not errors, matching the p2pd path: a node
+/// that cannot serve its Ollama proxy is still a useful DHT peer.
+async fn register_node_handlers(
+    handle: &NetworkHandle,
+    lease_table: std::sync::Arc<crate::capacity_lease::LeaseTable>,
+) {
+    let hello = kwaai_p2p_daemon::hello::make_handler();
+    if let Err(e) = handle
+        .add_unary_handler(kwaai_p2p_daemon::hello::HELLO_PROTO, move |data| {
+            let fut = hello(data);
+            async move { fut.await.map_err(|e| e.to_string()) }
+        })
+        .await
+    {
+        warn!("registering p2p hello handler failed: {e}");
+    }
+
+    let ollama = crate::ollama_proxy::make_ollama_proxy_handler(lease_table.clone());
+    if let Err(e) = handle
+        .add_unary_handler(crate::ollama_proxy::OLLAMA_PROXY_PROTO, move |data| {
+            let fut = ollama(data);
+            async move { fut.await.map_err(|e| e.to_string()) }
+        })
+        .await
+    {
+        warn!("registering ollama-proxy handler failed: {e}");
+    }
+
+    // Capacity-lease unary handler — the p2p:// (non-mux) callers negotiate
+    // here. The mux path negotiates over its own already-open stream instead.
+    let lease = crate::capacity_lease::make_capacity_lease_handler(lease_table);
+    if let Err(e) = handle
+        .add_unary_handler(crate::capacity_lease::CAPACITY_LEASE_PROTO, move |data| {
+            let fut = lease(data);
+            async move { fut.await.map_err(|e| e.to_string()) }
+        })
+        .await
+    {
+        warn!("registering capacity-lease handler failed: {e}");
+    }
+
+    let shard = crate::ollama_proxy::make_shard_proxy_handler();
+    if let Err(e) = handle
+        .add_unary_handler(crate::ollama_proxy::SHARD_PROXY_PROTO, move |data| {
+            let fut = shard(data);
+            async move { fut.await.map_err(|e| e.to_string()) }
+        })
+        .await
+    {
+        warn!("registering shard-proxy handler failed: {e}");
+    }
+}

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -57,9 +57,11 @@ use tracing::{info, warn};
 
 use crate::announce::{
     build_announce_records, build_unannounce_records, send_records_via_handle, AnnounceContext,
-    DHTServerInfo,
+    DHTServerInfo, StoreTiming,
 };
 use crate::config::KwaaiNetConfig;
+use crate::daemon::ShardManager;
+use crate::node::SigHup;
 
 /// Per-request budget on outbound unary calls.
 ///
@@ -272,6 +274,272 @@ impl NativeNode {
         for task in self.tasks {
             task.abort();
         }
+    }
+}
+
+/// Run the node on the native stack: start everything, announce, then serve
+/// until a shutdown signal.
+///
+/// Called from `run_node` after its shared prologue (PID file, SIGHUP
+/// registration, gRPC surface, identity, credentials, bootstrap-peer
+/// resolution), so this owns only what is genuinely path-specific. Returns when
+/// the node has unannounced and stopped; `run_node` does the PID cleanup and
+/// the deferred auto-update respawn exactly as it does for the p2pd path.
+///
+/// # Loop arms vs the p2pd path
+///
+/// | arm | native |
+/// | --- | --- |
+/// | inbound DHT RPC | **gone** — served in-swarm by `spawn_dht_service`, not over a forwarded TCP stream |
+/// | SIGHUP re-announce | same |
+/// | 300 s ± 30 s re-announce | same, minus the daemon watchdog that gated it |
+/// | periodic IDENTIFY + restart | **deferred to the NAT slice** |
+/// | 10 s p2pd heartbeat | **gone** — no child process to outlive us |
+/// | 60 s relay keepalive | **gone** — no unix socket to a child, no relay circuit yet |
+/// | Ollama recovery | same |
+/// | shutdown | same |
+pub async fn run_native_node(
+    config: &KwaaiNetConfig,
+    bootstrap_peers: &[String],
+    public_name: &str,
+    trust_attestations: Vec<String>,
+    sighup: &mut SigHup,
+) -> Result<Option<String>> {
+    info!("[1/4] Starting the native p2p stack...");
+    let node = NativeNode::start(config, bootstrap_peers).await?;
+    let peer_id = node.peer_id;
+
+    // ── Announce inputs ────────────────────────────────────────────────────
+    info!("[2/4] Preparing the DHT announcement...");
+
+    // Without NAT traversal a native node is "direct" when it has an address to
+    // advertise and unreachable otherwise; there is no relay circuit that could
+    // make the middle case ("reachable, but only via a relay") true yet. The
+    // p2pd path's `all_addrs_are_relay` check over IDENTIFY-discovered addresses
+    // has no native counterpart until the NAT slice lands, so this reports
+    // relay=false whenever an address is configured and relay=true when none is
+    // — the same "no usable address means don't claim Direct" rule.
+    let announce_addr = configured_announce_addr(config);
+    let using_relay = announce_addr.is_none();
+    if let Some(ref addr) = announce_addr {
+        info!("  Announce addr: {addr}");
+    } else {
+        warn!(
+            "No announce_addr/public_ip configured — a native node has no NAT traversal yet, so \
+             it will only be reachable if its listen address is directly dialable"
+        );
+    }
+
+    let dl_bps = crate::node::measure_download_bps_for(&config.model).await;
+    let throughput = crate::node::report_effective_tps(&config.model, dl_bps, using_relay);
+    let prefix = config.effective_dht_prefix();
+    let repository = crate::node::effective_repository(config);
+    info!("  DHT prefix:  {}", prefix);
+    info!("  Repository:  {}", repository);
+    info!("  Using relay: {}", using_relay);
+
+    let vpk_info = crate::node::initial_vpk_info(config, public_name).await;
+
+    let ctx = AnnounceContext {
+        peer_id,
+        prefix: &prefix,
+        repository: &repository,
+        total_blocks: config.model_total_blocks(),
+    };
+
+    let mut config = config.clone();
+    let mut server_info = DHTServerInfo::new(
+        config.start_block as i32,
+        config.effective_end_block() as i32,
+        public_name,
+        using_relay,
+        throughput,
+        trust_attestations,
+        vpk_info,
+        peer_id.to_base58(),
+    );
+
+    // ── Initial announcement ───────────────────────────────────────────────
+    info!("[3/4] Announcing to DHT...");
+    if let Err(e) = node.announce(&ctx, &server_info, bootstrap_peers).await {
+        warn!("Initial announce failed: {e:#} — will retry at the 300 s tick");
+    }
+
+    info!("[4/4] ✅ KwaaiNet node running (native p2p)");
+    info!("   Peer ID : {}", peer_id.to_base58());
+    info!("   Name    : {}", public_name);
+    info!("   Model   : {}", config.model);
+    info!(
+        "   Blocks  : {}–{}",
+        config.start_block,
+        config.effective_end_block()
+    );
+    info!("   Map     : https://map.kwaai.ai");
+
+    // ── Event loop ─────────────────────────────────────────────────────────
+    // Same 300 s ± 30 s jittered cadence as the p2pd path: the DHT TTL is 360 s,
+    // so every record keeps at least 30 s of headroom, and the jitter stops a
+    // mass restart from thundering-herding the bootstraps.
+    let mut rep_store = crate::reputation::ReputationStore::load();
+    let mut next_announce = Box::pin(tokio::time::sleep(Duration::from_secs(
+        crate::node::jitter_secs(300, 30),
+    )));
+    let mut ollama_recovery_rx = crate::node::spawn_ollama_watcher(&config);
+    let mut pending_update_version: Option<String> = None;
+
+    loop {
+        tokio::select! {
+            // SIGHUP (Unix) — re-read config and re-announce. `shard serve`
+            // signals a block-range change this way.
+            _ = sighup.recv() => {
+                info!("SIGHUP received — re-reading config and re-announcing");
+                reload_block_range(&mut config);
+                refresh_server_info(&mut server_info, &config);
+                if let Err(e) = node.announce(&ctx, &server_info, bootstrap_peers).await {
+                    warn!("Re-announce after SIGHUP failed: {e:#}");
+                }
+            }
+
+            // Periodic re-announcement.
+            _ = &mut next_announce => {
+                reload_block_range(&mut config);
+                #[cfg(not(unix))]
+                {
+                    let flag = crate::config::run_dir().join("reannounce.flag");
+                    if flag.exists() {
+                        let _ = std::fs::remove_file(&flag);
+                    }
+                }
+
+                crate::node::refresh_throughput(&mut server_info, &config.model, dl_bps, using_relay);
+                crate::node::refresh_vpk_info(&mut server_info, &config, public_name).await;
+
+                // Auto-update — installs a new binary when available (pre-v1.0)
+                // and breaks the loop so the respawn happens after our own
+                // cleanup. Identical to the p2pd path.
+                let auto_update = KwaaiNetConfig::load_or_create()
+                    .map(|c| c.contribute_policy(false).auto_update)
+                    .unwrap_or(false);
+                if auto_update {
+                    if let Some(version) = crate::node::maybe_auto_update().await {
+                        pending_update_version = Some(version);
+                        break;
+                    }
+                }
+
+                refresh_server_info(&mut server_info, &config);
+                info!(
+                    "Re-announcing to DHT (shard_ready={})...",
+                    ShardManager::shard_is_ready()
+                );
+                match node.announce(&ctx, &server_info, bootstrap_peers).await {
+                    Ok(timings) => record_reputation(&mut rep_store, timings),
+                    Err(e) => warn!("Re-announce failed: {e:#}"),
+                }
+
+                next_announce
+                    .as_mut()
+                    .reset(tokio::time::Instant::now()
+                        + Duration::from_secs(crate::node::jitter_secs(300, 30)));
+            }
+
+            // Ollama came back up — re-announce immediately so clients learn the
+            // host is usable again without waiting out the 300 s tick.
+            Some(()) = ollama_recovery_rx.recv() => {
+                info!("Ollama recovered — triggering immediate re-announce");
+                refresh_server_info(&mut server_info, &config);
+                if let Err(e) = node.announce(&ctx, &server_info, bootstrap_peers).await {
+                    warn!("Re-announce after Ollama recovery failed: {e:#}");
+                }
+            }
+
+            _ = crate::node::shutdown_signal() => {
+                info!("Shutdown signal received");
+                break;
+            }
+        }
+    }
+
+    // Tombstone before tearing down the swarm, so the map drops us immediately
+    // rather than waiting out the TTL.
+    info!("Unannouncing from DHT...");
+    node.unannounce(&ctx, &server_info, bootstrap_peers).await;
+    node.shutdown().await;
+
+    Ok(pending_update_version)
+}
+
+/// The address this node advertises, or `None` when it has none configured.
+///
+/// Same precedence as the p2pd path: an explicit `announce_addr` multiaddr
+/// wins, else `public_ip` formatted with `public_port` (for port-forwarded
+/// deployments) or the listen `port`. An empty `public_ip` string means "no
+/// public IP", not "the empty address".
+fn configured_announce_addr(config: &KwaaiNetConfig) -> Option<String> {
+    config.announce_addr.clone().or_else(|| {
+        let port = config.public_port.unwrap_or(config.port);
+        config
+            .public_ip
+            .as_deref()
+            .filter(|ip| !ip.is_empty())
+            .map(|ip| format!("/ip4/{ip}/tcp/{port}"))
+    })
+}
+
+/// Re-read the on-disk config for a block-range change written by
+/// `shard serve` (via `signal_reannounce`) or `kwaainet config set`.
+fn reload_block_range(config: &mut KwaaiNetConfig) {
+    let Ok(fresh) = KwaaiNetConfig::load_or_create() else {
+        return;
+    };
+    if fresh.start_block == config.start_block && fresh.blocks == config.blocks {
+        return;
+    }
+    info!(
+        "Block range updated: [{}–{}) → [{}–{})",
+        config.start_block,
+        config.effective_end_block(),
+        fresh.start_block,
+        fresh.start_block + fresh.blocks,
+    );
+    config.start_block = fresh.start_block;
+    config.blocks = fresh.blocks;
+}
+
+/// Sync the announced block range and readiness state from the live config.
+fn refresh_server_info(server_info: &mut DHTServerInfo, config: &KwaaiNetConfig) {
+    server_info.start_block = config.start_block as i32;
+    server_info.end_block = config.effective_end_block() as i32;
+    server_info.state = if ShardManager::shard_is_ready() { 2 } else { 0 };
+}
+
+/// Fold one announce round's per-bootstrap timings into the reputation store.
+///
+/// The announce doubles as the reputation probe on both paths — no extra RPCs.
+/// The display name is the `/dns/` hostname from the bootstrap multiaddr when
+/// there is one, else a truncated peer ID.
+fn record_reputation(rep: &mut crate::reputation::ReputationStore, timings: Vec<StoreTiming>) {
+    use crate::reputation::{now_secs, PeerObservation};
+    for (peer_id_str, addr, latency_ms, success) in timings {
+        let name = addr
+            .split('/')
+            .collect::<Vec<_>>()
+            .windows(2)
+            .find(|w| w[0] == "dns" || w[0] == "dns4" || w[0] == "dns6")
+            .map(|w| w[1].to_string())
+            .unwrap_or_else(|| peer_id_str[..peer_id_str.len().min(12)].to_string());
+        rep.record(
+            &peer_id_str,
+            &name,
+            PeerObservation {
+                timestamp_secs: now_secs(),
+                latency_ms,
+                success,
+                observed_tps: None,
+                claimed_tps: None,
+                lease_outcome: None,
+            },
+        );
     }
 }
 

--- a/core/crates/kwaai-network-tests/Cargo.toml
+++ b/core/crates/kwaai-network-tests/Cargo.toml
@@ -29,6 +29,7 @@ prost     = { workspace = true }          # 0.12 — for kwaai-hivemind-dht / kw
 prost013  = { package = "prost", version = "0.13" }  # 0.13 — for kwaai-rpc tonic-generated types
 rmp-serde = { workspace = true }
 hex       = "0.4"
+sha1      = "0.10"  # DHTID derivation in 13_native_node_assembly
 sha2      = "0.10"
 tempfile  = "3"
 unsigned-varint = { workspace = true }  # hand-built wire frames in 07_wire_interop

--- a/core/crates/kwaai-network-tests/tests/13_native_node_assembly.rs
+++ b/core/crates/kwaai-network-tests/tests/13_native_node_assembly.rs
@@ -1,0 +1,514 @@
+//! The assembled native node — the Phase 4 `run_node` gate.
+//!
+//! Tiers 09–12 each proved one component in isolation: a `NetworkService`
+//! interoperates over the libp2p wire (09), a `DHTStorage` behind unary handlers
+//! serves a Go caller (10), a `ControlServer` is indistinguishable from a p2pd
+//! to a `P2PClient` (11), and pipe mode relays bytes across both (12). None of
+//! them assembles those parts into a *node*, which is what `native_p2p = true`
+//! now makes `run_node` do.
+//!
+//! This tier assembles them the way `node_native::NativeNode::start` does and
+//! asserts the two properties a node has that its parts do not:
+//!
+//! ```text
+//!   ┌── node B (announcer) ─────────┐          ┌── node A (bootstrap) ───────┐
+//!   │ NetworkService + DHT service  │──store──▶│ NetworkService + DHT service│
+//!   │ ControlServer ◀── P2PClient   │◀──find───│ ControlServer               │
+//!   └───────────────────────────────┘          └─────────────────────────────┘
+//! ```
+//!
+//! | test | proves |
+//! | --- | --- |
+//! | `announced_records_are_findable_on_the_bootstrap` | B bootstraps to A, announces, and A serves the records back |
+//! | `an_external_client_drives_the_assembled_node` | a `P2PClient` on the node's own control socket does identify + a unary round trip |
+//! | `the_control_socket_reaches_the_swarm_the_node_is_running` | the socket and the swarm are the *same* node, not two that happen to coexist |
+//! | `a_node_serves_its_own_announced_records` | the local-store half of announce, which is what makes a node a DHT replica of itself |
+//! | `the_peer_id_is_the_identity_key_file_not_a_fresh_one` | the migrated node keeps its DID, credentials and map entry |
+//!
+//! # Why no `kwaainet run-node` spawn test
+//!
+//! Deliberately omitted. A spawned binary writes the real `~/.kwaainet` PID
+//! file, binds the real control socket, starts the gRPC surface on a fixed
+//! port, and probes Ollama and the update endpoint — all process-global state
+//! that collides with a node running on the developer's machine and with a
+//! second copy of the test. The properties a spawn test would add over this one
+//! are argument parsing and the config round trip, both already unit-tested,
+//! against a large increase in flakiness. The components are assembled here
+//! exactly as `NativeNode::start` assembles them, in the same order.
+//!
+//! Gate: `KWAAI_INTEGRATION_TESTS=1`, like tiers 07–12.
+//!
+//! # Process hygiene
+//!
+//! No p2pd is spawned and none is required — the point of the native path is
+//! that the binary need not exist. Every swarm listens on an ephemeral loopback
+//! port with a freshly generated key, and every control socket lives in its own
+//! tmpdir, so nothing here can collide with a node running on the same machine.
+
+use std::time::Duration;
+
+use kwaai_hivemind_dht::protocol::{
+    FindRequest, FindResponse, NodeInfo, RequestAuthInfo, ResultType, StoreRequest, StoreResponse,
+};
+use kwaai_hivemind_dht::value::get_dht_time;
+use kwaai_hivemind_dht::{DHTStorage, PROTOCOL_FIND, PROTOCOL_STORE};
+use kwaai_network_tests::{metrics::MetricsRecorder, require_integration};
+use kwaai_p2p::{dht_service, Multiaddr, NetworkConfig, NetworkHandle, NetworkService, PeerId};
+use kwaai_p2p_daemon::{ControlServer, P2PClient};
+use prost::Message;
+use sha1::{Digest, Sha1};
+use tempfile::TempDir;
+
+/// Cap on any single interaction, so a regression fails rather than hanging.
+const TIMEOUT: Duration = Duration::from_secs(20);
+
+/// The TTL every announced record carries, matching `announce::ANNOUNCE_TTL_SECS`.
+const ANNOUNCE_TTL_SECS: f64 = 360.0;
+
+// ============================================================================
+// The node under test
+// ============================================================================
+
+/// A native node assembled exactly as `node_native::NativeNode::start` does:
+/// identity from a key file, swarm, DHT service, control socket.
+///
+/// The CLI is a binary crate, so this cannot call `NativeNode::start` itself.
+/// What it can do is compose the same public API in the same order, which is
+/// the part that could break — the CLI glue on top is one call per line.
+struct AssembledNode {
+    handle: NetworkHandle,
+    peer_id: PeerId,
+    storage: DHTStorage,
+    /// Control-socket multiaddr, for `P2PClient::connect`.
+    socket: String,
+    /// libp2p listen address including `/p2p/<id>`, dialable by another node.
+    addr: Multiaddr,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+    _tmpdir: TempDir,
+}
+
+impl AssembledNode {
+    /// Start a node whose identity is read from a key file in its own tmpdir,
+    /// the way the CLI reads `~/.kwaainet/identity.key`.
+    async fn start() -> Self {
+        let tmpdir = TempDir::new().expect("tmpdir");
+        let key_path = tmpdir.path().join("identity.key");
+        let keypair = kwaai_p2p::identity::load_or_generate(&key_path)
+            .expect("the identity key file must load or generate");
+        let peer_id = keypair.public().to_peer_id();
+
+        let (handle, service_task) =
+            NetworkService::spawn(NetworkConfig::for_tests(), keypair).expect("service starts");
+        let mut tasks = vec![service_task];
+
+        // DHT serving — bootstrap-grade, as `-b` gave the p2pd path.
+        let storage = DHTStorage::new(peer_id);
+        tasks.push(
+            dht_service::spawn_dht_service(handle.clone(), storage.clone())
+                .await
+                .expect("the DHT service must register"),
+        );
+
+        let addr = wait_for_listen_addr(&handle).await;
+
+        // Control socket last, so an external client never sees a node whose
+        // handlers are only half-registered.
+        let socket = format!("/unix/{}", tmpdir.path().join("kwaai.sock").display());
+        let server = ControlServer::bind(&socket, handle.clone())
+            .await
+            .expect("the control socket must bind");
+        tasks.push(tokio::spawn(server.run()));
+
+        Self {
+            handle,
+            peer_id,
+            storage,
+            socket,
+            addr: format!("{addr}/p2p/{peer_id}")
+                .parse()
+                .expect("a dialable listen address"),
+            tasks,
+            _tmpdir: tmpdir,
+        }
+    }
+
+    /// Dial `other` and seed Kademlia from it, as `NativeNode::start` does with
+    /// the configured bootstrap peers.
+    async fn bootstrap_to(&self, other: &AssembledNode) {
+        tokio::time::timeout(TIMEOUT, self.handle.bootstrap(vec![other.addr.clone()]))
+            .await
+            .expect("bootstrap must not hang")
+            .expect("bootstrap must succeed against a live peer");
+    }
+
+    /// An external process's view of this node.
+    async fn external_client(&self) -> P2PClient {
+        P2PClient::connect(&self.socket)
+            .await
+            .expect("a P2PClient must connect to the assembled node's control socket")
+    }
+
+    async fn shutdown(self) {
+        let _ = self.handle.shutdown().await;
+        for task in self.tasks {
+            task.abort();
+        }
+    }
+}
+
+async fn wait_for_listen_addr(handle: &NetworkHandle) -> Multiaddr {
+    tokio::time::timeout(TIMEOUT, async {
+        loop {
+            if let Some(a) = handle
+                .listen_addrs()
+                .await
+                .ok()
+                .and_then(|a| a.into_iter().next())
+            {
+                return a;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("the swarm must report a listen address")
+}
+
+// ============================================================================
+// Announce records
+// ============================================================================
+
+/// `SHA1(msgpack(raw_key))` — hivemind's `DHTID.generate()`, as `announce::dht_id`.
+fn dht_id(raw_key: &str) -> Vec<u8> {
+    let packed = rmp_serde::to_vec(raw_key).expect("msgpack key");
+    Sha1::new().chain_update(&packed).finalize().to_vec()
+}
+
+/// One block record in the shape `announce::build_announce_records` produces:
+/// a real subkey (`msgpack(peer_b58)`, never a sentinel), a 360 s TTL, and
+/// `in_cache = false`.
+fn block_record(peer_id: PeerId, prefix: &str, block: i32, value: &[u8]) -> StoreRequest {
+    StoreRequest {
+        auth: Some(RequestAuthInfo::new()),
+        keys: vec![dht_id(&format!("{prefix}.{block}"))],
+        subkeys: vec![rmp_serde::to_vec(&peer_id.to_base58()).expect("msgpack subkey")],
+        values: vec![value.to_vec()],
+        expiration_time: vec![get_dht_time() + ANNOUNCE_TTL_SECS],
+        in_cache: vec![false],
+        peer: Some(NodeInfo::from_peer_id(peer_id)),
+    }
+}
+
+/// Push a record to `peer` over the handle, as `send_records_via_handle` does.
+async fn store_via_handle(
+    handle: &NetworkHandle,
+    peer: PeerId,
+    record: &StoreRequest,
+) -> StoreResponse {
+    let bytes = record.encode_to_vec();
+    let resp = tokio::time::timeout(
+        TIMEOUT,
+        handle.call_unary_handler(peer, PROTOCOL_STORE, &bytes),
+    )
+    .await
+    .expect("rpc_store must not hang")
+    .expect("rpc_store must reach the peer");
+    StoreResponse::decode(&resp[..]).expect("a decodable StoreResponse")
+}
+
+/// Look a key up on `peer` over the handle.
+async fn find_via_handle(handle: &NetworkHandle, peer: PeerId, key: Vec<u8>) -> FindResponse {
+    let request = FindRequest {
+        auth: Some(RequestAuthInfo::new()),
+        keys: vec![key],
+        peer: None,
+    };
+    let resp = tokio::time::timeout(
+        TIMEOUT,
+        handle.call_unary_handler(peer, PROTOCOL_FIND, &request.encode_to_vec()),
+    )
+    .await
+    .expect("rpc_find must not hang")
+    .expect("rpc_find must reach the peer");
+    FindResponse::decode(&resp[..]).expect("a decodable FindResponse")
+}
+
+// ============================================================================
+// Two nodes: announce and find
+// ============================================================================
+
+/// The end-to-end announce path between two native nodes.
+///
+/// Node B bootstraps to node A, announces a block record over its
+/// `NetworkHandle`, and A — running nothing but the same assembled stack —
+/// stores it and serves it back on `rpc_find` with the value byte-identical.
+///
+/// This is the property the whole migration exists to preserve: with the flag
+/// on, a node still gets onto the map. `rpc_store` is single-hop (verified live
+/// in Phase 2), so A serving the record back is exactly the guarantee the
+/// bootstrap fan-out relies on.
+#[tokio::test]
+async fn announced_records_are_findable_on_the_bootstrap() {
+    require_integration!();
+    let rec = MetricsRecorder::start(
+        "integration::native_node::announce_is_findable_on_the_bootstrap",
+        "integration",
+    );
+
+    let bootstrap = AssembledNode::start().await;
+    let announcer = AssembledNode::start().await;
+    announcer.bootstrap_to(&bootstrap).await;
+
+    let prefix = "Qwen/Qwen3-8B-hf";
+    let value = b"an Ext(64) ServerInfo would live here".to_vec();
+    let record = block_record(announcer.peer_id, prefix, 0, &value);
+
+    let stored = store_via_handle(&announcer.handle, bootstrap.peer_id, &record).await;
+    assert_eq!(
+        stored.store_ok,
+        vec![true],
+        "the bootstrap must accept the announce"
+    );
+
+    let found = find_via_handle(
+        &announcer.handle,
+        bootstrap.peer_id,
+        dht_id(&format!("{prefix}.0")),
+    )
+    .await;
+    assert_eq!(found.results.len(), 1);
+    assert_eq!(
+        found.results[0].result_type,
+        ResultType::FoundDictionary as i32,
+        "a subkeyed record reads back as a dictionary, so many servers accumulate under one key"
+    );
+
+    // The value must survive the round trip byte-for-byte — the map crawler
+    // decodes it, so any reshaping here takes nodes off the map.
+    let dict = kwaai_hivemind_dht::parse_dictionary(&found.results[0].value)
+        .expect("the result must parse as a hivemind dictionary");
+    let subkey = rmp_serde::to_vec(&announcer.peer_id.to_base58()).unwrap();
+    assert_eq!(
+        dict.entries[&subkey].0, value,
+        "the announced value must come back unchanged"
+    );
+
+    rec.finish(true);
+    announcer.shutdown().await;
+    bootstrap.shutdown().await;
+}
+
+/// A node stores what it announces into its own storage, so it serves as a
+/// replica of its own records rather than depending entirely on the bootstraps.
+///
+/// `NativeNode::announce` does this before the network round trip, mirroring the
+/// p2pd path's local `handle_store`. Asserted through a *remote* `rpc_find` from
+/// the other node, so this tests the serving path and not just the storage API.
+#[tokio::test]
+async fn a_node_serves_its_own_announced_records() {
+    require_integration!();
+    let rec = MetricsRecorder::start(
+        "integration::native_node::serves_its_own_records",
+        "integration",
+    );
+
+    let announcer = AssembledNode::start().await;
+    let reader = AssembledNode::start().await;
+    reader.bootstrap_to(&announcer).await;
+
+    let prefix = "Qwen/Qwen3-8B-hf";
+    let value = b"locally stored ServerInfo".to_vec();
+    let record = block_record(announcer.peer_id, prefix, 7, &value);
+
+    // The local half of announce: store into our own storage.
+    assert!(
+        announcer.storage.handle_store(record.clone()).store_ok[0],
+        "a node must accept its own announcement"
+    );
+
+    let found = find_via_handle(
+        &reader.handle,
+        announcer.peer_id,
+        dht_id(&format!("{prefix}.7")),
+    )
+    .await;
+    assert_eq!(
+        found.results[0].result_type,
+        ResultType::FoundDictionary as i32,
+        "the announcing node must serve its own record to a remote peer"
+    );
+
+    rec.finish(true);
+    reader.shutdown().await;
+    announcer.shutdown().await;
+}
+
+// ============================================================================
+// The control socket on the assembled node
+// ============================================================================
+
+/// An unchanged external client drives the node `run_node` assembled.
+///
+/// Tier 11 proved a standalone `ControlServer` is indistinguishable from a
+/// p2pd. This proves the one `run_node` binds is too — that adding the DHT
+/// service and the node's own handlers underneath it did not disturb the socket
+/// the GUI, `kwaainet p2p …` and `shard serve` all dial.
+///
+/// Identify plus a unary round trip is the minimum every client does at
+/// startup, and the round trip crosses both boundaries: registered over one
+/// node's socket, called over the other's, answered across the libp2p wire.
+#[tokio::test]
+async fn an_external_client_drives_the_assembled_node() {
+    require_integration!();
+    let rec = MetricsRecorder::start(
+        "integration::native_node::external_client_round_trip",
+        "integration",
+    );
+
+    let responder = AssembledNode::start().await;
+    let caller = AssembledNode::start().await;
+    caller.bootstrap_to(&responder).await;
+
+    // ── identify ────────────────────────────────────────────────────────────
+    let mut responder_client = responder.external_client().await;
+    let reported = responder_client
+        .identify()
+        .await
+        .expect("identify must succeed against the assembled node");
+    let reported =
+        PeerId::from_bytes(&hex::decode(&reported).expect("hex peer id")).expect("a valid peer id");
+    assert_eq!(
+        reported, responder.peer_id,
+        "the control socket must report the swarm's own peer ID, not a second identity"
+    );
+
+    // ── unary round trip across both boundaries ─────────────────────────────
+    const PROTO: &str = "/kwaai/p2p/hello/1.0.0";
+    responder_client
+        .add_unary_handler(
+            PROTO,
+            |req: Vec<u8>| async move {
+                let mut out = b"assembled:".to_vec();
+                out.extend_from_slice(&req);
+                Ok(out)
+            },
+            false,
+        )
+        .await
+        .expect("an external client must be able to register a handler");
+
+    let caller_client = caller.external_client().await;
+    let reply = tokio::time::timeout(
+        TIMEOUT,
+        caller_client.call_unary_handler(&responder.peer_id.to_bytes(), PROTO, b"ping"),
+    )
+    .await
+    .expect("the call must not hang")
+    .expect("the call must reach the handler");
+    assert_eq!(
+        reply, b"assembled:ping",
+        "the handler an external client registered must answer a remote caller"
+    );
+
+    rec.finish(true);
+    caller.shutdown().await;
+    responder.shutdown().await;
+}
+
+/// The control socket and the swarm are one node, not two that coexist.
+///
+/// The failure this guards against is real and silent: a `ControlServer` bound
+/// to a *different* `NetworkHandle` than the one serving the DHT would pass
+/// every tier-11 test and still be a broken node — `kwaainet p2p peers list`
+/// would show peers the DHT service could not reach. Asserted by dialing
+/// through the socket and observing the result on the swarm's own peer list.
+#[tokio::test]
+async fn the_control_socket_reaches_the_swarm_the_node_is_running() {
+    require_integration!();
+    let rec = MetricsRecorder::start(
+        "integration::native_node::socket_and_swarm_are_one_node",
+        "integration",
+    );
+
+    let node = AssembledNode::start().await;
+    let other = AssembledNode::start().await;
+
+    let mut client = node.external_client().await;
+    tokio::time::timeout(TIMEOUT, client.connect_peer(&other.addr.to_string()))
+        .await
+        .expect("connect must not hang")
+        .expect("the control socket must dial a reachable peer");
+
+    let peers = node
+        .handle
+        .list_peers()
+        .await
+        .expect("the swarm must list its peers");
+    assert!(
+        peers.iter().any(|p| p.peer_id == other.peer_id),
+        "a dial made through the control socket must appear on the swarm the node is running; \
+         got {peers:?}"
+    );
+
+    rec.finish(true);
+    other.shutdown().await;
+    node.shutdown().await;
+}
+
+/// The node's peer ID comes from its identity key file, so a node that migrates
+/// to the native path keeps its DID, its credentials and its map entry.
+///
+/// The on-disk format is the bare libp2p protobuf encoding that
+/// `kwaai-cli::NodeIdentity` writes and that p2pd accepts via `-id`, so the
+/// same file yields the same peer ID on either path. A regression here would
+/// silently mint a new identity on upgrade — records under the old subkey would
+/// age out and every issued credential would be orphaned.
+#[tokio::test]
+async fn the_peer_id_is_the_identity_key_file_not_a_fresh_one() {
+    require_integration!();
+    let rec = MetricsRecorder::start(
+        "integration::native_node::peer_id_comes_from_the_key_file",
+        "integration",
+    );
+
+    let tmpdir = TempDir::new().expect("tmpdir");
+    let key_path = tmpdir.path().join("identity.key");
+
+    // What the p2pd path would have had: the peer ID of the key on disk.
+    let expected = kwaai_p2p::identity::load_or_generate(&key_path)
+        .expect("key generates")
+        .public()
+        .to_peer_id();
+
+    // Starting a node from the same file must reproduce it, and the control
+    // socket must report it — the peer ID external clients see.
+    let keypair = kwaai_p2p::identity::load_keypair(&key_path).expect("key loads");
+    let (handle, service_task) =
+        NetworkService::spawn(NetworkConfig::for_tests(), keypair).expect("service starts");
+    assert_eq!(
+        handle.peer_id(),
+        expected,
+        "the swarm must adopt the key file's identity, not generate a fresh one"
+    );
+
+    let socket = format!("/unix/{}", tmpdir.path().join("kwaai.sock").display());
+    let server = ControlServer::bind(&socket, handle.clone())
+        .await
+        .expect("the control socket must bind");
+    let server_task = tokio::spawn(server.run());
+
+    let mut client = P2PClient::connect(&socket).await.expect("client connects");
+    let reported = PeerId::from_bytes(
+        &hex::decode(client.identify().await.expect("identify")).expect("hex peer id"),
+    )
+    .expect("a valid peer id");
+    assert_eq!(
+        reported, expected,
+        "external clients must see the key file's peer ID"
+    );
+
+    rec.finish(true);
+    let _ = handle.shutdown().await;
+    server_task.abort();
+    let _ = tokio::time::timeout(Duration::from_secs(5), service_task).await;
+}

--- a/core/crates/kwaai-p2p-daemon/src/lib.rs
+++ b/core/crates/kwaai-p2p-daemon/src/lib.rs
@@ -60,7 +60,7 @@ pub use client::{P2PClient, P2PStream};
 pub use daemon::{DaemonBuilder, P2PDaemon};
 pub use dht::{DhtPeerInfo, DhtValue};
 pub use error::{Error, Result};
-pub use server::ControlServer;
+pub use server::{default_socket_addr, ControlServer};
 
 // Re-export commonly used types
 pub use protocol::p2pd;


### PR DESCRIPTION
**Stack** (review in order; each PR shows only its own diff):
| # | PR | What |
|---|----|------|
| 0 | #91 | build: patched deps via fetch script |
| 1 | #80 | hivemind unary wire codec |
| 2 | #81 | in-process rust-libp2p swarm |
| 3 | #82 | hivemind unary RPC |
| 4 | #83 | native hivemind DHT serving |
| 5 | #84 | p2pd control socket + pipe mode |
| 6 | #85 | run_node native path behind the flag |
| 7 | #86 | NAT traversal + libp2p 0.56 |

Rebuilt from the 73-commit `feat/native-p2p` branch into 57 commits. Tip is functionally identical to that branch.

---

## What this adds

The `native_p2p` config flag (default off) and the `node_native` module behind it: setting it makes `kwaainet run-node` assemble PRs 1-5 into a working node — swarm, DHT service, its own handlers, and a control socket on the same path — with no Go `p2pd` child process at all.

## Why

PRs 0-5 built the parts and proved each against a real p2pd, but nothing assembled them, so none of it ran in a node. This is the assembly, put behind an opt-in flag so it can be exercised on real hardware without touching anyone's default. The flag deliberately adds no companion settings: the native path reuses `port`, `initial_peers`, `identity_key` and `KWAAINET_SOCKET`, so a node's PeerId and control socket are identical either way and migrating between paths is a single boolean rather than a reconfiguration.

## What's in it

**`kwaai-cli/src/config.rs` — the flag.** `native_p2p: bool`, `#[serde(default)]`, initialised `false` in `Default`, and settable through the existing `config set` string dispatcher. The doc comment records what it does *not* yet do: AutoNAT, circuit relay, DCUtR and UPnP are still p2pd-only, so `no_relay`, `force_private` and `trusted_relays` are ignored while it is set, and a node behind a NAT is only reachable on the p2pd path. (That gap closes in PR7.)

**`kwaai-cli/src/node_native.rs` (new, ~590 lines) — the native node.** `NativeNode` assembles what PRs 1-5 built into the node `run_node` otherwise gets from p2pd:

- the swarm on the configured port;
- the DHT service, bootstrap-grade, matching p2pd's `-b`;
- this node's own handlers — `hello` / ollama-proxy / shard-proxy as unary, inference-mux as a raw stream;
- a `ControlServer` on the same socket path p2pd would have used, so the GUI, `kwaainet p2p …` and `shard serve` are unchanged.

Identity comes from the same key file through the same libp2p protobuf encoding, so the peer ID is identical on both paths. Announce and unannounce go through PR4's `announce.rs`, byte-for-byte, on the same 300 s ± 30 s cadence against a 360 s TTL, and the tombstone still runs on clean shutdown.

**`kwaai-cli/src/node.rs` — one branch, then a module.** The two paths differ in their whole lifecycle rather than in a handful of branches — there is no child process to spawn, watch, restart or reap — so `run_node` takes a single early return into `node_native::run_native_node` rather than growing a hundred `if native_p2p` arms. Everything above the branch (PID file, SIGHUP registration, the gRPC IPC surface, identity, credentials, public name, bootstrap-peer list) is shared, and the tail (PID cleanup, deferred auto-update respawn) runs identically for both.

What they share is *shared*, not copied: SigHup, the Ollama watcher, the auto-update respawn and the announce-input helpers are all extracted.

**`refactor(cli): extract the announce inputs from run_node`** — throughput measurement/reporting, the repository URL, and the VPK health poll (both the startup form with its 5×1 s retry and the per-tick refresh) become free functions. Pure extraction; `run_node` calls them in the same order with the same arguments. These are what the native path needs to announce the identical records, and sharing them is what keeps the two paths from drifting on the values the map crawler decodes.

**`kwaai-cli/src/inference_mux.rs` — native mux serving.** The mux frame loop is extracted into `serve_mux_frames`, generic over the stream halves, with `start_native_inference_mux_server` built on `NetworkHandle::accept_streams`. The p2pd path binds a local TCP listener, has the daemon forward inbound streams to it, and consumes a `StreamInfo` prologue describing the forwarded stream. Natively there is no forwarding hop: `accept_streams` yields the negotiated libp2p stream itself, so there is no listener, no prologue, and one fewer place for backpressure to be lost. Both paths now run the identical frame loop, so the per-request concurrency model is defined once.

**`kwaai-p2p-daemon/src/lib.rs`** — re-exports `default_socket_addr` so the native node can bind the same control-socket path p2pd would have used.

## Risk

**No default behaviour change.** What makes it safe:

- `native_p2p` defaults to `false` (`#[serde(default)]` on a `bool`, and `native_p2p: false` in `Default for KwaaiNetConfig`), so an existing config file with no such key deserialises to the p2pd path.
- The native path is reached through **exactly one branch** in `run_node` (`node.rs:161`), which returns early. With the flag unset, control never enters `node_native` and the p2pd code below runs verbatim.
- The `inference_mux` and announce-input changes are pure extractions — the p2pd path calls the same code in the same order with the same arguments.

Worth looking at closely:

- **The `node.rs` refactor is the largest diff here** (~650 lines changed) and is the one place a "pure extraction" claim could hide a behaviour change on the default path. The extracted helpers (throughput/reporting, repository URL, VPK health poll with its 5×1 s startup retry) are where to check that call order and arguments really are unchanged.
- The `serve_mux_frames` generalisation now backs the p2pd path too; a reviewer should confirm the p2pd caller still supplies the prologue-consuming wrapper it did before.
- The flag's documented limitations are load-bearing: **a NATed node must not enable this yet**, since NAT traversal does not land until PR7.

## Test coverage

**Tier 13 — `core/crates/kwaai-network-tests/tests/13_native_node_assembly.rs`.** Tiers 09-12 each proved one component in isolation; none assembles them. This tier composes them the way `NativeNode::start` does — identity from a key file, swarm, DHT service, control socket, in that order — and asserts the properties a node has that its parts do not:

- two nodes: B bootstraps to A, announces a subkeyed block record, and A serves it back as `FOUND_DICTIONARY` with the value byte-identical;
- a node serves its own announced records to a remote peer (the local half of announce, which makes a node a replica of itself);
- an unchanged `P2PClient` on the node's own control socket does identify plus a unary round trip that crosses both the socket and the wire;
- the socket and the swarm are **one node** — a `ControlServer` bound to a different handle would pass every tier-11 test and still be broken;
- the peer ID comes from the key file, so migrating keeps the node's DID, credentials and map entry.

No p2pd is spawned and none is required, which is the point.

**Deliberately omitted:** a `kwaainet run-node` spawn test. It would write the real PID file, bind the real socket and take the fixed gRPC port — process-global state that collides with a developer's running node and with a second copy of itself — to add only argument parsing and the config round trip over what tier 13 already covers.

## Stacked on

`native-p2p-pr5-control-socket`

---

## Verification run for this PR

- `cargo build --workspace --all-targets` at this branch head: clean.
- `cargo test --workspace`: **803 passing, 0 failures.**
- Daemon run, `native_p2p: false`: starts the Go p2pd, connects to 2 bootstraps, no panic, clean shutdown.
- Daemon run, `native_p2p: true`: starts the native stack with **no p2pd child process**, registers the hivemind DHT service, bootstraps to 2 peers, and stores to a live bootstrap (`1/1 stored`).

This PR is one of a stack rebuilt from the 73-commit `feat/native-p2p` branch. The stack tip is functionally identical to that branch: the only difference in the whole tree is comment text in `core/Cargo.toml`.

---

**Rebased onto `main` @ v0.5.5 (2026-08-06).** Upstream landed Capacity Lease admission control (#a0a4065), which touched files this stack moves or refactors. Two conflicts were resolved, both carrying upstream's change forward rather than dropping it:

- **#83** — upstream added `lease_v1` to `DHTServerInfo`, which this PR relocates to `announce.rs`. The field, its encoder entry and its doc comment moved with the type; upstream's own `to_msgpack_announces_lease_v1_true` test passes against the relocated struct.
- **#85** — upstream added the lease admission gate to the mux frame loop, which this PR extracts into `serve_mux_frames`. `lease_table` and `connection_id` are threaded through, and the native mux path registers the capacity-lease handler, so the native transport is gated identically to the p2pd one rather than bypassing it.

Per-branch verification after the rebase (all clean, 0 failures): 659 / 689 / 696 / 723 / 784 / 824 / 829 / 916 tests.

