### PR TITLE
build: fall back to sha256sum when shasum is absent

### DIFF
--- a/core/patches/fetch-multistream-select.sh
+++ b/core/patches/fetch-multistream-select.sh
@@ -9,23 +9,28 @@ set -euo pipefail
 
 # SHA-256 front end. Stock macOS ships `shasum` (a perl script) but not
 # `sha256sum`; most Linux images ship `sha256sum` and usually, but not always,
-# `shasum`. Git Bash on a Windows runner is the case that motivated this: it is
-# reached through `run: bash …` in release.yml, and that path only executes on a
-# tag push, so a missing tool would surface for the first time during a release
-# rather than in any PR check. Prefer `shasum` (unchanged behaviour where it
-# exists), fall back to `sha256sum`, and fail with a readable message rather
-# than a bare "command not found" if neither is there.
+# `shasum`. Git Bash on a Windows runner reaches this script through
+# `run: bash …` in release.yml, and that path runs only on a tag push — so a
+# hashing problem there would surface during a release rather than in any PR
+# check. Rather than establish which tool every host has, use whichever works.
+#
+# Probed by running them, not by `command -v`: `shasum` is a perl script, so it
+# can exist on PATH and still fail (a Git Bash with a broken or absent perl is
+# exactly that shape). Existence is not usability, and picking a present-but-
+# broken tool would skip a working fallback — verified against a stub `shasum`
+# that exits 2 with a perl error.
 #
 # Both accept the same `HASH  FILE` input in `-c` mode, so one shim covers the
 # stamp calculation and the crate verification alike.
-if command -v shasum >/dev/null 2>&1; then
+if echo | shasum -a 256 >/dev/null 2>&1; then
     sha256() { shasum -a 256 "$@"; }
-elif command -v sha256sum >/dev/null 2>&1; then
+elif echo | sha256sum >/dev/null 2>&1; then
     sha256() { sha256sum "$@"; }
 else
-    echo "error: need 'shasum' or 'sha256sum' on PATH to verify the download" >&2
-    echo "       (macOS: shasum ships with perl; Debian/Ubuntu: coreutils;" >&2
-    echo "        Windows: use Git Bash, which provides both)" >&2
+    echo "error: need a working 'shasum' or 'sha256sum' to verify the download" >&2
+    echo "       (macOS: shasum, via perl; Debian/Ubuntu: coreutils;" >&2
+    echo "        Windows: Git Bash — if shasum is present but failing, perl is" >&2
+    echo "        the usual cause)" >&2
     exit 1
 fi
 

--- a/core/patches/fetch-multistream-select.sh
+++ b/core/patches/fetch-multistream-select.sh
@@ -7,6 +7,28 @@
 # Idempotent: re-runs are no-ops unless the patch file changed.
 set -euo pipefail
 
+# SHA-256 front end. Stock macOS ships `shasum` (a perl script) but not
+# `sha256sum`; most Linux images ship `sha256sum` and usually, but not always,
+# `shasum`. Git Bash on a Windows runner is the case that motivated this: it is
+# reached through `run: bash …` in release.yml, and that path only executes on a
+# tag push, so a missing tool would surface for the first time during a release
+# rather than in any PR check. Prefer `shasum` (unchanged behaviour where it
+# exists), fall back to `sha256sum`, and fail with a readable message rather
+# than a bare "command not found" if neither is there.
+#
+# Both accept the same `HASH  FILE` input in `-c` mode, so one shim covers the
+# stamp calculation and the crate verification alike.
+if command -v shasum >/dev/null 2>&1; then
+    sha256() { shasum -a 256 "$@"; }
+elif command -v sha256sum >/dev/null 2>&1; then
+    sha256() { sha256sum "$@"; }
+else
+    echo "error: need 'shasum' or 'sha256sum' on PATH to verify the download" >&2
+    echo "       (macOS: shasum ships with perl; Debian/Ubuntu: coreutils;" >&2
+    echo "        Windows: use Git Bash, which provides both)" >&2
+    exit 1
+fi
+
 VERSION=0.13.0
 SHA256=ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -14,7 +36,7 @@ DEST="$DIR/multistream-select"
 PATCH="$DIR/multistream-select.patch"
 STAMP="$DEST/.kwaai-patch-stamp"
 
-want_stamp="$VERSION $(shasum -a 256 "$PATCH" | cut -d' ' -f1)"
+want_stamp="$VERSION $(sha256 "$PATCH" | cut -d' ' -f1)"
 if [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$want_stamp" ]; then
     exit 0
 fi
@@ -26,7 +48,7 @@ trap 'rm -rf "$tmp"' EXIT
 crate="$tmp/ms.crate"
 curl -fsSL -o "$crate" \
     "https://static.crates.io/crates/multistream-select/multistream-select-$VERSION.crate"
-echo "$SHA256  $crate" | shasum -a 256 -c - >/dev/null
+echo "$SHA256  $crate" | sha256 -c - >/dev/null
 
 tar -xzf "$crate" -C "$tmp"
 rm -rf "$DEST"


### PR DESCRIPTION
Follow-up to #91 — the portability item I flagged when approving it, closed before the next release tag.

## The problem

`core/patches/fetch-multistream-select.sh` hashes with `shasum -a 256`, and its **first action, before any download**, is hashing the patch file for the idempotency stamp. A host without `shasum` fails immediately, on every build.

That host is plausibly Windows. `release.yml` builds Windows targets and reaches this script via `run: bash …` (Git Bash). Nothing has ever exercised it: **release build jobs skip on PRs and run only on tag push**, so a missing tool surfaces for the first time *during a release*, not in any PR check.

This repo's own workflows hash with `sha256sum` (`release.yml:524`, `release-riscv.yml:51`) — so #91 introduced a second, unproven tool into a path that includes Windows.

## Why a fallback, not a swap

Neither tool is universal:

| platform | `shasum` | `sha256sum` |
|---|---|---|
| stock macOS | ✅ (perl) | ❌ |
| typical Linux | usually | ✅ |
| Git Bash | usually | ✅ |

So preferring either one alone breaks somebody. The shim prefers `shasum` (behaviour unchanged everywhere it already works), falls back to `sha256sum`, and otherwise exits with a message naming both instead of a bare `command not found`. Both accept the same `HASH  FILE` input in `-c` mode, so one shim covers the stamp calculation and the crate verification alike.

## Testing

All three branches, not just the happy path — an untested fallback is precisely the failure mode being fixed:

| # | scenario | result |
|---|---|---|
| 1 | `shasum` present | fetches, patches, `KWAAI PATCH` present in source |
| 2 | re-run | no-op, exit 0 (stamp honoured) |
| 3 | **`shasum` hidden from PATH** | `sha256sum` fallback produces the same patched source |
| 4 | neither tool present | readable error, exit 1 |
| 5 | deliberately wrong `SHA256` | download rejected, no source tree left behind |

Worth noting on (3): my first attempt at that test was **invalid** — macOS's `/usr/bin/shasum` leaked back in through PATH, so the "fallback" never actually ran. Redone with `env -i PATH=…` against an isolated bin directory, and verified `shasum` was genuinely unreachable before trusting the result.

(5) matters because the shim sits directly in the integrity check; it confirms a tampered download is still rejected.

Workspace builds against the resulting tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BWbNeuVt2DX71FRGEtSeA