### PR TITLE
perf(p2p): close the native extra round trip with V1Lazy negotiation

### DIFF
--- a/core/crates/kwaai-network-tests/tests/08_unary_swarm_interop.rs
+++ b/core/crates/kwaai-network-tests/tests/08_unary_swarm_interop.rs
@@ -58,7 +58,15 @@ impl SwarmNode {
             .expect("tcp transport")
             .with_behaviour(|_| unary::Behaviour::new(unary::Config::default()))
             .expect("behaviour")
-            .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(60)))
+            .with_swarm_config(|c| {
+                c.with_idle_connection_timeout(Duration::from_secs(60))
+                    // Must mirror `service.rs`, or these tests exercise the eager
+                    // V1 path and their refusal assertions prove nothing about
+                    // what production actually runs.
+                    .with_substream_upgrade_protocol_override(
+                        libp2p::core::upgrade::Version::V1Lazy,
+                    )
+            })
             .build();
 
         swarm

--- a/core/crates/kwaai-p2p/src/raw_stream.rs
+++ b/core/crates/kwaai-p2p/src/raw_stream.rs
@@ -87,6 +87,30 @@ pub enum RawStreamError {
     Io(String),
 }
 
+/// A protocol nobody serves, appended to every *outbound* raw-stream
+/// negotiation to keep refusals eager.
+///
+/// The swarm negotiates outbound substreams with `Version::V1Lazy` (see
+/// `service.rs`), which wins a round trip per unary call but hands back a
+/// stream before the peer has confirmed the protocol. For a raw stream that is
+/// the wrong trade: [`RawStreamError::UnsupportedProtocol`] has to be decided
+/// *before* the caller is handed a stream, or the control socket enters pipe
+/// mode for a protocol the remote does not serve — a divergence from p2pd, and
+/// one the socket client cannot recover from because the reply slot is gone.
+///
+/// multistream-select only takes the lazy shortcut for the **last** protocol it
+/// has to offer (`dialer_select.rs`, the `protocols.peek().is_some()` branch).
+/// Appending one more entry therefore keeps every real protocol on the eager
+/// path, negotiated exactly as it was before, at the same one round trip: a
+/// long-lived stream pays that once, so there is nothing to win here anyway.
+///
+/// It is a marker, not a protocol. Reaching it means every real protocol was
+/// already refused, so [`Handler`] turns it straight back into
+/// `UnsupportedProtocol` and drops the stream. It is never proposed on the wire
+/// in the accepted case, and never advertised inbound — `listen_protocol` is
+/// built from the registered set alone.
+const NEGOTIATION_SENTINEL: &str = "kwaai.__negotiation_probe__";
+
 /// The result of an [`Behaviour::open_stream`] request: the protocol
 /// multistream-select settled on, plus the stream itself.
 pub type OpenResult = Result<(UnaryProtocol, RawStream), RawStreamError>;
@@ -267,7 +291,12 @@ impl ConnectionHandler for Handler {
         // clients, not by remote behaviour. The unary cap exists because there
         // a remote can open streams faster than handlers retire them.
         if let Some(open) = self.pending_outbound.pop_front() {
-            let protocols = Protocols::new(open.protocols.clone());
+            // Real protocols first, then the sentinel — see
+            // `NEGOTIATION_SENTINEL`. `open.protocols` itself is left alone, so
+            // error messages and bookkeeping only ever mention real names.
+            let mut offered = open.protocols.clone();
+            offered.push(UnaryProtocol::new(NEGOTIATION_SENTINEL));
+            let protocols = Protocols::new(offered);
             let id = self.next_outbound_id;
             self.next_outbound_id += 1;
             self.requested_outbound.insert(id, open);
@@ -296,6 +325,16 @@ impl ConnectionHandler for Handler {
                 protocol: (stream, proto),
                 info,
             }) => match self.requested_outbound.remove(&info) {
+                Some(open) if proto.as_ref() == NEGOTIATION_SENTINEL => {
+                    // Nothing real survived negotiation. `stream` is dropped
+                    // with this arm, which resets it — the remote never sees a
+                    // sentinel it would have to answer.
+                    let names: Vec<&str> = open.protocols.iter().map(|p| p.as_ref()).collect();
+                    trace!(protocols = %names.join(", "), "raw stream refused by the remote");
+                    let _ = open
+                        .reply
+                        .send(Err(RawStreamError::UnsupportedProtocol(names.join(", "))));
+                }
                 Some(open) => {
                     trace!(%proto, "outbound raw stream negotiated");
                     // If the caller has gone away the stream is dropped here,

--- a/core/crates/kwaai-p2p/src/raw_stream.rs
+++ b/core/crates/kwaai-p2p/src/raw_stream.rs
@@ -109,7 +109,17 @@ pub enum RawStreamError {
 /// `UnsupportedProtocol` and drops the stream. It is never proposed on the wire
 /// in the accepted case, and never advertised inbound — `listen_protocol` is
 /// built from the registered set alone.
-const NEGOTIATION_SENTINEL: &str = "kwaai.__negotiation_probe__";
+pub(crate) const NEGOTIATION_SENTINEL: &str = "kwaai.__negotiation_probe__";
+
+/// True for the reserved sentinel name. Callers and remote registrations must
+/// never use it: [`Handler::on_connection_event`] identifies the sentinel by
+/// name, so a caller-supplied `kwaai.__negotiation_probe__` would make
+/// `offered` read `[sentinel, sentinel]`, negotiate the *first* one eagerly and
+/// successfully, then trip the guard on the name — resetting a live stream
+/// under the remote while telling the caller it was unsupported.
+pub(crate) fn is_reserved(proto: &UnaryProtocol) -> bool {
+    proto.as_ref() == NEGOTIATION_SENTINEL
+}
 
 /// The result of an [`Behaviour::open_stream`] request: the protocol
 /// multistream-select settled on, plus the stream itself.
@@ -382,6 +392,10 @@ impl Behaviour {
     /// Start advertising `proto` for inbound raw streams. Idempotent, and
     /// visible to connections that already exist.
     pub fn register_protocol(&mut self, proto: UnaryProtocol) {
+        if is_reserved(&proto) {
+            debug!(%proto, "refusing to register the reserved negotiation sentinel");
+            return;
+        }
         self.inbound_protocols
             .write()
             .expect("raw stream protocol set lock poisoned")
@@ -419,6 +433,12 @@ impl Behaviour {
         protocols: Vec<UnaryProtocol>,
         reply: oneshot::Sender<OpenResult>,
     ) {
+        if protocols.iter().any(is_reserved) {
+            let _ = reply.send(Err(RawStreamError::UnsupportedProtocol(format!(
+                "{NEGOTIATION_SENTINEL} is reserved"
+            ))));
+            return;
+        }
         if protocols.is_empty() {
             let _ = reply.send(Err(RawStreamError::UnsupportedProtocol(
                 "no protocols requested".to_string(),

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -247,7 +247,25 @@ impl NetworkService {
                 KwaaiBehaviour::new(kp, &behaviour_config, relay_client)
             })
             .map_err(|e| anyhow::anyhow!("configuring behaviour: {e}"))?
-            .with_swarm_config(|c| c.with_idle_connection_timeout(config.connection_timeout))
+            .with_swarm_config(|c| {
+                c.with_idle_connection_timeout(config.connection_timeout)
+                    // 0-RTT protocol negotiation on outbound substreams.
+                    //
+                    // The default, `V1`, writes the multistream-select proposal,
+                    // waits for the peer to confirm it, and only then sends the
+                    // payload — two round trips for one request. `V1Lazy` buffers
+                    // the proposal and flushes it together with the first
+                    // application data, which is what go-libp2p does and why the
+                    // p2pd path costs one round trip where this cost two.
+                    //
+                    // Safe in a mixed fleet: the wire bytes are identical and a
+                    // *listener* behaves as `V1` regardless, so this only changes
+                    // what we do as dialer. It applies when the dialer offers a
+                    // single protocol, which every unary call here does.
+                    .with_substream_upgrade_protocol_override(
+                        libp2p::core::upgrade::Version::V1Lazy,
+                    )
+            })
             .build();
 
         for addr in config.swarm_listen_addrs() {

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -259,9 +259,36 @@ impl NetworkService {
                     // p2pd path costs one round trip where this cost two.
                     //
                     // Safe in a mixed fleet: the wire bytes are identical and a
-                    // *listener* behaves as `V1` regardless, so this only changes
-                    // what we do as dialer. It applies when the dialer offers a
-                    // single protocol, which every unary call here does.
+                    // *listener* behaves as `V1` regardless, so only our dialer
+                    // changes.
+                    //
+                    // SCOPE: this sits on the swarm pool config and therefore
+                    // applies to **every outbound substream of every
+                    // behaviour** — ping, identify, kad, autonat, relay, dcutr,
+                    // upnp and the raw-stream handler, not just unary. libp2p-
+                    // swarm 0.47 has no per-behaviour override, so the two
+                    // consequences below are accepted deliberately rather than
+                    // worked around:
+                    //
+                    // - `ping`: its only transition to `State::Inactive` is the
+                    //   `NegotiationFailed` arm, now unreachable. A peer not
+                    //   serving `/ipfs/ping/1.0.0` is re-pinged every 30s for
+                    //   the connection's life. Latent today — every fleet peer
+                    //   serves ping, and the go daemon does so unconditionally.
+                    // - `kad`: `on_fully_negotiated_outbound` marks the protocol
+                    //   supported on the first negotiated substream, which now
+                    //   fires before the remote confirms anything. A query to a
+                    //   connected non-kad peer can insert it into the routing
+                    //   table until identify corrects it. This is net new versus
+                    //   p2pd, where go-libp2p-kad-dht admits peers only from
+                    //   identify plus a live FIND_NODE probe.
+                    //
+                    // Closing both at the source means gating laziness on
+                    // identify's known-protocol set, as go does. Tracked as a
+                    // follow-up, not done here.
+                    //
+                    // Raw streams opt out via a trailing sentinel protocol, so
+                    // their refusals stay eager — see `raw_stream.rs`.
                     .with_substream_upgrade_protocol_override(
                         libp2p::core::upgrade::Version::V1Lazy,
                     )

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -49,7 +49,7 @@ use futures::io::AsyncWriteExt as _;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, SinkExt, StreamExt};
 use libp2p::core::transport::PortUse;
-use libp2p::core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+use libp2p::core::upgrade::{InboundUpgrade, NegotiationError, OutboundUpgrade, UpgradeInfo};
 use libp2p::core::{Endpoint, Multiaddr};
 use libp2p::swarm::handler::{
     ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
@@ -464,15 +464,15 @@ impl Handler {
                             &message.data,
                         ))
                         .await
-                        .map_err(|e| UnaryError::Wire(e.to_string()))?;
+                        .map_err(|e| wire_or_refusal(e, &proto))?;
                     stream
                         .flush()
                         .await
-                        .map_err(|e| UnaryError::Wire(e.to_string()))?;
+                        .map_err(|e| wire_or_refusal(e, &proto))?;
 
                     let frame = wire::read_framed_futures(&mut stream)
                         .await
-                        .map_err(|e| UnaryError::Wire(e.to_string()))?;
+                        .map_err(|e| wire_or_refusal(e, &proto))?;
                     let (echoed_id, result) = wire::decode_unary_response(&frame)
                         .map_err(|e| UnaryError::Wire(e.to_string()))?;
                     if echoed_id != call_id {
@@ -515,10 +515,69 @@ impl Handler {
             StreamUpgradeError::NegotiationFailed => {
                 UnaryError::UnsupportedProtocol(message.proto.to_string())
             }
+            // A refusal reaches us here, not as `NegotiationFailed`, whenever
+            // the substream upgrade ran lazily — see `is_negotiation_failure`.
+            StreamUpgradeError::Io(ref e) if is_negotiation_failure(e) => {
+                UnaryError::UnsupportedProtocol(message.proto.to_string())
+            }
             StreamUpgradeError::Io(e) => UnaryError::Wire(e.to_string()),
             StreamUpgradeError::Apply(infallible) => match infallible {},
         };
         let _ = message.reply.send(Err(error));
+    }
+}
+
+/// True when an error is really "the peer does not speak this protocol"
+/// wearing a different hat.
+///
+/// The swarm negotiates outbound substreams with `Version::V1Lazy` (see
+/// `service.rs`), which hands back the stream without waiting for the peer to
+/// confirm the protocol. The upgrade therefore *succeeds*, and a refusal is
+/// only discovered when the exchange below does its first real I/O — surfacing
+/// as an ordinary read/write failure rather than as
+/// [`StreamUpgradeError::NegotiationFailed`]. Nothing is lost in the process:
+/// `NegotiationError` converts into an `io::Error` that keeps the original
+/// enum as its inner error, so the cause is still there to be read.
+///
+/// Only [`NegotiationError::Failed`] counts. `NegotiationError::ProtocolError`
+/// means negotiation itself broke down — a truncated or malformed message —
+/// which is a real wire failure and keeps mapping to [`UnaryError::Wire`].
+///
+/// One inherited wrinkle, worth knowing but not worth working around:
+/// multistream-select also reports a clean EOF mid-negotiation as `Failed`,
+/// deliberately, treating a peer that hangs up rather than answering as a way
+/// of saying no. Such a peer is indistinguishable here from one that answered
+/// `na`, and both mean the call cannot be served.
+fn is_negotiation_failure(e: &(dyn std::error::Error + 'static)) -> bool {
+    let mut cause = Some(e);
+    while let Some(err) = cause {
+        if matches!(
+            err.downcast_ref::<NegotiationError>(),
+            Some(NegotiationError::Failed)
+        ) {
+            return true;
+        }
+        // `io::Error` hides its inner error from `source()`, which reports the
+        // inner error's *own* source instead. Step into it explicitly, or the
+        // walk jumps clean past the variant we are looking for.
+        cause = match err
+            .downcast_ref::<std::io::Error>()
+            .and_then(|io| io.get_ref())
+        {
+            Some(inner) => Some(inner as &(dyn std::error::Error + 'static)),
+            None => err.source(),
+        };
+    }
+    false
+}
+
+/// Classify a failed exchange: a deferred protocol refusal reads as
+/// [`UnaryError::UnsupportedProtocol`], anything else as [`UnaryError::Wire`].
+fn wire_or_refusal<E: std::error::Error + 'static>(e: E, proto: &UnaryProtocol) -> UnaryError {
+    if is_negotiation_failure(&e) {
+        UnaryError::UnsupportedProtocol(proto.to_string())
+    } else {
+        UnaryError::Wire(e.to_string())
     }
 }
 
@@ -858,5 +917,85 @@ impl NetworkBehaviour for Behaviour {
             return Poll::Ready(event);
         }
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p::core::upgrade::ProtocolError;
+
+    /// How multistream-select actually surfaces a refusal: the enum is moved
+    /// into an `io::Error` as its inner error (`From<NegotiationError>`).
+    fn refusal() -> std::io::Error {
+        NegotiationError::Failed.into()
+    }
+
+    // -- the case that costs a round trip if it regresses -----------------
+
+    #[test]
+    fn a_wrapped_negotiation_refusal_is_recognised() {
+        assert!(is_negotiation_failure(&refusal()));
+    }
+
+    #[test]
+    fn a_refusal_nested_behind_another_error_is_recognised() {
+        // `wire::WireError::Io` and friends wrap the io error rather than
+        // replacing it, so the cause has to be walked, not just read.
+        #[derive(Debug, thiserror::Error)]
+        #[error("framing: {0}")]
+        struct Wrapper(#[from] std::io::Error);
+
+        assert!(is_negotiation_failure(&Wrapper(refusal())));
+    }
+
+    #[test]
+    fn the_walk_steps_through_io_errors_own_inner_error() {
+        // Guards the reason this is not a plain `source()` loop: `io::Error`
+        // reports the *inner error's* source, never the inner error itself, so
+        // a naive walk skips straight past `NegotiationError`.
+        let e = refusal();
+        assert!(
+            std::error::Error::source(&e).is_none(),
+            "io::Error still hides its inner error from source(); \
+             if this ever changes the walk can be simplified"
+        );
+        assert!(is_negotiation_failure(&e));
+    }
+
+    // -- what must keep reading as a wire failure -------------------------
+
+    #[test]
+    fn a_broken_negotiation_is_not_a_refusal() {
+        // `ProtocolError` means the negotiation itself malfunctioned. Folding
+        // it into "unsupported" would report a corrupt stream as a peer that
+        // simply does not serve the handler.
+        let e: std::io::Error =
+            NegotiationError::ProtocolError(ProtocolError::InvalidMessage).into();
+        assert!(!is_negotiation_failure(&e));
+    }
+
+    #[test]
+    fn an_ordinary_io_error_is_not_a_refusal() {
+        let e = std::io::Error::new(std::io::ErrorKind::ConnectionReset, "reset by peer");
+        assert!(!is_negotiation_failure(&e));
+    }
+
+    // -- the classifier the exchange path uses ----------------------------
+
+    #[test]
+    fn wire_or_refusal_names_the_protocol_it_could_not_negotiate() {
+        let proto = UnaryProtocol::new("DHTProtocol.rpc_store");
+        match wire_or_refusal(refusal(), &proto) {
+            UnaryError::UnsupportedProtocol(p) => assert_eq!(p, "DHTProtocol.rpc_store"),
+            other => panic!("a refusal must not read as a wire failure: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wire_or_refusal_leaves_real_failures_alone() {
+        let proto = UnaryProtocol::new("hello");
+        let e = std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "truncated frame");
+        assert!(matches!(wire_or_refusal(e, &proto), UnaryError::Wire(_)));
     }
 }

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -515,11 +515,13 @@ impl Handler {
             StreamUpgradeError::NegotiationFailed => {
                 UnaryError::UnsupportedProtocol(message.proto.to_string())
             }
-            // A refusal reaches us here, not as `NegotiationFailed`, whenever
-            // the substream upgrade ran lazily — see `is_negotiation_failure`.
-            StreamUpgradeError::Io(ref e) if is_negotiation_failure(e) => {
-                UnaryError::UnsupportedProtocol(message.proto.to_string())
-            }
+            // No refusal arm here on purpose. Under `V1Lazy` the upgrade
+            // *succeeds* and the refusal surfaces during the exchange, so it is
+            // classified by `wire_or_refusal`. A guard on this arm would be dead
+            // code either way: `to_stream_upgrade_error`
+            // (libp2p-swarm `connection.rs`) maps `NegotiationError::Failed` to
+            // `NegotiationFailed` above, and only ever puts a bare io error or a
+            // `ProtocolError` inside `Io`.
             StreamUpgradeError::Io(e) => UnaryError::Wire(e.to_string()),
             StreamUpgradeError::Apply(infallible) => match infallible {},
         };
@@ -543,11 +545,22 @@ impl Handler {
 /// means negotiation itself broke down — a truncated or malformed message —
 /// which is a real wire failure and keeps mapping to [`UnaryError::Wire`].
 ///
-/// One inherited wrinkle, worth knowing but not worth working around:
-/// multistream-select also reports a clean EOF mid-negotiation as `Failed`,
-/// deliberately, treating a peer that hangs up rather than answering as a way
-/// of saying no. Such a peer is indistinguishable here from one that answered
-/// `na`, and both mean the call cannot be served.
+/// **A refusal and a hang-up are different, and that is correct.** Only a
+/// literal `na` reaches us as `NegotiationError::Failed`. A peer that resets or
+/// hangs up mid-negotiation takes a different path — `negotiated.rs`
+/// `State::Expecting` maps EOF to `ProtocolError::IoError(UnexpectedEof)`, and
+/// `From<NegotiationError> for io::Error` unwraps a `ProtocolError` rather than
+/// preserving the enum — so it classifies as [`UnaryError::Wire`].
+///
+/// This matches p2pd, which is the point: go-multistream returns its refusal
+/// error only for a literal `na`, and a reset surfaces as
+/// `failed to negotiate protocol: stream reset` — a wire error, never a
+/// refusal. The pre-V1Lazy native path was the outlier in conflating the two.
+/// Do not "fix" this toward treating a hang-up as a refusal; that breaks parity.
+///
+/// (The eager `dialer_select.rs::AwaitProtocol` path *does* fold EOF into
+/// `Failed`, which is where the old comment came from. V1Lazy does not reach it
+/// for a single-protocol offer.)
 fn is_negotiation_failure(e: &(dyn std::error::Error + 'static)) -> bool {
     let mut cause = Some(e);
     while let Some(err) = cause {
@@ -967,12 +980,25 @@ mod tests {
 
     #[test]
     fn a_broken_negotiation_is_not_a_refusal() {
-        // `ProtocolError` means the negotiation itself malfunctioned. Folding
-        // it into "unsupported" would report a corrupt stream as a peer that
-        // simply does not serve the handler.
-        let e: std::io::Error =
-            NegotiationError::ProtocolError(ProtocolError::InvalidMessage).into();
-        assert!(!is_negotiation_failure(&e));
+        // A malfunctioning negotiation must not read as "unsupported" — that
+        // would report a corrupt stream as a peer that does not serve the
+        // handler.
+        //
+        // Construct the wrapper explicitly rather than via
+        // `NegotiationError::ProtocolError(..).into()`: that conversion unwraps
+        // to a plain `ProtocolError`-derived io error, so the assertion would
+        // hold no matter what `is_negotiation_failure` did.
+        #[derive(Debug, thiserror::Error)]
+        #[error("negotiation: {0}")]
+        struct Wrapped(#[source] NegotiationError);
+
+        let e = Wrapped(NegotiationError::ProtocolError(
+            ProtocolError::InvalidMessage,
+        ));
+        assert!(
+            !is_negotiation_failure(&e),
+            "only NegotiationError::Failed is a refusal; ProtocolError is a wire failure"
+        );
     }
 
     #[test]

--- a/core/crates/kwaai-p2p/tests/raw_stream.rs
+++ b/core/crates/kwaai-p2p/tests/raw_stream.rs
@@ -215,6 +215,51 @@ async fn an_unserved_protocol_is_refused_not_hung() {
     );
 }
 
+/// A whole candidate list can be refused, and the refusal still arrives before
+/// the caller is handed anything.
+///
+/// This is the path the negotiation sentinel exists for. Outbound negotiation
+/// offers the real protocols and then one entry nobody serves, because
+/// multistream-select only takes its lazy shortcut on the *last* protocol it
+/// has to offer. Every real name here is therefore refused eagerly, one after
+/// another, and only the sentinel is reached lazily — where the handler turns
+/// it back into a refusal rather than surfacing it. A regression drops the
+/// caller into a stream for a protocol the remote never agreed to, and the
+/// error stops naming what was actually asked for.
+#[tokio::test]
+async fn a_candidate_list_that_is_entirely_unserved_is_refused() {
+    let (caller, _responder, responder_id, _tasks) = connected_pair().await;
+
+    let error = within(
+        "refusal of a full list",
+        caller.open_raw_stream(
+            responder_id,
+            vec![
+                "nobody.serves.this".to_string(),
+                "nor.this.one".to_string(),
+                "nor.this.either".to_string(),
+            ],
+        ),
+    )
+    .await
+    .expect_err("a list with nothing served must not yield a stream");
+
+    assert!(
+        matches!(error, P2PError::Protocol(_)),
+        "a clean negotiation refusal is a protocol-level answer, got: {error:?}"
+    );
+    for name in ["nobody.serves.this", "nor.this.one", "nor.this.either"] {
+        assert!(
+            error.to_string().contains(name),
+            "the error must name every protocol that was refused, missing {name}: {error}"
+        );
+    }
+    assert!(
+        !error.to_string().contains("__negotiation_probe__"),
+        "the sentinel is an implementation detail and must never reach a caller: {error}"
+    );
+}
+
 /// Removing a handler stops negotiation, observable to the remote as the same
 /// clean refusal an unregistered protocol produces.
 #[tokio::test]

--- a/core/crates/kwaai-p2p/tests/raw_stream.rs
+++ b/core/crates/kwaai-p2p/tests/raw_stream.rs
@@ -260,6 +260,40 @@ async fn a_candidate_list_that_is_entirely_unserved_is_refused() {
     );
 }
 
+/// The negotiation sentinel is reserved and a caller cannot reach it.
+///
+/// Without this guard, a caller asking for `kwaai.__negotiation_probe__`
+/// produced an offered list of `[sentinel, sentinel]`: the first entry
+/// negotiates *eagerly and successfully* against a remote that registered the
+/// name, the handler's guard then fires on the name, and a live stream is reset
+/// under the remote while the caller is told it was unsupported — leaking the
+/// sentinel that `a_candidate_list_that_is_entirely_unserved_is_refused`
+/// asserts can never reach a caller. Found in review of #107.
+#[tokio::test]
+async fn the_negotiation_sentinel_is_reserved() {
+    let (caller, responder, responder_id, _tasks) = connected_pair().await;
+
+    // Even with the remote advertising it, the name must not be openable.
+    let _ = responder
+        .accept_streams(vec!["kwaai.__negotiation_probe__".to_string()])
+        .await;
+
+    let error = within(
+        "reserved sentinel",
+        caller.open_raw_stream(
+            responder_id,
+            vec!["kwaai.__negotiation_probe__".to_string()],
+        ),
+    )
+    .await
+    .expect_err("the sentinel must never be openable by a caller");
+
+    assert!(
+        error.to_string().contains("reserved"),
+        "the caller should be told the name is reserved, got: {error}"
+    );
+}
+
 /// Removing a handler stops negotiation, observable to the remote as the same
 /// clean refusal an unregistered protocol produces.
 #[tokio::test]

--- a/core/crates/kwaai-p2p/tests/unary.rs
+++ b/core/crates/kwaai-p2p/tests/unary.rs
@@ -44,7 +44,13 @@ fn new_swarm(config: unary::Config) -> Swarm<unary::Behaviour> {
         .expect("tcp transport")
         .with_behaviour(|_| unary::Behaviour::new(config))
         .expect("behaviour")
-        .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(60)))
+        .with_swarm_config(|c| {
+            c.with_idle_connection_timeout(Duration::from_secs(60))
+                // Must mirror `service.rs`, or these tests exercise the eager
+                // V1 path and their refusal assertions prove nothing about
+                // what production actually runs.
+                .with_substream_upgrade_protocol_override(libp2p::core::upgrade::Version::V1Lazy)
+        })
         .build()
 }
 


### PR DESCRIPTION
Closes the 0.6 cutover blocker written up in #100: an accepted unary call cost
two round trips on the native stack where p2pd costs one, so flipping
`native_p2p` on by default would have slowed every remote inference ~57%.

Found with `p2p probe` (#99).

## The change

**`V1Lazy` outbound substream negotiation** (commit 1). The default `V1`
upgrade writes the multistream-select proposal, waits for the peer to confirm
it, and only then sends the payload. `V1Lazy` flushes the proposal together
with the first application data — the optimistic negotiation go-libp2p has
always done. Measured on rezas-mini-2 against metro-win, same peer, same
protocols, switching only `native_p2p`:

|                | p2pd        | native V1   | native V1Lazy |
|----------------|-------------|-------------|---------------|
| accepted call  | 159.4 ms    | 320.1 ms    | **158.0 ms**  |
| inference      | 478 ms/tok  | 750 ms/tok  | **483 ms/tok**|

Interop-safe: the wire bytes are identical, and a *listener* behaves as V1
regardless, so only our dialer changes.

**Keeping refusals precise** (commit 2). Laziness moves *where* a refusal
shows up, and two call sites had to be taught the new shape to keep the
contracts they already had.

## Where the refusal actually surfaces

Worth reviewing carefully, because it is not where you would first look.
`poll_read` drives negotiation to completion; `poll_write` and `poll_flush`
do not. So for a unary call the upgrade **succeeds**, the write and flush
pass, and the *read* fails — the refusal never reaches
`on_dial_upgrade_error`, it lands in the exchange worker as a wire failure. A
peer that simply does not serve a handler therefore read as a broken stream,
and the health probe lost the clean refusal it depends on.

Nothing is actually lost: `NegotiationError` converts into an `io::Error`
that keeps the original enum as its inner error. One trap — the walk has to
step into `io::Error::get_ref()` explicitly, because `io::Error::source()`
reports the inner error's *own* source and skips straight past the variant we
want. There is a unit test pinning that specific trap.

Only `NegotiationError::Failed` is folded into `UnsupportedProtocol`;
`ProtocolError` still means the stream broke and still reads as a wire
failure.

## The sentinel, and why raw streams stay eager

`open_stream` has to decide `UnsupportedProtocol` *before* the caller is
handed a stream, or the control socket enters pipe mode for a protocol the
remote does not serve — a divergence from p2pd right where the cutover claims
parity, and one the socket client cannot recover from because the reply slot
is gone by then. `stream_open_for_an_unserved_protocol_errors_without_entering_pipe_mode`
and four sibling tests encode this.

The version override is swarm-global (no per-substream API in libp2p-swarm
0.47), so raw streams cannot simply opt out. But multistream-select only
takes the lazy shortcut for the **last** protocol it has to offer, so
outbound raw negotiation now appends a single sentinel nobody serves. Every
real protocol stays on the eager path at the same one round trip it already
paid — which a long-lived stream pays exactly once — and reaching the
sentinel means everything real was refused, so the handler turns it straight
back into a refusal. It is never advertised inbound, and never proposed on
the wire in the accepted case.

Alternatives considered and rejected: a zero-length read to force negotiation
**hangs** on success (yamux returns `Pending` when the buffer yields nothing);
vendoring libp2p-swarm to plumb a per-substream version is cleaner but pulls
a large core crate into `patches/`; and letting raw refusals go lazy breaks
the contract above.

## Verification

- `kwaai-p2p` 85 unit + all integration tests green; `kwaai-p2p-daemon` green
  (the 3 control-server tests that broke under plain V1Lazy now pass)
- **Interop tiers 07–13 run manually** with `KWAAI_INTEGRATION_TESTS=1` — all
  green, including `12_pipe_mode_interop`. CI never runs these.
- `clippy --all-targets -D warnings` clean on both crates
- `kwaai-rpc`, `kwaai-distributed`, `kwaainet`, `map-server` compile and test
- **No existing test needed changing** — the refusal signal callers see is
  identical to before. New coverage: the error walk (including the
  `io::Error::source()` trap) and a raw-stream candidate list with nothing
  served, the path the sentinel exists for. Both verified to fail without the
  fix.

## Not yet done

The live re-measurement has **not** been redone since the sentinel landed —
the table above is from V1Lazy applied to everything. It should hold: remote
inference goes through `ollama_proxy.rs` `call_unary_handler`, one unary call
per request, which stays fully lazy; the inference-mux raw stream is opened
once per session, so its one round trip does not touch per-token cost. Worth
confirming on real hardware before the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP