### PR TITLE
perf(rag): maintain the persistent BM25 index instead of rebuilding per query

### DIFF
--- a/core/crates/kwaai-cli/src/rag_api.rs
+++ b/core/crates/kwaai-cli/src/rag_api.rs
@@ -12,6 +12,7 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use kwaai_rag::{
+    bm25::BM25Index,
     embedder::EmbedClient,
     graph::GraphStore,
     ingestion::{ingest_text, IngestConfig},
@@ -44,6 +45,9 @@ struct RagState {
     client: Option<Arc<Mutex<P2PClient>>>,
     embed: EmbedClient,
     meta: Arc<MetaStore>,
+    /// Persistent keyword index; None means fall back to per-query in-RAM
+    /// builds (never wrong, just slower).
+    bm25: Option<Arc<BM25Index>>,
     inference_url: String,
     top_k: usize,
     http: reqwest::Client,
@@ -97,6 +101,14 @@ pub async fn run(port: u16, inference_url: String, top_k: usize, kb: String) -> 
         };
         let meta = Arc::new(MetaStore::open(&rag.data_dir(), tenant_id)?);
 
+        let bm25 = match BM25Index::open_backfilled(&rag.data_dir(), &meta) {
+            Ok(idx) => Some(Arc::new(idx)),
+            Err(e) => {
+                tracing::warn!("BM25 index unavailable ({e:#}); using in-RAM fallback");
+                None
+            }
+        };
+
         let doc_context: Option<String> = GraphStore::open(&rag.data_dir(), tenant_id)
             .ok()
             .and_then(|g| {
@@ -120,6 +132,7 @@ pub async fn run(port: u16, inference_url: String, top_k: usize, kb: String) -> 
             client: p2p_client,
             embed,
             meta,
+            bm25,
             inference_url: inference_url.clone(),
             top_k,
             http: reqwest::Client::new(),
@@ -237,6 +250,7 @@ async fn do_chat(state: &RagState, req: ChatRequest) -> Result<serde_json::Value
             hyde_inference_url: None,
             hyde_model: None,
             hyde_alpha: None,
+            bm25: state.bm25.clone(),
             ..Default::default()
         };
 
@@ -406,6 +420,7 @@ async fn do_search(
             hyde_inference_url: None,
             hyde_model: None,
             hyde_alpha: None,
+            bm25: state.bm25.clone(),
             ..Default::default()
         };
         let chunks = match state.storage_url.as_deref() {
@@ -507,6 +522,11 @@ async fn api_delete_doc(
         if ids.is_empty() {
             return (axum::http::StatusCode::NOT_FOUND, "document not found").into_response();
         }
+        // Best-effort: on failure the count drift makes the next
+        // open_backfilled rebuild the index without the deleted doc.
+        if let Some(ref idx) = state.bm25 {
+            let _ = idx.delete_doc(&name);
+        }
         match state.storage_url.as_deref() {
             Some("local") => {
                 if let Some(ref vs) = state.local_vs {
@@ -566,7 +586,8 @@ async fn api_ingest(
 
             let tenant_id = state.tenant_id;
             let meta = state.meta.clone();
-            let cfg = IngestConfig::new(state.embed.clone());
+            let mut cfg = IngestConfig::new(state.embed.clone());
+            cfg.bm25 = state.bm25.clone();
 
             let result = match state.storage_url.as_deref() {
                 Some("local") => {

--- a/core/crates/kwaai-cli/src/rag_cmd.rs
+++ b/core/crates/kwaai-cli/src/rag_cmd.rs
@@ -7,6 +7,7 @@ use libp2p::PeerId;
 use uuid::Uuid;
 
 use kwaai_rag::{
+    bm25::BM25Index,
     cache::QueryCache,
     document,
     embedder::EmbedClient,
@@ -587,6 +588,7 @@ async fn cmd_ingest(
         cfg.chunk_cfg.min_chunk_len = min_chunk_len;
         cfg.chunk_cfg.strategy = parse_chunk_strategy(&chunk_strategy);
         cfg.chunk_cfg.surr_mode = parse_surr_mode(&surr_mode);
+        cfg.bm25 = open_bm25(&rag_cfg, &meta, &kb);
 
         if let Some(path) = doc_meta_path {
             cfg.doc_meta = load_doc_meta(&path)?;
@@ -997,6 +999,7 @@ async fn cmd_query(
             query_classify: parse_classify_method(&query_classify),
             query_multi_hop: false,
             use_summary_expansion: false,
+            bm25: None, // per-KB index attached inside the loop below
         };
         let mut spinner = if json_out {
             None
@@ -1017,6 +1020,11 @@ async fn cmd_query(
             let embed =
                 EmbedClient::new(rag_cfg.embed_url.clone(), Some(rag_cfg.embed_model.clone()));
             let meta = MetaStore::open(&rag_cfg.data_dir(), tenant_id)?;
+            let retrieve_cfg = {
+                let mut c = retrieve_cfg.clone();
+                c.bm25 = open_bm25(&rag_cfg, &meta, kb_name);
+                c
+            };
             let infer_url = inference_url
                 .clone()
                 .unwrap_or_else(|| rag_cfg.inference_url.clone());
@@ -1532,6 +1540,7 @@ async fn cmd_chat(
             query_classify: kwaai_rag::query_understand::ClassifyMethod::Rule,
             query_multi_hop: false,
             use_summary_expansion: false,
+            bm25: open_bm25(&rag_cfg, &meta, &kb),
         };
 
         let http = reqwest::Client::new();
@@ -1846,6 +1855,12 @@ async fn cmd_delete_doc(name: String, yes: bool, kb: String) -> Result<()> {
             return Ok(());
         }
 
+        // Best-effort: on failure the count drift makes the next
+        // open_backfilled rebuild the index without the deleted doc.
+        if let Ok(idx) = BM25Index::open(&rag_cfg.data_dir(), tenant_id) {
+            let _ = idx.delete_doc(&name);
+        }
+
         match rag_cfg.storage_url.as_deref() {
             Some("local") => {
                 let vs = open_local_vs(&rag_cfg.data_dir())?;
@@ -1874,6 +1889,23 @@ async fn cmd_delete_doc(name: String, yes: bool, kb: String) -> Result<()> {
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Open the KB's persistent BM25 index, backfilling if it has drifted from
+/// the metadata store.
+///
+/// Best-effort by design: `None` (e.g. another process holds the tantivy
+/// writer lock) makes ingest skip index maintenance and retrieval fall back
+/// to a transient in-RAM build — slower, never wrong, and the next
+/// successful open rebuilds from the authoritative metadata store.
+fn open_bm25(rag_cfg: &RagConfig, meta: &MetaStore, label: &str) -> Option<Arc<BM25Index>> {
+    match BM25Index::open_backfilled(&rag_cfg.data_dir(), meta) {
+        Ok(idx) => Some(Arc::new(idx)),
+        Err(e) => {
+            tracing::warn!("BM25 index unavailable for {label} ({e:#}); using in-RAM fallback");
+            None
+        }
+    }
+}
 
 fn load_rag_config_for(kb: &str) -> Result<(RagConfig, Uuid)> {
     let cfg = KwaaiNetConfig::load_or_create()?;
@@ -2560,6 +2592,7 @@ async fn run_sync_pass(
 
     let (rag_cfg, tenant_id) = load_rag_config_for(kb)?;
     let meta = MetaStore::open(&rag_cfg.data_dir(), tenant_id)?;
+    let bm25 = open_bm25(&rag_cfg, &meta, kb);
 
     // Discover all matching files under the folder.
     let mut disk_files: Vec<(String, std::path::PathBuf)> = Vec::new();
@@ -2604,6 +2637,9 @@ async fn run_sync_pass(
                 sync_delete_vectors(&rag_cfg, tenant_id, old_ids).await;
             }
             meta.delete_sync_meta(doc_name)?;
+            if let Some(ref idx) = bm25 {
+                let _ = idx.delete_doc(doc_name);
+            }
         }
 
         // Ingest the file.
@@ -2620,6 +2656,7 @@ async fn run_sync_pass(
         let mut ingest_cfg = IngestConfig::new(embed);
         ingest_cfg.chunk_cfg = chunk_cfg.clone();
         ingest_cfg.doc_meta = doc_meta.clone();
+        ingest_cfg.bm25 = bm25.clone();
 
         if extract_entities {
             let infer_url = inference_url
@@ -2750,6 +2787,9 @@ async fn run_sync_pass(
             meta.delete_sync_meta(&doc_name)?;
             if !old_ids.is_empty() {
                 sync_delete_vectors(&rag_cfg, tenant_id, old_ids).await;
+            }
+            if let Some(ref idx) = bm25 {
+                let _ = idx.delete_doc(&doc_name);
             }
             println!("  - deleted  '{}' (source: {})", doc_name, sync.file_path);
             result.deleted += 1;
@@ -7894,6 +7934,7 @@ async fn cmd_eval(
             query_classify: parse_classify_method(&query_classify),
             query_multi_hop: false,
             use_summary_expansion: summary_expansion,
+            bm25: open_bm25(&rag_cfg, &meta, &kb),
         };
 
         // Load document context preamble from persisted schema metadata (if any).

--- a/core/crates/kwaai-rag/src/bm25.rs
+++ b/core/crates/kwaai-rag/src/bm25.rs
@@ -33,6 +33,14 @@ pub struct BM25Index {
     body_field: Field,
 }
 
+// Hand-written because tantivy's Index isn't Debug, and RetrieveConfig
+// (which now carries an optional Arc<BM25Index>) derives it.
+impl std::fmt::Debug for BM25Index {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BM25Index").finish_non_exhaustive()
+    }
+}
+
 impl BM25Index {
     /// Build a transient in-RAM index from chunks. No disk persistence.
     /// Used for single-shot CLI queries where per-query rebuild is acceptable.
@@ -54,9 +62,12 @@ impl BM25Index {
         Ok(this)
     }
 
-    /// Open (or create) the tantivy index at `data_dir/tantivy/`.
-    pub fn open(data_dir: &Path) -> Result<Self> {
-        let index_dir = data_dir.join("tantivy");
+    /// Open (or create) the tantivy index at `data_dir/tantivy/<tenant>/`.
+    ///
+    /// Scoped per tenant because every KB shares one `data_dir` — a single
+    /// index would leak chunks across knowledge bases at search time.
+    pub fn open(data_dir: &Path, tenant_id: uuid::Uuid) -> Result<Self> {
+        let index_dir = data_dir.join("tantivy").join(tenant_id.to_string());
         std::fs::create_dir_all(&index_dir)?;
 
         let schema = Self::build_schema();
@@ -80,6 +91,38 @@ impl BM25Index {
             title_field,
             body_field,
         })
+    }
+
+    /// Open the persistent index, rebuilding from the metadata store when
+    /// the two disagree.
+    ///
+    /// Drift happens when chunks were ingested by a binary that predates
+    /// persistent-index maintenance, or when a best-effort index write
+    /// failed mid-ingest. Comparing counts is cheap and catches both, at
+    /// the cost of a one-off full rebuild the first time a stale KB is
+    /// opened.
+    pub fn open_backfilled(data_dir: &Path, meta: &crate::meta_store::MetaStore) -> Result<Self> {
+        let idx = Self::open(data_dir, meta.tenant_id())?;
+        if idx.num_docs() as usize != meta.chunk_count()? {
+            let all = meta.all_chunks()?;
+            let triples: Vec<(i64, &str, &str)> = all
+                .iter()
+                .map(|(id, cm)| (*id, cm.doc_name.as_str(), cm.text.as_str()))
+                .collect();
+            idx.build_from_chunks(&triples)?;
+        }
+        Ok(idx)
+    }
+
+    /// Number of documents (chunks) currently searchable. 0 when the
+    /// reader cannot be opened, which callers treat the same as empty.
+    pub fn num_docs(&self) -> u64 {
+        self.index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::OnCommitWithDelay)
+            .try_into()
+            .map(|r: tantivy::IndexReader| r.searcher().num_docs())
+            .unwrap_or(0)
     }
 
     fn build_schema() -> Schema {
@@ -256,7 +299,7 @@ mod tests {
 
     fn make_index() -> (TempDir, BM25Index) {
         let dir = TempDir::new().unwrap();
-        let idx = BM25Index::open(dir.path()).unwrap();
+        let idx = BM25Index::open(dir.path(), uuid::Uuid::new_v4()).unwrap();
         (dir, idx)
     }
 
@@ -308,6 +351,54 @@ mod tests {
         let res = idx.search("apartheid", 5);
         // doc_b deleted — should no longer appear
         assert!(res.is_empty() || res.iter().all(|(id, _)| *id != 11));
+    }
+
+    #[test]
+    fn open_backfilled_rebuilds_on_drift() {
+        use crate::meta_store::{ChunkMeta, MetaStore};
+        let dir = TempDir::new().unwrap();
+        let tenant = uuid::Uuid::new_v4();
+        let meta = MetaStore::open(dir.path(), tenant).unwrap();
+        let cm = ChunkMeta {
+            doc_name: "doc_a.txt".into(),
+            chunk_index: 0,
+            text: "apartheid segregation history".into(),
+            surrounding: String::new(),
+            page_num: None,
+            ingested_at: MetaStore::now_rfc3339(),
+            section_name: None,
+            skip_extraction: false,
+            section_note: None,
+            section_type: Default::default(),
+        };
+        meta.put_chunks(std::slice::from_ref(&cm), &[1]).unwrap();
+
+        // Chunks exist but the index was never maintained — open must
+        // detect the drift and rebuild from the metadata store.
+        let idx = BM25Index::open_backfilled(dir.path(), &meta).unwrap();
+        assert_eq!(idx.num_docs(), 1);
+        assert!(!idx.search("apartheid", 5).is_empty());
+
+        // A second open finds the counts in agreement and keeps the index.
+        let idx2 = BM25Index::open_backfilled(dir.path(), &meta).unwrap();
+        assert_eq!(idx2.num_docs(), 1);
+        assert!(!idx2.search("segregation", 5).is_empty());
+    }
+
+    #[test]
+    fn tenant_scoped_indexes_do_not_mix() {
+        use crate::meta_store::MetaStore;
+        let dir = TempDir::new().unwrap();
+        let (t1, t2) = (uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+        let idx1 = BM25Index::open(dir.path(), t1).unwrap();
+        idx1.add_chunks(&[(1, "a.txt", "cricket bat wicket")])
+            .unwrap();
+
+        // A different tenant in the same data dir sees an empty index.
+        let meta2 = MetaStore::open(dir.path(), t2).unwrap();
+        let idx2 = BM25Index::open_backfilled(dir.path(), &meta2).unwrap();
+        assert_eq!(idx2.num_docs(), 0);
+        assert!(idx2.search("cricket", 5).is_empty());
     }
 
     #[test]

--- a/core/crates/kwaai-rag/src/ingestion.rs
+++ b/core/crates/kwaai-rag/src/ingestion.rs
@@ -116,6 +116,14 @@ pub struct IngestConfig {
     pub doc_meta: HashMap<String, String>,
     /// Optional document schema — controls section tagging, skip flags, and narrator overrides.
     pub doc_schema: Option<DocSchema>,
+    /// Persistent BM25 index to keep in sync with the metadata store.
+    ///
+    /// When set, newly ingested chunks are added incrementally so hybrid
+    /// retrieval never has to rebuild the keyword index from the full
+    /// corpus. Maintenance is best-effort: a failed index write is logged
+    /// and ingest continues, because `BM25Index::open_backfilled` detects
+    /// the resulting count drift and rebuilds on the next query.
+    pub bm25: Option<std::sync::Arc<crate::bm25::BM25Index>>,
 }
 
 impl IngestConfig {
@@ -127,6 +135,7 @@ impl IngestConfig {
             graph: None,
             doc_meta: HashMap::new(),
             doc_schema: None,
+            bm25: None,
         }
     }
 }
@@ -210,6 +219,19 @@ pub async fn ingest_text(
     }
 
     meta.put_chunks(&metas, &ids)?;
+
+    if let Some(ref bm25) = cfg.bm25 {
+        let triples: Vec<(i64, &str, &str)> = metas
+            .iter()
+            .zip(ids.iter())
+            .map(|(m, id)| (*id, m.doc_name.as_str(), m.text.as_str()))
+            .collect();
+        if let Err(e) = bm25.add_chunks(&triples) {
+            // Best-effort: a busy tantivy writer lock (e.g. a concurrent
+            // ingest in another process) must not fail the ingest itself.
+            warn!(error = %e, doc = doc_name, "BM25 index update failed; will rebuild on next query");
+        }
+    }
 
     // Optional: extract entities from each chunk and populate the knowledge graph.
     if let Some(graph_cfg) = &cfg.graph {

--- a/core/crates/kwaai-rag/src/iterative.rs
+++ b/core/crates/kwaai-rag/src/iterative.rs
@@ -127,12 +127,21 @@ where
 {
     let candidate_k = cfg.top_k * 4;
 
-    let all = meta.all_chunks()?;
-    let triples: Vec<(i64, &str, &str)> = all
-        .iter()
-        .map(|(id, cm)| (*id, cm.doc_name.as_str(), cm.text.as_str()))
-        .collect();
-    let bm25 = BM25Index::build_in_ram(&triples)?;
+    // Keyword index: the caller's persistent index when provided, else a
+    // transient rebuild — same choice as `retrieve_hybrid`.
+    let built;
+    let bm25: &BM25Index = match cfg.bm25 {
+        Some(ref idx) => idx,
+        None => {
+            let all = meta.all_chunks()?;
+            let triples: Vec<(i64, &str, &str)> = all
+                .iter()
+                .map(|(id, cm)| (*id, cm.doc_name.as_str(), cm.text.as_str()))
+                .collect();
+            built = BM25Index::build_in_ram(&triples)?;
+            &built
+        }
+    };
 
     // ── Round 1: vector+graph fusion ──────────────────────────────────────────
 

--- a/core/crates/kwaai-rag/src/meta_store.rs
+++ b/core/crates/kwaai-rag/src/meta_store.rs
@@ -201,6 +201,37 @@ impl MetaStore {
         Ok(out)
     }
 
+    /// Tenant this store is scoped to.
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    /// Number of chunks stored for this tenant.
+    ///
+    /// A COUNT over the key range — cheap even for large corpora, unlike
+    /// `all_chunks` which deserialises every chunk body. Used to detect
+    /// BM25 index drift without paying for a full load.
+    pub fn chunk_count(&self) -> Result<usize> {
+        let prefix = self.tenant_id.as_bytes();
+        let start: [u8; 24] = {
+            let mut k = [0u8; 24];
+            k[..16].copy_from_slice(prefix);
+            k
+        };
+        let end: [u8; 24] = {
+            let mut k = [0xffu8; 24];
+            k[..16].copy_from_slice(prefix);
+            k
+        };
+        let db = self.db();
+        let n: i64 = db.0.query_row(
+            "SELECT COUNT(*) FROM chunks WHERE key >= ?1 AND key <= ?2",
+            params![start.as_ref(), end.as_ref()],
+            |r| r.get(0),
+        )?;
+        Ok(n as usize)
+    }
+
     pub fn list_docs(&self) -> Result<Vec<String>> {
         let prefix = self.tenant_id.as_bytes();
         let start: Vec<u8> = prefix.to_vec();

--- a/core/crates/kwaai-rag/src/retriever.rs
+++ b/core/crates/kwaai-rag/src/retriever.rs
@@ -97,6 +97,14 @@ pub struct RetrieveConfig {
     /// When true, run Round 2.5: cosine-search over HiRAG summary nodes and
     /// expand matched summaries to their child chunks.
     pub use_summary_expansion: bool,
+    /// Prebuilt BM25 index for the keyword half of hybrid retrieval.
+    ///
+    /// When `None`, each call loads every chunk from the metadata store and
+    /// builds a transient in-RAM index — O(corpus) per query, acceptable
+    /// only for one-shot CLI use. Long-lived callers should pass
+    /// `BM25Index::open_backfilled` so queries search the persistent index
+    /// instead.
+    pub bm25: Option<std::sync::Arc<crate::bm25::BM25Index>>,
 }
 
 impl Default for RetrieveConfig {
@@ -112,6 +120,7 @@ impl Default for RetrieveConfig {
             query_classify: crate::query_understand::ClassifyMethod::Rule,
             query_multi_hop: false,
             use_summary_expansion: false,
+            bm25: None,
         }
     }
 }
@@ -140,13 +149,22 @@ pub async fn retrieve_hybrid(
     meta: &MetaStore,
     search_fn: impl Fn(Vec<f32>, usize) -> Pin<Box<dyn Future<Output = Result<Vec<(i64, f64)>>> + Send>>,
 ) -> Result<Vec<RetrievedChunk>> {
-    // Build BM25 index from all stored chunks (including doc name for title-word discrimination).
-    let all = meta.all_chunks()?;
-    let triples: Vec<(i64, &str, &str)> = all
-        .iter()
-        .map(|(id, cm)| (*id, cm.doc_name.as_str(), cm.text.as_str()))
-        .collect();
-    let bm25 = BM25Index::build_in_ram(&triples)?;
+    // Keyword index: the caller's persistent index when provided, else a
+    // transient rebuild from all stored chunks (including doc name for
+    // title-word discrimination).
+    let built;
+    let bm25: &BM25Index = match cfg.bm25 {
+        Some(ref idx) => idx,
+        None => {
+            let all = meta.all_chunks()?;
+            let triples: Vec<(i64, &str, &str)> = all
+                .iter()
+                .map(|(id, cm)| (*id, cm.doc_name.as_str(), cm.text.as_str()))
+                .collect();
+            built = BM25Index::build_in_ram(&triples)?;
+            &built
+        }
+    };
 
     let candidate_k = cfg.top_k * 4;
 
@@ -302,13 +320,21 @@ pub async fn retrieve_graph_anchored(
             .collect()
     };
 
-    // 5. Hybrid vector+BM25 retrieval.
-    let all = meta.all_chunks()?;
-    let triples: Vec<(i64, &str, &str)> = all
-        .iter()
-        .map(|(id, cm)| (*id, cm.doc_name.as_str(), cm.text.as_str()))
-        .collect();
-    let bm25 = BM25Index::build_in_ram(&triples)?;
+    // 5. Hybrid vector+BM25 retrieval. Same index-or-rebuild choice as
+    // `retrieve_hybrid`.
+    let built;
+    let bm25: &BM25Index = match cfg.bm25 {
+        Some(ref idx) => idx,
+        None => {
+            let all = meta.all_chunks()?;
+            let triples: Vec<(i64, &str, &str)> = all
+                .iter()
+                .map(|(id, cm)| (*id, cm.doc_name.as_str(), cm.text.as_str()))
+                .collect();
+            built = BM25Index::build_in_ram(&triples)?;
+            &built
+        }
+    };
     let semantic_raw = search_fn(embedding, candidate_k).await?;
     let keyword_raw = bm25.search(query, candidate_k);
     let vector_chunks = rrf_merge(&semantic_raw, &keyword_raw, candidate_k);

--- a/core/crates/kwaai-rag/tests/pipeline.rs
+++ b/core/crates/kwaai-rag/tests/pipeline.rs
@@ -117,7 +117,7 @@ fn pipeline_delete_doc_removes_from_meta_store() {
 #[test]
 fn pipeline_bm25_indexes_chunk_text_and_returns_hit() {
     let dir = TempDir::new().unwrap();
-    let index = BM25Index::open(dir.path()).unwrap();
+    let index = BM25Index::open(dir.path(), uuid::Uuid::new_v4()).unwrap();
 
     let text = "District Six was a vibrant community in Cape Town before forced removals.";
     let chunks = split_text(text, "d6.txt", &default_cfg(), None);
@@ -143,7 +143,7 @@ fn pipeline_bm25_indexes_chunk_text_and_returns_hit() {
 #[test]
 fn pipeline_bm25_search_miss_for_absent_term() {
     let dir = TempDir::new().unwrap();
-    let index = BM25Index::open(dir.path()).unwrap();
+    let index = BM25Index::open(dir.path(), uuid::Uuid::new_v4()).unwrap();
 
     let text = "Alice went to the park and fed the ducks by the pond.";
     let chunks = split_text(text, "park.txt", &default_cfg(), None);
@@ -164,7 +164,7 @@ fn pipeline_bm25_search_miss_for_absent_term() {
 #[test]
 fn pipeline_bm25_delete_doc_removes_from_index() {
     let dir = TempDir::new().unwrap();
-    let index = BM25Index::open(dir.path()).unwrap();
+    let index = BM25Index::open(dir.path(), uuid::Uuid::new_v4()).unwrap();
 
     let text = "Walied Rassool was born in Cape Town and attended local schools.";
     let chunks = split_text(text, "walied.txt", &default_cfg(), None);

--- a/core/crates/kwaai-rag/tests/suite.rs
+++ b/core/crates/kwaai-rag/tests/suite.rs
@@ -145,7 +145,7 @@ fn bm25_special_chars_in_query_handled() {
 #[test]
 fn bm25_persistent_open_and_delete() {
     let dir = TempDir::new().unwrap();
-    let idx = BM25Index::open(dir.path()).unwrap();
+    let idx = BM25Index::open(dir.path(), uuid::Uuid::new_v4()).unwrap();
     let chunks = vec![
         (10i64, "doc_a.txt", "hello world foo bar"),
         (11i64, "doc_b.txt", "apartheid segregation history"),
@@ -161,7 +161,7 @@ fn bm25_persistent_open_and_delete() {
 #[test]
 fn bm25_rebuild_is_idempotent() {
     let dir = TempDir::new().unwrap();
-    let idx = BM25Index::open(dir.path()).unwrap();
+    let idx = BM25Index::open(dir.path(), uuid::Uuid::new_v4()).unwrap();
     let chunks = vec![(1i64, "doc.txt", "cape town district history")];
     idx.build_from_chunks(&chunks).unwrap();
     // Second rebuild should clear old docs and re-add


### PR DESCRIPTION
## Problem

`retrieve_hybrid` — and the graph-anchored and iterative variants — rebuilt the BM25 keyword index in RAM from every stored chunk on every query. That is O(corpus) work per query, which costs tens of seconds on a 2,800-chunk knowledge base.

A persistent tantivy index at `data_dir/tantivy/` already existed, with incremental add/delete support. Nothing ever wrote to or read from it.

## Change

Wires the existing persistent index up end to end.

**`kwaai-rag`**
- `BM25Index::open` is now tenant-scoped (`data_dir/tantivy/<tenant>/`). Knowledge bases can share a data dir, and a shared index would leak chunks across KBs.
- `BM25Index::open_backfilled` compares the index doc count against the new `MetaStore::chunk_count` and rebuilds from the metadata store on drift. This self-heals KBs ingested before this change, and any KB left inconsistent by a failed best-effort write.
- `IngestConfig` / `RetrieveConfig` gain an optional `Arc<BM25Index>`. Ingest adds new chunks incrementally; retrieval searches the prebuilt index and skips the full-corpus load entirely. Passing `None` preserves the previous in-RAM behaviour for one-shot callers, so this is additive for existing library users.

**`kwaai-cli`**
- `ingest` / `query` / `chat` / `eval` / `sync` and the HTTP API open the index once and pass it through; delete paths prune it alongside the metadata.

## Notes for review

Two deliberate trade-offs worth a look:

- **Ingest writes are best-effort.** A busy tantivy writer lock warns and lets the index drift rather than failing the ingest. The rationale is that a dropped keyword-index write should not lose a user's ingested document, and `open_backfilled` repairs the drift on next open. If you would rather ingest fail loudly, that is a one-line change.
- **Backfill triggers on doc-count drift alone**, not a content hash. Cheap to check on every open, but it will not detect a same-count divergence. That seemed an acceptable bound for a keyword index that is already a recall aid rather than a source of truth.

## Testing

- `cargo test -p kwaai-rag` — 210 passed, 0 failed.
- `cargo check -p kwaai-cli --features storage,rag` — clean.
- `cargo fmt --check -p kwaai-rag` — clean.

The performance claim above is from the originating profile on a 2,800-chunk KB; I have not re-run a formal before/after benchmark as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
