### PR TITLE
chore: let the pinned toolchain supply rust-analyzer

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.93.1"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
One line. `rust-toolchain.toml` pins 1.93.1 but declared only `rustfmt` and `clippy`, so VS Code fell back to the rust-analyzer bundled with the extension — newer than the pinned compiler, and it refuses to run against it:

> Your workspace uses a rust-toolchain file with a toolchain too old for the extension shipped rust-analyzer to work properly. Consider adding the rust-analyzer component to the toolchain file to use a compatible rust-analyzer version.

Declaring the component makes rustup provide a rust-analyzer built from the same 1.93.1 tree, which is the fix the extension itself suggests. Anyone cloning the repo gets a working editor without touching their own settings.

Verified locally — `rustup run 1.93.1 rust-analyzer --version` now reports `rust-analyzer 1.93.1 (01f6ddf7 2026-02-11)`, matching the pinned compiler.

**One cost worth naming:** the toolchain file governs CI too, so each job pulls one extra component. Small, and paid once per job against a warning every contributor would otherwise hit. If that trade is not wanted, the alternative is setting `rust-analyzer.server.path` in `.vscode/settings.json`, which fixes it locally without touching CI — happy to switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8tRHgpzGxZWe7yVjRrgfu