### PR TITLE
fix(tests): stop the gRPC lifecycle tests fighting the real daemon, clear clippy

### DIFF
--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1430,6 +1430,16 @@ fn unix_socket_path() -> PathBuf {
 /// running even if the IPC surface didn't come up (the node still serves
 /// p2p traffic).
 pub fn spawn(config: KwaaiNetConfig) -> GrpcServerHandle {
+    spawn_on_tcp_port(config, DEFAULT_GRPC_TCP_PORT)
+}
+
+/// As [`spawn`], but binds TCP on an explicit port.
+///
+/// Exists so tests can take an ephemeral port instead of the well-known one.
+/// Binding the real port made the lifecycle tests fail on any machine with a
+/// node already running — the listener they were asserting had closed was the
+/// daemon's, not theirs.
+pub(crate) fn spawn_on_tcp_port(config: KwaaiNetConfig, tcp_port: u16) -> GrpcServerHandle {
     let (shutdown_tcp_tx, shutdown_tcp_rx) = oneshot::channel::<()>();
     #[cfg(unix)]
     let (shutdown_unix_tx, shutdown_unix_rx) = oneshot::channel::<()>();
@@ -1438,7 +1448,7 @@ pub fn spawn(config: KwaaiNetConfig) -> GrpcServerHandle {
     let service = KwaaiNetServer::new(svc_state);
 
     // TCP: every platform.
-    let tcp_addr: std::net::SocketAddr = format!("127.0.0.1:{DEFAULT_GRPC_TCP_PORT}")
+    let tcp_addr: std::net::SocketAddr = format!("127.0.0.1:{tcp_port}")
         .parse()
         .expect("valid loopback addr");
     let tcp_service = service.clone();
@@ -1632,22 +1642,36 @@ mod tests {
         }
     }
 
-    /// True iff a fresh TCP connect to the gRPC loopback port succeeds.
-    async fn tcp_accepting() -> bool {
-        tokio::net::TcpStream::connect(("127.0.0.1", DEFAULT_GRPC_TCP_PORT))
+    /// Ask the OS for a free loopback port.
+    ///
+    /// The listener is dropped before the value is returned, so there is a
+    /// small window where something else could claim it. That is still far
+    /// safer than the well-known port, which a running `kwaainet run-node`
+    /// holds for the life of the machine.
+    fn ephemeral_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("bind ephemeral loopback port")
+            .local_addr()
+            .expect("read ephemeral local addr")
+            .port()
+    }
+
+    /// True iff a fresh TCP connect to `port` succeeds.
+    async fn tcp_accepting(port: u16) -> bool {
+        tokio::net::TcpStream::connect(("127.0.0.1", port))
             .await
             .is_ok()
     }
 
-    /// True iff a fresh TCP connect to the gRPC loopback port is refused
-    /// quickly (used to assert the listener is gone after shutdown).
-    async fn tcp_refused() -> bool {
+    /// True iff a fresh TCP connect to `port` is refused quickly (used to
+    /// assert the listener is gone after shutdown).
+    async fn tcp_refused(port: u16) -> bool {
         // ConnectionRefused is the happy-path answer; any other Err (e.g.
         // network unreachable) we also treat as "not accepting". We bound
         // the dial with a short timeout so a slow stack can't lie to us.
         match tokio::time::timeout(
             Duration::from_millis(250),
-            tokio::net::TcpStream::connect(("127.0.0.1", DEFAULT_GRPC_TCP_PORT)),
+            tokio::net::TcpStream::connect(("127.0.0.1", port)),
         )
         .await
         {
@@ -1673,16 +1697,13 @@ mod tests {
         let _env = EnvGuard::set(tmp.path());
 
         let config = KwaaiNetConfig::default();
-        let handle = spawn(config);
+        let port = ephemeral_port();
+        let handle = spawn_on_tcp_port(config, port);
 
         // The server task is spawned on tokio; give it up to ~2 s to wire
         // up the TCP listener. In practice this happens in <50 ms locally.
-        let up = wait_for(Duration::from_secs(2), tcp_accepting).await;
-        assert!(
-            up,
-            "gRPC TCP listener never came up on 127.0.0.1:{}",
-            DEFAULT_GRPC_TCP_PORT
-        );
+        let up = wait_for(Duration::from_secs(2), || tcp_accepting(port)).await;
+        assert!(up, "gRPC TCP listener never came up on 127.0.0.1:{port}");
 
         #[cfg(unix)]
         {
@@ -1719,11 +1740,10 @@ mod tests {
         // tonic's serve_with_shutdown returns -> listener is closed.
         drop(handle);
 
-        let down = wait_for(Duration::from_secs(2), tcp_refused).await;
+        let down = wait_for(Duration::from_secs(2), || tcp_refused(port)).await;
         assert!(
             down,
-            "TCP listener on 127.0.0.1:{} did not close within 2s of dropping the handle",
-            DEFAULT_GRPC_TCP_PORT
+            "TCP listener on 127.0.0.1:{port} did not close within 2s of dropping the handle"
         );
 
         #[cfg(unix)]
@@ -1766,13 +1786,14 @@ mod tests {
         let tmp = tempfile::tempdir().expect("create tempdir for fake HOME");
         let _env = EnvGuard::set(tmp.path());
 
-        let handle = spawn(KwaaiNetConfig::default());
+        let port = ephemeral_port();
+        let handle = spawn_on_tcp_port(KwaaiNetConfig::default(), port);
 
         // Make sure the server is accepting before we dial.
-        let up = wait_for(Duration::from_secs(2), tcp_accepting).await;
+        let up = wait_for(Duration::from_secs(2), || tcp_accepting(port)).await;
         assert!(up, "gRPC TCP listener never came up");
 
-        let endpoint = format!("http://127.0.0.1:{DEFAULT_GRPC_TCP_PORT}");
+        let endpoint = format!("http://127.0.0.1:{port}");
         let channel = tonic::transport::Endpoint::from_shared(endpoint)
             .expect("valid endpoint")
             .connect()
@@ -1803,7 +1824,7 @@ mod tests {
         drop(handle);
         // Wait for the listener to actually go away before the next test
         // tries to bind the same port.
-        let down = wait_for(Duration::from_secs(2), tcp_refused).await;
+        let down = wait_for(Duration::from_secs(2), || tcp_refused(port)).await;
         assert!(down, "TCP listener did not close after handle drop");
     }
 

--- a/core/crates/kwaai-distributed/src/averaging.rs
+++ b/core/crates/kwaai-distributed/src/averaging.rs
@@ -319,7 +319,9 @@ mod tests {
             &Device::Cpu,
         )
         .unwrap();
-        let compressed = averager.compress_gradients(&[g.clone()]).unwrap();
+        let compressed = averager
+            .compress_gradients(std::slice::from_ref(&g))
+            .unwrap();
         let recovered = averager.decompress_gradients(&compressed).unwrap();
         let orig: Vec<f32> = g.to_vec1().unwrap();
         let got: Vec<f32> = recovered[0].to_vec1().unwrap();

--- a/core/crates/kwaai-network-tests/src/bin/metrics_report.rs
+++ b/core/crates/kwaai-network-tests/src/bin/metrics_report.rs
@@ -51,8 +51,8 @@ fn main() -> anyhow::Result<()> {
     );
     println!();
     println!(
-        "{:<name_w$}  {:>5}  {:>6}  {:>9}  {:>8}  {}",
-        "Test", "Runs", "Pass%", "Avg(ms)", "Last(ms)", "Trend"
+        "{:<name_w$}  {:>5}  {:>6}  {:>9}  {:>8}  Trend",
+        "Test", "Runs", "Pass%", "Avg(ms)", "Last(ms)"
     );
     println!("{}", "─".repeat(name_w + 40));
 

--- a/core/crates/kwaai-network-tests/src/harness.rs
+++ b/core/crates/kwaai-network-tests/src/harness.rs
@@ -11,9 +11,9 @@
 //! - `TestNode::new_dht_client(bootstrap)` — dht, auto_relay, bootstraps from
 //!   the provided multiaddr.
 //! - `TestNode::new_nat_client(bootstrap, relay_addr)` — force_reachability_private
-//!   + auto_relay, bootstraps from `bootstrap`, uses `relay_addr` as trusted relay.
-//!   This forces the node to obtain a /p2p-circuit address, giving us a relay path
-//!   to test against.
+//!   and auto_relay, bootstraps from `bootstrap`, uses `relay_addr` as trusted
+//!   relay. This forces the node to obtain a /p2p-circuit address, giving us a
+//!   relay path to test against.
 //! - `RelayHarness::new()` — relay + two clients (one "NAT", one direct). Used by
 //!   the relay connectivity tests.
 

--- a/core/crates/kwaai-network-tests/tests/04_integration_daemon.rs
+++ b/core/crates/kwaai-network-tests/tests/04_integration_daemon.rs
@@ -223,7 +223,7 @@ async fn dht_provide_node_a_find_node_b() {
         .await;
     let find_ms = t.elapsed().as_millis() as u64;
 
-    let found = result.map_or(false, |p| p.is_some());
+    let found = result.is_ok_and(|p| p.is_some());
     rec.metric("cross_find_ms", find_ms);
     rec.metric("found", found);
     // Cross-node provider propagation may vary in small local nets

--- a/core/crates/kwaai-network-tests/tests/05_integration_relay.rs
+++ b/core/crates/kwaai-network-tests/tests/05_integration_relay.rs
@@ -240,7 +240,7 @@ async fn dht_provide_by_nat_node_findable_by_observer() {
         .await;
     let find_ms = t.elapsed().as_millis() as u64;
 
-    let found = result.map_or(false, |p| p.is_some());
+    let found = result.is_ok_and(|p| p.is_some());
     rec.metric("find_ms", find_ms);
     rec.metric("found", found);
     rec.finish(found);

--- a/core/crates/kwaai-network-tests/tests/06_network_bootstrap.rs
+++ b/core/crates/kwaai-network-tests/tests/06_network_bootstrap.rs
@@ -118,7 +118,7 @@ async fn dht_roundtrip_latency() {
         .await;
     let find_ms = t_find.elapsed().as_millis() as u64;
 
-    let found = result.map_or(false, |p| p.is_some());
+    let found = result.is_ok_and(|p| p.is_some());
     rec.metric("provide_ms", provide_ms);
     rec.metric("find_ms", find_ms);
     rec.metric("found", found);
@@ -155,7 +155,7 @@ async fn vpk_nodes_discoverable() {
         .await;
     let lookup_ms = t.elapsed().as_millis() as u64;
 
-    let found = result.map_or(false, |p| p.is_some());
+    let found = result.is_ok_and(|p| p.is_some());
     rec.metric("lookup_ms", lookup_ms);
     rec.metric("vpk_providers_found", found);
     rec.finish(true); // Not a failure if no VPK nodes online — just report

--- a/core/crates/kwaai-network-tests/tests/08_unary_swarm_interop.rs
+++ b/core/crates/kwaai-network-tests/tests/08_unary_swarm_interop.rs
@@ -161,7 +161,7 @@ async fn swarm_calls_daemon_handler() {
         .expect("register unary handler on daemon");
 
     let (daemon_id, daemon_addr) = daemon_peer(&daemon);
-    let swarm = SwarmNode::spawn(Some((daemon_id, daemon_addr)), |data| Ok(data)).await;
+    let swarm = SwarmNode::spawn(Some((daemon_id, daemon_addr)), Ok).await;
 
     let response = swarm
         .call(daemon_id, PROTO, b"from-swarm")
@@ -228,7 +228,7 @@ async fn swarm_gets_clean_refusal_from_daemon() {
         .expect("register unary handler on daemon");
 
     let (daemon_id, daemon_addr) = daemon_peer(&daemon);
-    let swarm = SwarmNode::spawn(Some((daemon_id, daemon_addr)), |data| Ok(data)).await;
+    let swarm = SwarmNode::spawn(Some((daemon_id, daemon_addr)), Ok).await;
 
     let error = swarm
         .call(daemon_id, "DHTProtocol.rpc_nonexistent", b"x")


### PR DESCRIPTION
Makes a clean checkout of `main` green on a developer machine. Everything here is pre-existing — none of it comes from #101, #102, or #104.

## The two failing tests

`server_binds_and_shuts_down_cleanly` and `chat_returns_invalid_argument_on_empty_inbound_stream` bound `DEFAULT_GRPC_TCP_PORT` — 8093, the port a running `kwaainet run-node` already holds. So the listener they asserted had closed after dropping their handle was **the daemon's, not theirs**:

```
TCP listener on 127.0.0.1:8093 did not close within 2s of dropping the handle
```

They pass in CI only because no daemon runs there. Green exactly where they are least useful, red on the machines most likely to be running the thing they test.

**Fix:** take an ephemeral port. `spawn` keeps its signature and its default; a new `spawn_on_tcp_port` lets the tests ask the OS for a free one, and the `tcp_accepting` / `tcp_refused` probes take a port instead of reading the constant.

Verified with a daemon holding 8093 the whole time — that is the condition that used to break them. They also drop **4.06s → 0.09s**, since they no longer wait out two-second timeouts against a listener that was never going to close.

## The clippy failures

`cargo clippy --workspace --all-targets -- -D warnings` failed on `main`. The lib error masked the rest, so fixing the first surfaced five more:

| Where | Lint |
|---|---|
| `harness.rs` | `doc_lazy_continuation` ×2 |
| `metrics_report.rs` | `print_literal` |
| `04/05/06_*.rs` | `unnecessary_map_or` ×4 |
| `08_unary_swarm_interop.rs` | `redundant_closure` ×2 |
| `averaging.rs` | `cloned_ref_to_slice_refs` |

The `harness.rs` one had a real cause worth noting: a continuation line starting with `+` was read as a **nested markdown list**, which made the two lines after it lazy continuations. Reworded so the phantom list stops existing, rather than indenting to satisfy the lint.

## Result

61 test binaries pass, clippy clean under `-D warnings`, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8tRHgpzGxZWe7yVjRrgfu