### PR TITLE
fix(node): stop logging every DHT RPC at INFO

### DIFF
--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -23,7 +23,7 @@ use std::{
     time::Duration,
 };
 use tokio::{io::AsyncWriteExt, net::TcpListener, signal, sync::RwLock};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::config::KwaaiNetConfig;
 use crate::daemon::{DaemonManager, ShardManager};
@@ -1883,7 +1883,11 @@ async fn handle_rpc_stream(tcp: &mut tokio::net::TcpStream, storage: SharedStora
     let info = stream::parse_stream_info(tcp)
         .await
         .map_err(|e| anyhow::anyhow!("parse stream info: {}", e))?;
-    info!("RPC {}", info.proto);
+    // Per-request, so it grows with network traffic and never stops. At INFO
+    // this was 94% of the daemon log's volume and the reason it reached 6.9 GB
+    // with no rotation to bound it. The protocol name of a routine DHT stream
+    // is debugging detail, not an event worth a permanent record.
+    debug!("RPC {}", info.proto);
 
     use prost::Message as _;
 


### PR DESCRIPTION
Found while clearing a full disk on the dev machine. `~/.kwaainet/logs/kwaainet.log` had reached **6.9 GB**.

## Cause

`handle_rpc_stream` logs the protocol name of every inbound stream at INFO:

```rust
info!("RPC {}", info.proto);
```

That is per-request, so volume grows with network traffic and never stops — and nothing rotates the daemon log. Sampling the last 20,000 lines:

| lines | source |
|---|---|
| 19,992 | `kwaainet::node` — almost entirely `RPC DHTProtocol.rpc_find` / `rpc_store` |
| 8 | everything else |

**94% of the log was routine DHT traffic.**

## Fix

Move it to DEBUG. The protocol name of a routine DHT stream is debugging detail, not an event worth a permanent record. Anyone diagnosing DHT traffic still gets it with `RUST_LOG=debug`; the default level stops paying for it.

## What this does not fix

The log still has **no rotation**, so this bounds the everyday growth rate but not the worst case — a debug-level session or a noisy failure loop can still fill a disk. Size-based rotation is the natural follow-up; I did not bundle it here to keep this a one-line, obviously-safe change.

## Note on tests

`cargo test -p kwaainet` shows two failures on this branch — `grpc_server::tests::server_binds_and_shuts_down_cleanly` and `chat_returns_invalid_argument_on_empty_inbound_stream`. They are the port-collision failures fixed by #105 and are unrelated to this change; this branch is cut from `main`, which still has them. Clippy clean under `-D warnings`, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8tRHgpzGxZWe7yVjRrgfu