### PR TITLE
fix(test): supply lease_v1 in the block-coverage test fixture

### DIFF
--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1467,6 +1467,7 @@ mod tests {
             public_name: "peer".into(),
             throughput: 1.0,
             trust_score: None,
+            lease_v1: false,
         };
 
         // Gap at block 3: [0,3) + [4,8).


### PR DESCRIPTION
`main` does not currently compile its own test targets. `cargo build` and `cargo check` pass, so this is invisible locally, but `cargo test` and `cargo clippy --all-targets` fail on `main` itself and on every branch cut from it:

```
error[E0063]: missing field `lease_v1` in initializer of `shard_cmd::BlockServerEntry`
  --> crates/kwaai-cli/src/grpc_server.rs:1463:34
```

Reproduced on a pristine worktree at `2c4572ed` with nothing else applied.

## How it got there

Neither PR involved is at fault, and neither could have caught it alone.

- **#85** added `lease_v1` to `BlockServerEntry` (`c2aa3f72`, Aug 5).
- **#75** added `coverage_update_counts_blocks_and_clamps_ranges`, which builds that struct as a literal. It was branched before the field existed.

The two touch different files, so they never conflicted textually. Both went green on their own PRs. The break appeared only once `c18b19ec` (#75) was squash-merged on top of `ffd21244` (#85) — a semantic conflict that per-PR CI structurally cannot see, because neither branch ever compiled the other's code.

## The fix

Two lines, in the one place that still needs them. `false` rather than a real value because this test covers block-coverage bitmap math and lease admission does not participate in it. I checked the other five `BlockServerEntry` construction sites (`rebalancer.rs:143`, `shard_cmd.rs:2321/2408/2589`) — all already supply the field, so this is the only gap.

## Verification

On this branch, using the exact CI commands:

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy -p kwaainet -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p kwaainet` — 88 passed, 0 failed

The previously-uncompilable test passes on its merits rather than merely building:

```
test grpc_server::tests::coverage_update_counts_blocks_and_clamps_ranges ... ok
```

## Blast radius

#76 and #77 are currently red *only* because of this — both inherit it from `main` and neither touches `BlockServerEntry`. They should go green on a re-run once this lands; no changes needed in either.

#86 already carries an equivalent two-line fix, added while chasing its own CI failure before the main-side cause was identified. Once this merges, that copy becomes redundant — it will either drop out cleanly on rebase or resolve as a trivial conflict.

#94 and #96 are green today only because they have not been rebased onto the broken tip yet.

## Worth a follow-up

This class of failure will recur as long as `main` is not built post-merge. Two individually-green PRs merging into a red `main` is invisible to per-PR CI by construction. A required post-merge job on `main`, or requiring branches to be current before merge, would catch the next one — this is the same root cause as the stacked-pair hazard noted in #76, where GitHub could not see a relationship neither PR declared.
