### PR TITLE
test(knowledge): D6 validation of the native-p2p transport

### DIFF
--- a/tests/kwaai-knowledge/native_p2p_d6_rebuild.sh
+++ b/tests/kwaai-knowledge/native_p2p_d6_rebuild.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# D6 rebuild over the native-p2p transport, as an end-to-end test of the
+# V1Lazy negotiation fix (PR #107) under sustained real load.
+#
+# Why a D6 rebuild is the right test: every chunk extraction is an LLM call
+# relayed over p2p, and transport on this fabric costs ~160 ms per *token*
+# (see project_p2p_relay_token_latency). The pre-fix native path paid that
+# twice per token (750 vs 478 ms/tok), which would stretch the recorded
+# 4792.9 s graph build to roughly 125 min. So wall clock is a direct read on
+# whether V1Lazy is working, and the eval score is a read on whether native
+# drops or corrupts calls under load — the silent-degradation failure mode
+# that once discarded up to 94% of a corpus's chunks as false successes.
+#
+# Builds into D6_native. The production D6 knowledge base is never touched.
+#
+# Usage: bash tests/kwaai-knowledge/native_p2p_d6_rebuild.sh [/path/to/kwaainet]
+
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+
+BIN="${1:-kwaainet}"
+KB=D6_native
+DOC="docs/LEST WE FORGET -rev25.pdf"
+SEED=tests/kwaai-knowledge/d6_family_tree.yaml
+SCHEMA=tests/kwaai-knowledge/d6_doc_schema.yaml
+QUESTIONS=tests/kwaai-knowledge/d6_eval_questions.json
+RESULTS=tests/kwaai-knowledge/results
+MODEL=llama3.1:8b
+# Workers are per-run, not per-peer. The 0.24 chunks/s baseline ran 4 workers
+# across 2 peers — 2 in flight per Ollama. Pointing 4 at a single peer
+# overloads its Ollama and it answers 502/503 instead of extracting.
+WORKERS="${WORKERS:-2}"
+
+# The third peer in the canonical D6 command (12D3KooWDyPJBav…) is omitted
+# throughout: it is long gone from the DHT, and an unreachable peer in the
+# round-robin costs a circuit-breaker cooldown per cycle, which would corrupt
+# the timing this run exists to measure.
+METRO_LINUX="p2p://12D3KooWCzuhpXrZXD8aezgm4JCkCZSTgj48uDywYYdTzUhF8SHs"
+METRO_WIN="p2p://12D3KooWLMizEbViSoL4WGJUMsLVRyLccyymosX36MDKdbYgGFzE"
+
+# Peer set. metro-win only by default: as of 2026-08-18 metro-linux runs with
+# reduced VRAM, so it cannot hold a deep pipeline of concurrent requests and
+# sheds load as 502/503 rather than queueing it — 98 timeouts at 30 s plus
+# 47x503 and 40x502 in 15 minutes, against a single failure to metro-win.
+# Its *transport* is fine (the ollama-proxy handler answered a probe in 22.5 ms
+# and it still advertised 32/32 blocks VERIFIED), which is exactly why this is
+# worth writing down: left in the round-robin it dropped the build to 0.07
+# chunks/s and failed chunks out of the graph entirely, which reads as an
+# accuracy regression while having nothing to do with the transport under test.
+#   PEERS=both  -> restore the two-peer set once metro-linux has VRAM again,
+#                  and keep WORKERS low enough that it is not the bottleneck
+PEERS="${PEERS:-metrowin}"
+case "$PEERS" in
+  both)     URLS="${METRO_LINUX},${METRO_WIN}" ;;
+  metrowin) URLS="${METRO_WIN}" ;;
+  metrolinux) URLS="${METRO_LINUX}" ;;
+  *) echo "unknown PEERS=$PEERS (want: both|metrowin|metrolinux)" >&2; exit 2 ;;
+esac
+
+TS=$(date +%Y%m%d_%H%M%S)
+RUN="${RESULTS}/native_p2p_d6_${TS}"
+mkdir -p "${RESULTS}"
+LOG="${RUN}.log"
+PROGRESS="${RUN}.progress.json"
+
+log() { echo "[$(date '+%H:%M:%S')] $*" | tee -a "$LOG"; }
+
+# Phase telemetry, so the run can be watched without stdout access.
+stamp() {
+  local phase="$1" status="$2" started="$3"
+  local now; now=$(date +%s)
+  cat > "$PROGRESS" <<JSON
+{"run":"${TS}","kb":"${KB}","transport":"native-p2p","phase":"${phase}",
+ "status":"${status}","phase_elapsed_s":$((now - started)),
+ "total_elapsed_s":$((now - RUN_START)),"updated_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+JSON
+}
+
+RUN_START=$(date +%s)
+log "=== D6 rebuild over native-p2p — run ${TS} ==="
+log "binary:   ${BIN} ($("$BIN" --version 2>&1))"
+log "kb:       ${KB}  (production D6 untouched)"
+log "peers:    ${PEERS} (${URLS})"
+log "workers:  ${WORKERS}"
+log "baseline: 1152 chunks / 4792.9 s / 0.24 chunks per s / eval 90.4% (189.0 of 209)"
+
+# --- 1. rebuild: destroy -> init -> ingest -> graph build -> seed -> reembed -> dedup -> score
+P_START=$(date +%s); stamp rebuild running $P_START
+log "-- phase 1/4: rag rebuild --"
+"$BIN" rag rebuild "$DOC" --kb "$KB" \
+  --model "$MODEL" \
+  --inference-urls "$URLS" \
+  --workers "$WORKERS" \
+  --entity-types "Person,Place,Organization,Legislation,Publication" \
+  --no-relations \
+  --graph-window 1 \
+  --timeline \
+  --axiomatic-threshold 0.80 \
+  --seed-file "$SEED" \
+  --doc-schema "$SCHEMA" \
+  --yes >> "$LOG" 2>&1
+RC=$?
+REBUILD_S=$(( $(date +%s) - P_START ))
+stamp rebuild "exit_${RC}" $P_START
+log "-- rebuild finished rc=${RC} in ${REBUILD_S}s --"
+[ $RC -ne 0 ] && { log "!! rebuild failed — stopping before eval, results would be meaningless"; exit $RC; }
+
+# --- 2. coref (rule-based) — part of the pipeline that produced the 90.4% baseline
+P_START=$(date +%s); stamp coref running $P_START
+log "-- phase 2/4: graph coref --"
+"$BIN" rag graph coref --kb "$KB" --output "${RUN}_coref.md" --commit >> "$LOG" 2>&1
+log "-- coref rc=$? in $(( $(date +%s) - P_START ))s --"
+
+# --- 3. enrich entities (descriptions + gender) — also over p2p
+P_START=$(date +%s); stamp enrich running $P_START
+log "-- phase 3/4: graph enrich-entities --"
+"$BIN" rag graph enrich-entities --kb "$KB" \
+  --inference-urls "$URLS" --model "$MODEL" --workers "$WORKERS" --min-mentions 1 >> "$LOG" 2>&1
+ENRICH_S=$(( $(date +%s) - P_START ))
+log "-- enrich rc=$? in ${ENRICH_S}s --"
+
+log "-- graph score --"
+"$BIN" rag graph score --kb "$KB" 2>&1 | tee -a "$LOG" | grep -E "Overall:|Unknown type:" || true
+"$BIN" rag graph stats --kb "$KB" 2>&1 | tee -a "$LOG" | grep -E "Entities:|Relations:" || true
+
+# --- 4. eval — per-question results are written to the report, always kept
+P_START=$(date +%s); stamp eval running $P_START
+log "-- phase 4/4: eval --"
+"$BIN" rag eval --kb "$KB" --questions "$QUESTIONS" --output "${RUN}_eval.md" >> "$LOG" 2>&1
+EVAL_S=$(( $(date +%s) - P_START ))
+stamp eval done $P_START
+
+TOTAL_S=$(( $(date +%s) - RUN_START ))
+log "=== complete in ${TOTAL_S}s (rebuild ${REBUILD_S}s, enrich ${ENRICH_S}s, eval ${EVAL_S}s) ==="
+grep -E "Overall recall" "${RUN}_eval.md" 2>/dev/null | tee -a "$LOG"
+log "report:   ${RUN}_eval.md"
+log "log:      ${LOG}"

--- a/tests/kwaai-knowledge/results/README_native_p2p_d6_20260818.md
+++ b/tests/kwaai-knowledge/results/README_native_p2p_d6_20260818.md
@@ -1,0 +1,48 @@
+# Native-p2p D6 validation — 2026-08-18
+
+Read this before trusting any single report in this run set. **Two of the four
+evals here scored catastrophically low for reasons that have nothing to do with
+RAG accuracy**, and are kept only as evidence of the failure mode.
+
+Harness: `../native_p2p_d6_rebuild.sh` (`PEERS=` and `WORKERS=`).
+Transport: native-p2p with the V1Lazy fix (PR #107). Model: `llama3.1:8b`.
+Production `D6` was never modified — the rebuild targets `D6_native`.
+
+## The results
+
+| Report | Graph | Recall | Verdict |
+|---|---|---|---|
+| `control_D6_prod_native_20260818_160106.md` | production D6 | **90.0%** (188.0/209) | **The headline.** Same graph as the 90.4% p2pd baseline, re-evaluated over native |
+| `native_p2p_d6_eval_metrowin_20260818_154848.md` | fresh `D6_native` | **83.5%** (174.6/209) | Valid, clean run. Lower because a single-pass rebuild lacks the refinement production D6 has accumulated |
+| `native_p2p_d6_20260818_114949_eval.md` | fresh `D6_native` | 9.6% | **Invalid.** Eval routed via `p2p://auto` to a VRAM-starved peer → 7 × 30 s timeouts → circuit breaker → 30 questions failed in ~109 ms |
+| `native_p2p_d6_eval_metrowin_20260818_154708.md` | fresh `D6_native` | 0.5% | **Invalid.** Issue #108 (loopback dial) → 3 dial failures → circuit breaker latched → 37 questions failed in ~109 ms. Fixed by restarting the node |
+
+## What it establishes
+
+**Native transport is accuracy-neutral: 90.0% vs 90.4% on the identical graph** —
+0.4pp, inside LLM nondeterminism.
+
+**Throughput is at parity per peer.** The graph build did 1152/1152 chunks with
+**zero** transport errors at 0.12 chunks/s on one peer with 2 workers; the p2pd
+baseline was 0.24 chunks/s across two peers with 4 workers — the same 0.12 per
+peer. Extraction was *richer*, not lossier: 2083 entities vs the baseline's 1983.
+
+## Two traps this run walked into
+
+**Workers are per-run, not per-peer.** 4 workers on a single peer overloads its
+Ollama, which answers 502/503 instead of extracting. Dropping to 2 took errors
+from 142 to zero. Keep it near 2 per peer.
+
+**A peer can look perfectly healthy and still be unusable.** metro-linux answered
+a probe in 22.5 ms and advertised 32/32 blocks VERIFIED while failing ~50% of
+inference calls (reduced VRAM). Liveness checks do not catch this — only the
+workload does, and it surfaces as a *RAG accuracy* regression.
+
+**Corollary: audit completeness before believing any score.** Chunks that exhaust
+their retries drop out of the graph silently. Check `chunks_done` and the entity
+count against a baseline first; the `*.progress.json` files here exist for that.
+
+## Not committed
+
+Run logs (`*.log`) and the 1 MB coref intermediate are deliberately omitted — no
+`.log` file is tracked anywhere under `results/`.

--- a/tests/kwaai-knowledge/results/control_D6_prod_native_20260818_160106.md
+++ b/tests/kwaai-knowledge/results/control_D6_prod_native_20260818_160106.md
@@ -1,0 +1,505 @@
+# RAG Eval Report
+
+**KB:** `D6`  **Model:** `llama3.1:8b`
+
+**Flags:** top_k=20  hyde=false  rerank=false  understand=false  llm_judge=false
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Questions | 40 |
+| Overall recall (token-overlap) | 90.0% (188.0/209) |
+| Avg latency | 5370ms |
+
+## Per-question results
+
+| ID | Question | Hit rate | Sources | Latency |
+|----|----------|----------|---------|--------|
+| q01 | Who is the author? | 3/3 (100%) | [Graph: Yousuf Rassool], LEST WE FORGET -rev25.pdf | 7773ms |
+| q02 | Who are the author's children? | 3/3 (100%) | LEST WE FORGET -rev25.pdf | 3494ms |
+| q03 | Who are the author's grandchildren? | 6/6 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Yousuf Rassool] | 3575ms |
+| q04 | To whom is the book dedicated? | 4/4 (100%) | LEST WE FORGET -rev25.pdf | 3356ms |
+| q05 | Who was J.M.H. Gool? | 8/8 (100%) | [Graph: Haji Joosub Maulvi Hamid Gool], LEST WE FORGET -rev25.pdf | 9899ms |
+| q06 | Tell me about Buitencingle. | 8/8 (100%) | [Graph: 7 Buitencingle Street], LEST WE FORGET -rev25.pdf | 6477ms |
+| q07 | Who is the author's wife? | 3/3 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Nazima Rassool] | 3445ms |
+| q08 | Tell me more about the author's wife. | 6/6 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Nazima Rassool] | 4541ms |
+| q09 | Who was the author's grandfather? | 6/9 (67%) | LEST WE FORGET -rev25.pdf, [Graph: Haji Joosub Maulvi Hamid Gool] | 3521ms |
+| q10 | Tell me about Kloof Nek. | 7/7 (100%) | [Graph: Kloof Nek], LEST WE FORGET -rev25.pdf | 5730ms |
+| q11 | What was the Teachers League of South Africa (TLSA)? | 4/4 (100%) | [Graph: Teachers League of South Africa], LEST WE FORGET -rev25.pdf | 5473ms |
+| q12 | Who was Cissie Gool? | 6/6 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Cissie Gool] | 6441ms |
+| q13 | What was the All Africa Convention? | 5/5 (100%) | LEST WE FORGET -rev25.pdf, [Graph: All African Convention] | 4013ms |
+| q14 | Where was District Six and what kind of place was it? | 5/6 (83%) | [Graph: District Six], LEST WE FORGET -rev25.pdf | 3393ms |
+| q15 | What were the forced removals from District Six? | 3/5 (60%) | [Graph: District Six], sequence_diagram:District Six, LEST WE FORGET -rev25.pdf | 16742ms |
+| q16 | Who was Gandhi and what was his connection to the Gool family? | 5/5 (100%) | [Graph: Gool family], LEST WE FORGET -rev25.pdf | 6476ms |
+| q17 | What was Hewat Training College? | 5/5 (100%) | [Graph: Hewat Training College], LEST WE FORGET -rev25.pdf | 3799ms |
+| q18 | What was the New Era Fellowship? | 4/4 (100%) | [Graph: New Era Fellowship], LEST WE FORGET -rev25.pdf | 5048ms |
+| q19 | What was the Non-European Unity Movement? | 4/4 (100%) | [Graph: Non-European Unity Movement], LEST WE FORGET -rev25.pdf | 4913ms |
+| q20 | Describe the author's involvement in cricket. | 4/5 (80%) | [Graph: Kismets Cricket Club], LEST WE FORGET -rev25.pdf | 5658ms |
+| q21 | Who was the author's mother? | 5/5 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Ayesha Rassool] | 4384ms |
+| q22 | Who was the author's father? | 4/4 (100%) | [Graph: Peter Alexander Rassool], LEST WE FORGET -rev25.pdf | 3154ms |
+| q23 | Who were the author's siblings? | 5/5 (100%) | [Graph: Yousuf Rassool], LEST WE FORGET -rev25.pdf | 3968ms |
+| q24 | Who were the children of J.M.H. Gool? | 7/7 (100%) | [Graph: Haji Joosub Maulvi Hamid Gool], LEST WE FORGET -rev25.pdf | 4713ms |
+| q25 | Who was I.B. Tabata? | 5/5 (100%) | [Graph: I.B. Tabata], LEST WE FORGET -rev25.pdf | 5511ms |
+| q26 | Who was Dr. Abdullah Abdurahman? | 4/6 (67%) | LEST WE FORGET -rev25.pdf, [Graph: Dr. Abdulla Abdurahman] | 4953ms |
+| q27 | What was the connection between Gandhi and J.M.H. Gool? | 5/5 (100%) | [Graph: Haji Joosub Maulvi Hamid Gool], LEST WE FORGET -rev25.pdf | 6402ms |
+| q28 | Which organisations was the author involved in? | 3/3 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Cape Coloured political organisations] | 4156ms |
+| q29 | What was the relationship between the TLSA and the Non-European Unity Movement? | 4/4 (100%) | [Graph: Non-European Unity Movement], LEST WE FORGET -rev25.pdf | 4749ms |
+| q30 | When did J.M.H. Gool arrive in Cape Town and from where? | 4/6 (67%) | sequence_diagram:Haji Joosub Maulvi Hamid Gool, [Graph: Haji Joosub Maulvi Hamid Gool], LEST WE FORGET -rev25.pdf | 3673ms |
+| q31 | What was the Hanaffi Quwatul Islam Mosque? | 6/6 (100%) | [Graph: Hanaffi Quwatul Islam Mosque], LEST WE FORGET -rev25.pdf | 4817ms |
+| q32 | How was Cissie Gool related to J.M.H. Gool? | 4/5 (80%) | [Graph: Haji Joosub Maulvi Hamid Gool], LEST WE FORGET -rev25.pdf | 5986ms |
+| q33 | Who were the notable historical figures that J.M.H. Gool knew personally? | 4/5 (80%) | LEST WE FORGET -rev25.pdf, [Graph: Haji Joosub Maulvi Hamid Gool] | 7612ms |
+| q34 | What was the Group Areas Act and how did it affect District Six? | 4/6 (67%) | sequence_diagram:District Six, [Graph: District Six], LEST WE FORGET -rev25.pdf | 6889ms |
+| q35 | Who was Hassen Mall? | 4/4 (100%) | [Graph: Hassen Mall], LEST WE FORGET -rev25.pdf | 6759ms |
+| q36 | What political organisations were active in the Cape Coloured community during the author's lifetime? | 4/4 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Cape Coloured political organisations] | 4534ms |
+| q37 | Who was Mahatma Gandhi and why was he in South Africa? | 7/7 (100%) | [Graph: Mohandas Karamchand Gandhi], LEST WE FORGET -rev25.pdf | 4394ms |
+| q38 | Who was Cissie Gool's father? | 3/5 (60%) | LEST WE FORGET -rev25.pdf, [Graph: Cissie Gool] | 3468ms |
+| q39 | What was District Six like as a neighbourhood before the forced removals? | 5/6 (83%) | [Graph: District Six], LEST WE FORGET -rev25.pdf | 4517ms |
+| q40 | What was the Unity Movement's boycott policy? | 2/5 (40%) | [Graph: Non-European Unity Movement], LEST WE FORGET -rev25.pdf | 6410ms |
+
+## Answers
+
+### q01 — Who is the author?
+
+The author is Yousuf (Joe) Rassool [1, 10].
+
+### q02 — Who are the author's children?
+
+According to excerpt [4], the author's children are:
+
+1. Feyruz
+2. Reza
+3. Zarina
+
+Additionally, according to excerpt [12] and again in excerpt [13], they have the following grandchildren:
+
+1. Joseph
+2. Samuel
+3. Alexander
+4. Leonardo
+5. Dylan
+6. Lewis
+
+### q03 — Who are the author's grandchildren?
+
+The provided sources do not list all of the author's grandchildren. However, we can enumerate those mentioned:
+
+1. Joseph Rassool [16]
+2. Samuel Rassool [19]
+3. Alexander Rassool [19]
+4. Leonardo Rassool [19]
+5. Dylan Rassool [19]
+6. Lewis Rassool [19]
+
+### q04 — To whom is the book dedicated?
+
+The book is dedicated to the author's children: Feyruz, Reza, and Zarina, as well as his grandchildren: Joseph, Samuel, Alexander, Leonardo, Dylan, and Lewis. [3]
+
+### q05 — Who was J.M.H. Gool?
+
+J.M.H. Gool, also known as Joosub Maulvi Hamid Gool, was a community leader and spice merchant who arrived in Cape Town in 1884 from Mauritius, with family origins in Swat via Gujarat, India [1]. He was married to two women: Bibi Gool (children: Ayesha Rassool, Mohamed Saaid Gool, Zohra) and Wahida Gool (children: Abdul Hamid Gool, Mariam, Zobeida, Mohammed Hanief Gool, Goolam Gool, Jane Gool-Tabata, Minnie, Fatima Gool) [1]. He was the grandfather of the memoir's author, Yousuf (Joe) Rassool. J.M.H. Gool lived at 7 Buitencingle Street in District Six and was a highly regarded citizen [5].
+
+As a community leader, J.M.H. Gool was involved in various activities, including being a founding trustee of the Hanaffi Quwatul Islam Mosque in District Six [1]. He received notable visitors such as Mahatma Gandhi, who stayed at his residence in February 1914 [8]. Gandhi saw great potential in J.M.H. Gool for community service and invested hope in him, building up his image in the community through editorials reporting his career progress [10].
+
+J.M.H. Gool was also a medical doctor and wrote articles for the Indian Opinion, including two medical articles on "Modern Footwear" and "Tuberculosis" [17]. He continued to submit articles to other journals.
+
+As a public figure, J.M.H. Gool attended meetings of various organizations, including the Coloured People's Vigilant Committee in 1906 [14] and the British Indian League, where he declared his support for the league and collected donations for it [14]. He also interacted with prominent figures such as Dr. Abdurahman, who was related to Wahida Gool (J.M.H.'s second wife) through marriage [3].
+
+Specific facts about J.M.H. Gool from the provided sources include:
+
+* Arrived in Cape Town: 1884
+* Origin: Mauritius via Swat, Gujarat, India
+* Occupation: Spice merchant and medical doctor
+* Community leader
+* Founding trustee of Hanaffi Quwatul Islam Mosque in District Six
+* Received notable visitors such as Mahatma Gandhi, Cecil John Rhodes, George Bernard Shaw, and Dr. Abdulla Abdurahman
+* Had two wives: Bibi Gool (children: Ayesha Rassool, Mohamed Saaid Gool, Zohra) and Wahida Gool (children: Abdul Hamid Gool, Mariam, Zobeida, Mohammed Hanief Gool, Goolam Gool, Jane Gool-Tabata, Minnie, Fatima Gool)
+* Grandfather of the memoir's author, Yousuf (Joe) Rassool
+
+### q06 — Tell me about Buitencingle.
+
+Buitencingle was a grand 13-roomed mansion located at No. 7 Buitencingle Street in District Six, Cape Town. It belonged to J.M.H. Gool, the grandfather of the author. The house had a wide and cobbled street with traffic islands sporting stunted palm trees opposite it stood the German Lutheran Church.
+
+The author's family lived in one part of the house, while some rooms were left vacant, and others were occupied by relatives or possibly tramps. The house was spacious enough that the author had to climb fruit trees to reach the pears, and he made up fanciful stories about them for his siblings.
+
+Buitencingle was a place where the author's family would often hold gatherings and parties, and it seemed to have a positive influence on the author's life. However, the house eventually fell into disrepair, and some rooms were used as makeshift beds by individuals, including possibly a relative or a tramp.
+
+The author also mentions that his grandfather received an offer from Gardener Williams, who wanted to extend his premises next door to the Gool residence. 
+
+Buitencingle was situated near Kloof Street, which led up to Kloof Nek, a connecting saddle of land joining Table Mountain to Lion's Head. Beyond it lay the foothills of Table Mountain.
+
+The name Buitencingle is Dutch in origin, and "cingle" means belt. At that time, Buitencingle was the outermost belt of Cape Town. 
+
+[1], [2], [3], [5], [9], [10] and [19] provide various details about Buitencingle.
+
+### q07 — Who is the author's wife?
+
+The author's wife is Professor Nazima Rassool [1]. She is an academic researcher who played a central role in shaping the memoir by urging the author, Yousuf Rassool, to ground his personal memories in historical research [1] and [6].
+
+### q08 — Tell me more about the author's wife.
+
+Based on the provided sources, here are all the specific facts mentioned about the author's wife:
+
+1. Her name is Nazima Rassool [1].
+2. She is an academic researcher [1] and a Professor [1].
+3. The author owes a great deal to her for urging him to ground his writing in background investigation and making it historically documented [4, 13].
+4. The author's wife insisted that he should not rely solely on his own memories but do some research to lend authenticity to the story [19].
+
+Note: While there is limited information about Nazima Rassool in these sources, we can infer from the context that she was a significant influence on the author's writing process and helped him shape the memoir into its current form.
+
+### q09 — Who was the author's grandfather?
+
+The author's grandfather was J.M.H. Gool, also known as Haji Joosub Maulvi Hamid Gool. He arrived in Cape Town in 1884 from Mauritius, and his family origins were in Swat via Gujarat, India. [1]
+
+### q10 — Tell me about Kloof Nek.
+
+Kloof Nek is a natural saddle or mountain pass between Table Mountain and Lion's Head in Cape Town [1]. It is located near the Glen, a place of haunting beauty with views of both Table Mountain and Lion's Head [4] [17].
+
+The area was known as Buitencingle Street in District Six [2], which referred to an outer belt of Cape Town. Beyond it lay the foothills of Table Mountain reached via Kloof Street [2]. The bus terminus for a single-decker trackless tram that ran from Adderley Street outside Fletchers & Cartwrights department store was near Kloof Nek [2].
+
+Kloof Nek was used by lovers, mountaineers, nature lovers, ramblers, and down-and-outs known as "Bergies" for refuge in the area's cavelets, culverts, and bushes [5]. The Table Mountain cable car began its run a few hundred feet up the mountain path near Kloof Nek [5].
+
+Kloof Street climbs from the city bowl up to Kloof Nek, beyond which lies the Glen and the Atlantic seaboard. Kloof Nek is also accessible via Buitencingle Street in District Six.
+
+### q11 — What was the Teachers League of South Africa (TLSA)?
+
+The Teachers League of South Africa (TLSA) was a professional and political organisation for Coloured teachers. It was affiliated with the Non-European Unity Movement, and its members adopted a boycott and non-collaboration policy to challenge racial discrimination in education and fight for equal opportunities for Coloured teachers and students [1].
+
+The TLSA held conferences that were important civic occasions, opened by the mayor with a civic banquet at the ratepayers' expense. These events were also social occasions where teachers from other areas could come to the city to spend their winter vacation listening to eloquence about the nobility of the teaching profession and sometimes even to catch the eye of the president [2].
+
+The TLSA was in the forefront of the struggle for democracy, with its members being involved in various activities, including establishing a Students' Union at Hewat [6]. The organisation also had an Education Journal where good writers were trained in political/educational composition and their articles published [8].
+
+However, there is no information available on what happened to the TLSA or whether it continued to exist after 1952.
+
+### q12 — Who was Cissie Gool?
+
+Cissie Gool (full name Zainunnissa Gool) was a Cape Town city councillor, lawyer, and political activist closely associated with the Non-European Unity Movement and the anti-apartheid struggle. She was the daughter of Dr. Abdulla Abdurahman, a leading figure in the Coloured community.
+
+Cissie's father, Dr. Abdurahman, was the first Coloured person to be elected to the Cape Town City Council [1]. Cissie herself was a prominent figure in her own right, known for her passionate oratory skills and her commitment to fighting against social, economic, and political injustice [13].
+
+As a member of the Non-European Unity Movement, Cissie Gool played an important role in mobilizing the community against apartheid policies. She organized mass demonstrations and rallies, including a massive demonstration on the Grand Parade in 1937 to protest against residential segregation [4].
+
+Cissie Gool's personal life is also documented in these sources. She was married to Abdul Hamid Gool, with whom she had a son named Shaheen Gool [1]. Her relationship with her brother-in-law or adopted sister Toetie is also mentioned in several excerpts [2].
+
+The provided sources do not contain information on Cissie Gool's date of birth.
+
+Sources:
+[1] Cissie Gool [Person]
+[4] 
+[13]
+
+### q13 — What was the All Africa Convention?
+
+According to [1], The All African Convention (AAC) was founded in 1935 in response to the Hertzog Bills, which stripped Africans of their limited voting rights. It united a broad coalition of African political organisations seeking unity against racial oppression. It later aligned closely with the Non-European Unity Movement and its non-collaboration policy.
+
+Note: The exact founders of the All African Convention are not specified in the provided sources.
+
+### q14 — Where was District Six and what kind of place was it?
+
+District Six was a neighborhood located near the center of Cape Town, situated below Devil's Peak [1]. It was a vibrant, multicultural community that housed Coloured, African, Indian, and White residents who built a rich urban culture of music, jazz, and community life [1].
+
+### q15 — What were the forced removals from District Six?
+
+The provided sources do not contain specific information about the forced removals from District Six. However, based on general knowledge, I can provide some context: The forced removals from District Six occurred during the apartheid era in South Africa. In 1960, the government of Prime Minister Hendrik Verwoerd decided to remove thousands of residents from the predominantly coloured community of District Six, located in Cape Town, to make way for a new "white" area. The removals were part of the Group Areas Act, which aimed to segregate communities along racial lines.
+
+However, the exact dates and details of the forced removals are not mentioned in the provided sources.
+
+### q16 — Who was Gandhi and what was his connection to the Gool family?
+
+Gandhi, also known as Mahatma Gandhi, was a significant figure in South African history. The sources describe him as a pioneer of satyagraha (non-violent resistance) who spent over 20 years in South Africa before returning to India.
+
+The connection between Gandhi and the Gool family is one of friendship and hospitality. According to the sources [1] and [2], the Gool family, particularly Dr. J.M.H. Gool, hosted Gandhi at their residence at 7 Buitencingle Street in Cape Town on multiple occasions. Gandhi would visit the Gools' home, where he was welcomed by the family.
+
+The correspondence between Gandhi and the Gool family is documented [4], with letters exchanged between them, especially during Gandhi's time as a medical student in London. The sources also mention that Gandhi had great potential for community service and that Dr. Gool repaid Gandhi with attentive medical care and wrote articles for Indian Opinion and other scholarly journals.
+
+The relationship between the two families is described as one of mutual respect and trust, with Gandhi having built up Dr. Gool's image in the community through editorials reporting his career progress [11].
+
+It is also mentioned that Gandhi had visited the Gools' residence at Noor Bagh (8 Kloof Street) to receive G.H. Gokhale, a member of the Indian Viceroy's Legislative Assembly, in 1912 [9]. 
+
+The connection between the two families was crucial in understanding the broader context of South African history and the role of the non-white struggle for equality in the land.
+
+### q17 — What was Hewat Training College?
+
+Hewat Training College was a teacher training college in Cape Town, South Africa, specifically designed to train Coloured students as teachers. It operated under the apartheid-era segregated education system. The author, Yousuf Rassool, and his associates in the Teachers League of South Africa (TLSA) had connections to Hewat.
+
+During its operation, Hewat College trained teachers for the upper years of the primary division, which was considered more prestigious than training students for lower-class positions.
+
+### q18 — What was the New Era Fellowship?
+
+According to [1] and [4], the New Era Fellowship (NEF) was a cultural and political discussion society in Cape Town, associated with the Non-European Unity Movement. It held public lectures and debates on political, social, and philosophical topics, serving as a gathering place for progressive intellectuals, teachers, and activists in the Coloured community.
+
+[2] mentions that Mr. I.B. Tabata became chairman of the NEF after completing his book "The Awakening of a People", which was to be an NEF publication.
+
+[4] lists various organisations that responded to the call of the New Era Fellowship, including The African People’s Organisation (A.P.O.), sports’ clubs, The Moravian church, the Communist Party of South Africa, and others.
+
+Throughout the sources, it is clear that the New Era Fellowship played an important role in promoting unity, democratic rights, and progressive ideas among the Coloured community in Cape Town.
+
+### q19 — What was the Non-European Unity Movement?
+
+The Non-European Unity Movement (NEUM) was a movement that emerged in 1943 with the goal of uniting African, Coloured, and Indian people against apartheid and colonialism. Its programme was based on the Ten Point plan for equal rights.
+
+According to the sources [1], [7], and [10], the NEUM adopted a boycott and non-collaboration policy, refusing to participate in any apartheid government institutions. The movement revolutionized the political scene with its doctrine of non-collaboration and the boycott weapon, galvanizing the non-white disenfranchised to a realization of the need for a programme-based struggle.
+
+Source [1] specifically states that the NEUM was founded in 1943 by the "young Turks", who included Grandpa's daughter, Aunt Jane, and her brother, Dr. Goolam, as moving spirits.
+
+### q20 — Describe the author's involvement in cricket.
+
+According to the sources [1], [3], [9], and [20], the author, Yousuf (Joe) Rassool, was actively involved in cricket through the Kismets Cricket Club and non-European cricket more broadly. He mentions playing and administering club cricket in the Cape.
+
+Source [2] mentions that Parker of the Indian Congress became General secretary of their Union which was a major strengthening to the Union.
+
+Source [5] mentions Edross’s life revolved around the Barnato Cricket Board, but it is implied through this passage and other passages mentioning Kismets CC as his primary involvement rather than just a passing mention. The author recalls playing cricket seriously with Hassen Mall's help, learning to master the forward defensive stroke, and building the foundation of batting.
+
+Source [10] mentions that he did not make the final team for the biennial tournament but notes that there were many good players in their non-racial Sunday league.
+
+The author also participated in a meeting at Hewat where they tried to organize a cricket team. (source [7]) The author also proposed an idea of having a loose union, which could arrange regular fixtures.
+
+Source [8] discusses the debate within the Western Province Indian Cricket Union regarding whether or not to play against the West Indians.
+
+### q21 — Who was the author's mother?
+
+The author's mother is Ayesha Rassool, also known as Lallie (or Lallie Gool). [1] 
+
+Further details about her:
+- Daughter of Bibi Gool and Haji Joosub Maulvi Hamid Gool.
+- Half-sibling of Abdul Hamid Gool, Jane Gool-Tabata, Goolam Gool, Mohammed Hanief Gool.
+- Mother of Rasheda Rassool, Abdul Rassool, Berina Rassool, Nasim Rassool, Yousuf (Joe) Rassool, Zain Rassool, Fazil Rassool, Yasmin Rassool.
+- Married to Peter Alexander Rassool.
+
+### q22 — Who was the author's father?
+
+The author, Yousuf (Joe) Rassool, states that Peter Alexander Rassool was his father [1].
+
+### q23 — Who were the author's siblings?
+
+The provided sources list the following siblings of the author:
+
+1. Rasheda Rassool
+2. Abdul Rassool
+3. Berina Rassool
+4. Nasim Rassool
+5. Zain Rassool
+6. Fazil Rassool (also referred to as "Fazil was then all of seven" in [19])
+7. Yasmin Rassool 
+
+These are the siblings mentioned in source [1].
+
+### q24 — Who were the children of J.M.H. Gool?
+
+According to sources [1]–[20], the children of J.M.H. Gool are as follows:
+
+From his first wife, Bibi:
+1. Abdul Hamid Gool (married to Cissie Gool)
+2. Jane Gool-Tabata
+3. Mariam Margie Gool
+4. Minnie Gool
+5. Zobeida Gool
+6. Goolam Gool
+7. Fatima Gool
+
+From his second wife, Wahida:
+1. Ayesha Rassool
+2. Mohamed Saaid Gool
+3. Mohammed Hanief Gool
+4. Fatima Timmie Gool
+5. Zohra Abdurahman
+
+### q25 — Who was I.B. Tabata?
+
+I.B. Tabata (also referred to as Mr. Tabata or Dr. Tabata) was a prominent political activist and leader in the Non-European Unity Movement (Unity Movement). He was married to Jane Gool, daughter of J.M.H. Gool. He was deeply involved in the anti-apartheid struggle and the Unity Movement's non-collaboration policy.
+
+Specific facts from the sources:
+
+* Member of: All African Convention, Non-European Unity Movement.
+* Married to: Jane Gool-Tabata
+* Occupation: author [1]
+* Had a book titled "The Awakening of a People" which was published by the New Era Fellowship and was an occasion of considerable excitement [3] [16]
+* Was involved in the formation of SOYA (South African Organisation for Youth Abroad) as a training ground for young Africans [15]
+* Had a class analysis accused of being undialectical code language that was un-Marxist by Tabata himself [17]
+
+Note: I.B. Tabata is mentioned throughout the sources, but this list highlights some specific facts about him from the provided excerpts.
+
+### q26 — Who was Dr. Abdullah Abdurahman?
+
+According to the provided sources:
+
+* He was a Cape Town doctor and physician [1].
+* He was the first Coloured person elected to the Cape Town City Council [1].
+* He qualified as a doctor from Glasgow University in 1893 [6].
+* He was associated with Haji Joosub Maulvi Hamid Gool and the Non-European Unity Movement [1].
+* His mother, Gadija Dollie, was said to be a beautiful woman [6].
+* Dr. Abdurahman's grandfather was brought to South Africa as a slave, bought his freedom, and became prominent in the community [15].
+
+Note: There is also another mention of a person named Abdullah (or Abdulla) Abdurahman in source [19], but it appears to be referring to a different individual or possibly an error.
+
+### q27 — What was the connection between Gandhi and J.M.H. Gool?
+
+The connection between Gandhi and J.M.H. Gool can be seen in several excerpts:
+
+[2] mentions that Ralph Bunche's travel notes of his stay with the Gools in 1937 do not mention J.M.H. Gool, suggesting that by this time, he had possibly retired from public life.
+
+[3] states that Gandhi corresponded with Abdul Hamid Gool (J.M.H.'s son) while he was a medical student at Guy's Hospital in London.
+
+[8] mentions that Gandhi drafted a letter on behalf of five South African students, including A., to Lord Elgin, Colonial Secretary, supporting the case of Transvaal Indians.
+
+[10] reports on meetings of the Coloured People’s Vigilant Committee, where J.M.H. Gool and others addressed the audience.
+
+[13] mentions Gandhi's visit to Buitencingle in 1911 and his friendship with the Gools.
+
+[15] states that Gandhi was impressed by Abdul Hamid Gool's community service potential and promoted him through editorials in Indian Opinion.
+
+[16] reports on a function held for Gandhi before his departure from Cape Town, where he thanked J.M.H. Gool for his services to Mrs. Gandhi during her illness.
+
+[17] mentions the close relationship between Gandhi and Dr. Gool, who provided medical care to Gandhi's family and wrote articles for Indian Opinion.
+
+However, it is not explicitly stated what the nature of their connection was or how they first met.
+
+### q28 — Which organisations was the author involved in?
+
+The author, Joe Rassool, was involved in the following organisations:
+
+1. The New Era Fellowship (NEF) [16]
+2. The Teachers League of South Africa (TLSA) [6]
+3. The All African Convention (AAC) [1]
+4. The Non-European Unity Movement (NEUM) [1]
+
+He also mentioned being involved with other organisations, such as:
+
+1. The Anti-CAD (Anti-Coloured Affairs Department)
+2. The Cape Peninsula Students Union [19]
+3. The Hewat Amateur Theatrical Society
+4. The Trafalgar Players
+
+### q29 — What was the relationship between the TLSA and the Non-European Unity Movement?
+
+The Teachers League of South Africa (TLSA) was affiliated with the Non-European Unity Movement. They shared a boycott and non-collaboration programme [1]. 
+
+This affiliation indicates that the TLSA supported the goals and policies of the Non-European Unity Movement, which aimed to unite African, Coloured, and Indian people against apartheid and colonialism [1].
+
+Further evidence can be seen in [3] where it is mentioned that after the League took "the new road" by joining the Non-European Unity Movement, teachers were able to make meaningful contact with the people for the first time.
+
+Additionally, [9] states that the author joined the Teachers' League of South Africa (TLSA) after starting his teaching career and began to work closely with the Non-European Unity Movement.
+
+These sources indicate a strong connection between the TLSA and the Non-European Unity Movement.
+
+### q30 — When did J.M.H. Gool arrive in Cape Town and from where?
+
+According to [1], Haji Joosub Maulvi Hamid Gool arrived in The Cape (Cape Town) from India via Mauritius in 1884.
+
+### q31 — What was the Hanaffi Quwatul Islam Mosque?
+
+The Hanaffi Quwatul Islam Mosque, also known as the Quwatul Islam Mosque or Loop Street Mosque, was founded in 1898 and is one of the oldest mosques in the Cape Muslim community. (Source: [1]) 
+
+It is located on Loop Street, Cape Town. The mosque was central to the history of the Gool family and the Cape Muslim community in District Six. (Source: [1])
+
+The author's grandfather was a founder and life trustee of the mosque. (Source: [20])
+
+### q32 — How was Cissie Gool related to J.M.H. Gool?
+
+The provided sources do not explicitly state how Cissie Gool was related to J.M.H. Gool. However, [1] mentions that Abdul Hamid Gool (one of the children of J.M.H. Gool and Bibi Gool) married Cissie Gool, who is also mentioned as his daughter-in-law ([1]). This implies that Cissie Gool was married to Abdul Hamid Gool, making her a daughter-in-law of J.M.H. Gool.
+
+However, [8] states that Uncle Doctor and Cissie Gool had a son named Shaheen, which suggests that Cissie Gool may have been married to Uncle Doctor (whose first name is not mentioned), not Abdul Hamid Gool.
+
+The correct relationship between Cissie Gool and J.M.H. Gool needs further clarification from the provided sources.
+
+However, it seems from source [1] that  Cissie Gool was married to Abdul Hamid Gool and therefore was a daughter-in-law of Haji Joosub Maulvi Hamid Gool (J.M.H. Gool).
+
+### q33 — Who were the notable historical figures that J.M.H. Gool knew personally?
+
+The provided sources mention the following notable historical figures who interacted with or knew J.M.H. Gool personally:
+
+1. Mahatma Gandhi [13]: Gandhi stayed at J.M.H. Gool's residence in 1914, and there is a picture of him hosted by the Gools [3].
+2. Dr. Abdulla Abdurahman [17]: The Abdurahman family was related to the Dollie clan, which also connected them to J.M.H. Gool's second wife Wahida Ta'Al.
+3. Cecil John Rhodes [1]: Although it is not explicitly stated that they knew each other, Gandhi and Rhodes were mentioned in the same context as visitors to J.M.H. Gool's residence.
+4. George Bernard Shaw: Like Rhodes, Shaw was a visitor to J.M.H. Gool's residence, but there is no indication of a personal relationship [1].
+5. Dr. Abdulla Abdurahman [17]: As mentioned earlier, the Abdurahman family had close ties with the Dollie clan and J.M.H. Gool.
+6. Joseph Chamberlain: Although it is not explicitly stated that they knew each other, the context suggests that Chamberlain was a notable figure in South Africa during the time period.
+
+It's also worth noting that J.M.H. Gool may have met or interacted with other notable figures mentioned in the text, such as Emily Hobhouse and Mrs. Gladstone (the wife of the Governor-General), but these interactions are not described as personal relationships.
+
+The following individuals were board members of a school where J.M.H. Gool's son Abdul Hamid worked:
+
+1. Joseph Chamberlain [11]
+2. Dr. A Abdurahman [11]
+3. J. M. Wilson [11]
+4. Advocate Henry Sylvester Williams [11]
+
+### q34 — What was the Group Areas Act and how did it affect District Six?
+
+According to [1]–[21], the Group Areas Act was a law that transformed South Africa into a patchwork of Black "Coloured", Indian, and White areas. The act was passed in 1950 (source: [11]) and was considered the crowning piece of the Government legislation against Apartheid.
+
+The Act had a significant impact on District Six. As stated in [2], the area began to die in the early fifties as shops in Hanover Street started closing, and the haemorrhaging was gradual but definite for years (source: [2]). The Group Areas Board's valuation of properties was generally below market value, making it difficult for Coloured owners to sell their properties or obtain fair compensation when they were forced to relocate (sources: [2], [6]).
+
+The Act also led to the destruction of District Six as a vibrant community. According to [1] and [8], the period of recapturing subjugated cultural histories of Cape Town ends in 1956, marking the end of an era for the community. The Group Areas Act effectively disfranchised the residents by making them lose their municipal franchise due to living in sub-economic houses (source: [5]).
+
+In addition, the Act forced many people out of District Six, leading to its eventual demolition and relocation of residents to other areas such as Bonteheuwel, Hanover Park, Mannenberg, Mitchell's Plain, Vanguard Estate, and Bishop Lavis (source: [5]). The Group Areas Act was a potent source of misery for the community, causing irreparable harm and loss.
+
+### q35 — Who was Hassen Mall?
+
+Based on the provided sources:
+
+Hassen Mall was a close friend and fellow cricket player from District Six, Cape Town. He was also the captain of a team that included the author, Yousuf Rassool.
+
+Specific facts about Hassen Mall include:
+
+* He had come to Cape Town to do medicine (source [2])
+* He was known for being brilliant at cricket and spinning a wristy leg break (source [14])
+* He batted at number one, two, or four, depending on the situation (sources [16] and [17])
+* He qualified with a degree BA LLB 44 from Durban (source [14])
+* He had a clipped brush moustache and smoked a pipe in later years (source [14])
+* His departure for Durban in 1951 left an indelible imprint of his personality on the author (source [14])
+* He was known to have good relationships with other people, including Mrs. Allie, who provided him with table tennis and encouraged her sons to visit the author (sources [9] and [19])
+
+Hassen Mall's role in Yousuf Rassool's life included:
+
+* Introducing the author to cricket and helping him develop his skills (source [18])
+* Being a source of inspiration and friendship for the author
+* Leading a team that competed in the biennial cricket tournament at Durban's Curry's Fountain in early January, with Yousuf Rassool selected as part of the side (source [19])
+
+Overall, Hassen Mall was an important figure in Yousuf Rassool's life and played a significant role in his development as a person.
+
+### q36 — What political organisations were active in the Cape Coloured community during the author's lifetime?
+
+The main political organisations active in the Cape Coloured community during the mid-twentieth century were: 
+
+1. The Non-European Unity Movement (NEUM)
+2. The Teachers League of South Africa (TLSA)
+3. The New Era Fellowship (NEF)
+4. The All African Convention (AAC) [1]
+
+These organisations shared a common policy of boycott and non-collaboration against apartheid institutions.
+
+The Non-European Unity Movement was the umbrella body, while the Teachers League organised Coloured teachers; the New Era Fellowship was a discussion and lecture forum; and the All African Convention was a broader African political body that joined forces with the Unity Movement.
+
+### q37 — Who was Mahatma Gandhi and why was he in South Africa?
+
+Mahatma Gandhi came to South Africa in 1893 as a lawyer on a one-year assignment for the merchant Dada Abdullah [1]. He stayed on for over 20 years developing satyagraha (non-violent resistance) after Natal moved to disenfranchise Indians in 1894 [1].
+
+The author of this memoir does not provide information about Gandhi's background before his arrival in South Africa. However, according to excerpt [1], Gandhi was born Mohandas Karamchand Gandhi on October 2, 1869 [1].
+
+### q38 — Who was Cissie Gool's father?
+
+According to [1] and [20], Cissie Gool's (Zainunnissa Gool) father was Dr. Abdulla Abdurahman.
+
+### q39 — What was District Six like as a neighbourhood before the forced removals?
+
+According to the sources [1] and [4], District Six was a vibrant, multicultural community near the centre of Cape Town. It was home to Coloured, African, Indian, and White residents who built a rich urban culture of music, jazz, and community life. Source [1] states that it was "a neighborhood" and describes its history as having "rich history of political struggle." 
+
+In source [4], the author recalls walking through District Six with his ten-year-old eyes: "Caledon Street ran from Corporation Street straight through to Clifton Street, getting tattier along the way."
+
+The sources suggest that District Six was a bustling and diverse neighborhood before the forced removals.
+
+### q40 — What was the Unity Movement's boycott policy?
+
+According to [1], the Non-European Unity Movement (NEUM) was founded in 1943 with a programme based on the Ten Point plan for equal rights. However, it does not explicitly state their boycott policy.
+
+However, according to [5] and [7], the NEUM's alliance with the Communist Party disintegrated over the issue of boycotting "dummy" elections, specifically the election of Native Representatives to Parliament. The Communist Party wanted to participate in these elections, while the NEUM wanted to boycott them.
+
+From [17], it is mentioned that during the boycott campaign of the Unity Movement, one of the board members took revenge on the group by informing them that they would no longer be able to meet at their previous location.
+
+From [3], we know that when the Communist Party decided to put up its candidates despite the general desire among Blacks to boycott these "dummy" elections, they responded with convoluted thinking, which suggests that they had a different approach to boycotting than the NEUM.
+
+However, from [7] and [10], it is clear that the Unity Movement's policy was to boycott the Group Areas Act. According to [10], the government worked on an age-old theory that people tended to anticipate the wishes of the authorities, but the NEUM's boycott did not work as intended because some members simply ignored the injunction to boycott.
+
+From [1] and [4], it is mentioned that if the "Coloured" voters insisted on voting, they were asked to spoil their ballot by writing: “For Full Democratic Rights” across the ballot slip.
+

--- a/tests/kwaai-knowledge/results/native_p2p_d6_20260818_111937.progress.json
+++ b/tests/kwaai-knowledge/results/native_p2p_d6_20260818_111937.progress.json
@@ -1,0 +1,3 @@
+{"run":"20260818_111937","kb":"D6_native","transport":"native-p2p","phase":"rebuild",
+ "status":"running","phase_elapsed_s":0,
+ "total_elapsed_s":0,"updated_at":"2026-08-18T18:19:37Z"}

--- a/tests/kwaai-knowledge/results/native_p2p_d6_20260818_113751.progress.json
+++ b/tests/kwaai-knowledge/results/native_p2p_d6_20260818_113751.progress.json
@@ -1,0 +1,3 @@
+{"run":"20260818_113751","kb":"D6_native","transport":"native-p2p","phase":"rebuild",
+ "status":"running","phase_elapsed_s":0,
+ "total_elapsed_s":0,"updated_at":"2026-08-18T18:37:51Z"}

--- a/tests/kwaai-knowledge/results/native_p2p_d6_20260818_114949.progress.json
+++ b/tests/kwaai-knowledge/results/native_p2p_d6_20260818_114949.progress.json
@@ -1,0 +1,3 @@
+{"run":"20260818_114949","kb":"D6_native","transport":"native-p2p","phase":"eval",
+ "status":"done","phase_elapsed_s":293,
+ "total_elapsed_s":14038,"updated_at":"2026-08-18T22:43:47Z"}

--- a/tests/kwaai-knowledge/results/native_p2p_d6_20260818_114949_eval.md
+++ b/tests/kwaai-knowledge/results/native_p2p_d6_20260818_114949_eval.md
@@ -1,0 +1,234 @@
+# RAG Eval Report
+
+**KB:** `D6_native`  **Model:** `llama3.1:8b`
+
+**Flags:** top_k=20  hyde=false  rerank=false  understand=false  llm_judge=false
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Questions | 40 |
+| Overall recall (token-overlap) | 9.6% (20.0/209) |
+| Avg latency | 7047ms |
+
+## Per-question results
+
+| ID | Question | Hit rate | Sources | Latency |
+|----|----------|----------|---------|--------|
+| q01 | Who is the author? | 3/3 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Yousuf Rassool] | 20438ms |
+| q02 | Who are the author's children? | 3/3 (100%) | LEST WE FORGET -rev25.pdf | 29626ms |
+| q03 | Who are the author's grandchildren? | 6/6 (100%) | [Graph: Yousuf Rassool], LEST WE FORGET -rev25.pdf | 30078ms |
+| q04 | To whom is the book dedicated? | 4/4 (100%) | LEST WE FORGET -rev25.pdf | 24620ms |
+| q05 | Who was J.M.H. Gool? | 0/8 (0%) | [Graph: Haji Joosub Maulvi Hamid Gool], LEST WE FORGET -rev25.pdf | 30114ms |
+| q06 | Tell me about Buitencingle. | 1/8 (12%) | LEST WE FORGET -rev25.pdf, [Graph: 7 Buitencingle Street] | 30117ms |
+| q07 | Who is the author's wife? | 3/3 (100%) | [Graph: Nazima Rassool], LEST WE FORGET -rev25.pdf | 23260ms |
+| q08 | Tell me more about the author's wife. | 0/6 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Nazima Rassool] | 30110ms |
+| q09 | Who was the author's grandfather? | 0/9 (0%) | [Graph: Grandpa's right hand man], LEST WE FORGET -rev25.pdf | 30110ms |
+| q10 | Tell me about Kloof Nek. | 0/7 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Kloof Nek] | 30115ms |
+| q11 | What was the Teachers League of South Africa (TLSA)? | 0/4 (0%) | [Graph: Teachers League of South Africa], LEST WE FORGET -rev25.pdf | 102ms |
+| q12 | Who was Cissie Gool? | 0/6 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Cissie Gool] | 110ms |
+| q13 | What was the All Africa Convention? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: All African Convention] | 113ms |
+| q14 | Where was District Six and what kind of place was it? | 0/6 (0%) | LEST WE FORGET -rev25.pdf, [Graph: District Six] | 112ms |
+| q15 | What were the forced removals from District Six? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, sequence_diagram:District Six, [Graph: District Six] | 156ms |
+| q16 | Who was Gandhi and what was his connection to the Gool family? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Gool family] | 114ms |
+| q17 | What was Hewat Training College? | 0/5 (0%) | [Graph: Hewat Training College], LEST WE FORGET -rev25.pdf | 110ms |
+| q18 | What was the New Era Fellowship? | 0/4 (0%) | LEST WE FORGET -rev25.pdf, [Graph: New Era Fellowship] | 108ms |
+| q19 | What was the Non-European Unity Movement? | 0/4 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Non-European Unity Movement] | 101ms |
+| q20 | Describe the author's involvement in cricket. | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Kismets Cricket Club] | 104ms |
+| q21 | Who was the author's mother? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Ayesha Rassool] | 110ms |
+| q22 | Who was the author's father? | 0/4 (0%) | [Graph: Peter Alexander Rassool], LEST WE FORGET -rev25.pdf | 109ms |
+| q23 | Who were the author's siblings? | 0/5 (0%) | [Graph: Yousuf Rassool], LEST WE FORGET -rev25.pdf | 112ms |
+| q24 | Who were the children of J.M.H. Gool? | 0/7 (0%) | [Graph: J.M.H. Gool & Co.], LEST WE FORGET -rev25.pdf | 111ms |
+| q25 | Who was I.B. Tabata? | 0/5 (0%) | [Graph: I.B. Tabata], LEST WE FORGET -rev25.pdf | 101ms |
+| q26 | Who was Dr. Abdullah Abdurahman? | 0/6 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Dr. Abdulla Abdurahman] | 90ms |
+| q27 | What was the connection between Gandhi and J.M.H. Gool? | 0/5 (0%) | [Graph: J.M.H. Gool & Co.], LEST WE FORGET -rev25.pdf | 111ms |
+| q28 | Which organisations was the author involved in? | 0/3 (0%) | [Graph: Cape Coloured political organisations], LEST WE FORGET -rev25.pdf | 112ms |
+| q29 | What was the relationship between the TLSA and the Non-European Unity Movement? | 0/4 (0%) | [Graph: Non-European Unity Movement], LEST WE FORGET -rev25.pdf | 112ms |
+| q30 | When did J.M.H. Gool arrive in Cape Town and from where? | 0/6 (0%) | [Graph: J.M.H. Gool & Co.], sequence_diagram:Haji Joosub Maulvi Hamid Gool, LEST WE FORGET -rev25.pdf | 115ms |
+| q31 | What was the Hanaffi Quwatul Islam Mosque? | 0/6 (0%) | [Graph: Hanaffi Quwatul Islam Mosque], LEST WE FORGET -rev25.pdf | 107ms |
+| q32 | How was Cissie Gool related to J.M.H. Gool? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: J.M.H. Gool & Co.] | 112ms |
+| q33 | Who were the notable historical figures that J.M.H. Gool knew personally? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: J.M.H. Gool & Co.] | 114ms |
+| q34 | What was the Group Areas Act and how did it affect District Six? | 0/6 (0%) | sequence_diagram:District Six, LEST WE FORGET -rev25.pdf, [Graph: District Six] | 108ms |
+| q35 | Who was Hassen Mall? | 0/4 (0%) | [Graph: Hassen Mall], LEST WE FORGET -rev25.pdf | 110ms |
+| q36 | What political organisations were active in the Cape Coloured community during the author's lifetime? | 0/4 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Cape Coloured political organisations] | 114ms |
+| q37 | Who was Mahatma Gandhi and why was he in South Africa? | 0/7 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Mohandas Karamchand Gandhi] | 114ms |
+| q38 | Who was Cissie Gool's father? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Cissie Gool] | 95ms |
+| q39 | What was District Six like as a neighbourhood before the forced removals? | 0/6 (0%) | LEST WE FORGET -rev25.pdf, [Graph: District Six] | 110ms |
+| q40 | What was the Unity Movement's boycott policy? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Non-European Unity Movement] | 112ms |
+
+## Answers
+
+### q01 — Who is the author?
+
+The author is Yousuf (Joe) Rassool [1].
+
+### q02 — Who are the author's children?
+
+The provided sources do not contain that information. 
+
+However, based on a combination of excerpts [5] and [10], it can be concluded that:
+
+* The author has at least three children: Feyruz, Reza, and Zarina.
+* Additionally, there are six grandchildren mentioned: Joseph, Samuel, Alexander, Leonardo, Dylan, and Lewis.
+
+### q03 — Who are the author's grandchildren?
+
+According to [19] and [20], which list the dedication of the book "LEST WE FORGET -rev25.pdf" by Yousuf (Joe) Rassool:
+
+* Grandchildren: 
+  1. Joseph
+  2. Samuel
+  3. Alexander
+  4. Leonardo
+  5. Dylan
+  6. Lewis
+
+### q04 — To whom is the book dedicated?
+
+The book "LEST WE FORGET -rev25.pdf" by Yousuf (Joe) Rassool is dedicated to his children: Feyruz, Reza, and Zarina; and his grandchildren, Joseph, Samuel, Alexander, Leonardo, Dylan, and Lewis. [16]
+
+### q05 — Who was J.M.H. Gool?
+
+(no response)
+
+### q06 — Tell me about Buitencingle.
+
+(no response)
+
+### q07 — Who is the author's wife?
+
+The author's wife is Professor Nazima Rassool [1].
+
+### q08 — Tell me more about the author's wife.
+
+(no response)
+
+### q09 — Who was the author's grandfather?
+
+(no response)
+
+### q10 — Tell me about Kloof Nek.
+
+(no response)
+
+### q11 — What was the Teachers League of South Africa (TLSA)?
+
+(no response)
+
+### q12 — Who was Cissie Gool?
+
+(no response)
+
+### q13 — What was the All Africa Convention?
+
+(no response)
+
+### q14 — Where was District Six and what kind of place was it?
+
+(no response)
+
+### q15 — What were the forced removals from District Six?
+
+(no response)
+
+### q16 — Who was Gandhi and what was his connection to the Gool family?
+
+(no response)
+
+### q17 — What was Hewat Training College?
+
+(no response)
+
+### q18 — What was the New Era Fellowship?
+
+(no response)
+
+### q19 — What was the Non-European Unity Movement?
+
+(no response)
+
+### q20 — Describe the author's involvement in cricket.
+
+(no response)
+
+### q21 — Who was the author's mother?
+
+(no response)
+
+### q22 — Who was the author's father?
+
+(no response)
+
+### q23 — Who were the author's siblings?
+
+(no response)
+
+### q24 — Who were the children of J.M.H. Gool?
+
+(no response)
+
+### q25 — Who was I.B. Tabata?
+
+(no response)
+
+### q26 — Who was Dr. Abdullah Abdurahman?
+
+(no response)
+
+### q27 — What was the connection between Gandhi and J.M.H. Gool?
+
+(no response)
+
+### q28 — Which organisations was the author involved in?
+
+(no response)
+
+### q29 — What was the relationship between the TLSA and the Non-European Unity Movement?
+
+(no response)
+
+### q30 — When did J.M.H. Gool arrive in Cape Town and from where?
+
+(no response)
+
+### q31 — What was the Hanaffi Quwatul Islam Mosque?
+
+(no response)
+
+### q32 — How was Cissie Gool related to J.M.H. Gool?
+
+(no response)
+
+### q33 — Who were the notable historical figures that J.M.H. Gool knew personally?
+
+(no response)
+
+### q34 — What was the Group Areas Act and how did it affect District Six?
+
+(no response)
+
+### q35 — Who was Hassen Mall?
+
+(no response)
+
+### q36 — What political organisations were active in the Cape Coloured community during the author's lifetime?
+
+(no response)
+
+### q37 — Who was Mahatma Gandhi and why was he in South Africa?
+
+(no response)
+
+### q38 — Who was Cissie Gool's father?
+
+(no response)
+
+### q39 — What was District Six like as a neighbourhood before the forced removals?
+
+(no response)
+
+### q40 — What was the Unity Movement's boycott policy?
+
+(no response)
+

--- a/tests/kwaai-knowledge/results/native_p2p_d6_eval_metrowin_20260818_154708.md
+++ b/tests/kwaai-knowledge/results/native_p2p_d6_eval_metrowin_20260818_154708.md
@@ -1,0 +1,221 @@
+# RAG Eval Report
+
+**KB:** `D6_native`  **Model:** `llama3.1:8b`
+
+**Flags:** top_k=20  hyde=false  rerank=false  understand=false  llm_judge=false
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Questions | 40 |
+| Overall recall (token-overlap) | 0.5% (1.0/209) |
+| Avg latency | 109ms |
+
+## Per-question results
+
+| ID | Question | Hit rate | Sources | Latency |
+|----|----------|----------|---------|--------|
+| q01 | Who is the author? | 0/3 (0%) | [Graph: Yousuf Rassool], LEST WE FORGET -rev25.pdf | 88ms |
+| q02 | Who are the author's children? | 0/3 (0%) | LEST WE FORGET -rev25.pdf | 109ms |
+| q03 | Who are the author's grandchildren? | 0/6 (0%) | [Graph: Yousuf Rassool], LEST WE FORGET -rev25.pdf | 112ms |
+| q04 | To whom is the book dedicated? | 0/4 (0%) | LEST WE FORGET -rev25.pdf | 108ms |
+| q05 | Who was J.M.H. Gool? | 0/8 (0%) | [Graph: Haji Joosub Maulvi Hamid Gool], LEST WE FORGET -rev25.pdf | 109ms |
+| q06 | Tell me about Buitencingle. | 1/8 (12%) | [Graph: 7 Buitencingle Street], LEST WE FORGET -rev25.pdf | 108ms |
+| q07 | Who is the author's wife? | 0/3 (0%) | [Graph: Nazima Rassool], LEST WE FORGET -rev25.pdf | 109ms |
+| q08 | Tell me more about the author's wife. | 0/6 (0%) | [Graph: Nazima Rassool], LEST WE FORGET -rev25.pdf | 104ms |
+| q09 | Who was the author's grandfather? | 0/9 (0%) | [Graph: Grandpa's right hand man], LEST WE FORGET -rev25.pdf | 109ms |
+| q10 | Tell me about Kloof Nek. | 0/7 (0%) | [Graph: Kloof Nek], LEST WE FORGET -rev25.pdf | 110ms |
+| q11 | What was the Teachers League of South Africa (TLSA)? | 0/4 (0%) | [Graph: Teachers League of South Africa], LEST WE FORGET -rev25.pdf | 109ms |
+| q12 | Who was Cissie Gool? | 0/6 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Cissie Gool] | 111ms |
+| q13 | What was the All Africa Convention? | 0/5 (0%) | [Graph: All African Convention], LEST WE FORGET -rev25.pdf | 99ms |
+| q14 | Where was District Six and what kind of place was it? | 0/6 (0%) | [Graph: District Six], LEST WE FORGET -rev25.pdf | 111ms |
+| q15 | What were the forced removals from District Six? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: District Six], sequence_diagram:District Six | 154ms |
+| q16 | Who was Gandhi and what was his connection to the Gool family? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Gool family] | 103ms |
+| q17 | What was Hewat Training College? | 0/5 (0%) | [Graph: Hewat Training College], LEST WE FORGET -rev25.pdf | 111ms |
+| q18 | What was the New Era Fellowship? | 0/4 (0%) | [Graph: New Era Fellowship], LEST WE FORGET -rev25.pdf | 110ms |
+| q19 | What was the Non-European Unity Movement? | 0/4 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Non-European Unity Movement] | 109ms |
+| q20 | Describe the author's involvement in cricket. | 0/5 (0%) | [Graph: Kismets Cricket Club], LEST WE FORGET -rev25.pdf | 110ms |
+| q21 | Who was the author's mother? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Ayesha Rassool] | 113ms |
+| q22 | Who was the author's father? | 0/4 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Peter Alexander Rassool] | 113ms |
+| q23 | Who were the author's siblings? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Yousuf Rassool] | 99ms |
+| q24 | Who were the children of J.M.H. Gool? | 0/7 (0%) | [Graph: J.M.H. Gool & Co.], LEST WE FORGET -rev25.pdf | 109ms |
+| q25 | Who was I.B. Tabata? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: I.B. Tabata] | 108ms |
+| q26 | Who was Dr. Abdullah Abdurahman? | 0/6 (0%) | [Graph: Dr. Abdulla Abdurahman], LEST WE FORGET -rev25.pdf | 109ms |
+| q27 | What was the connection between Gandhi and J.M.H. Gool? | 0/5 (0%) | [Graph: Haji Joosub Maulvi Hamid Gool], LEST WE FORGET -rev25.pdf | 112ms |
+| q28 | Which organisations was the author involved in? | 0/3 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Cape Coloured political organisations] | 99ms |
+| q29 | What was the relationship between the TLSA and the Non-European Unity Movement? | 0/4 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Non-European Unity Movement] | 111ms |
+| q30 | When did J.M.H. Gool arrive in Cape Town and from where? | 0/6 (0%) | LEST WE FORGET -rev25.pdf, sequence_diagram:Haji Joosub Maulvi Hamid Gool, [Graph: J.M.H. Gool & Co.] | 114ms |
+| q31 | What was the Hanaffi Quwatul Islam Mosque? | 0/6 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Hanaffi Quwatul Islam Mosque] | 113ms |
+| q32 | How was Cissie Gool related to J.M.H. Gool? | 0/5 (0%) | [Graph: Haji Joosub Maulvi Hamid Gool], LEST WE FORGET -rev25.pdf | 109ms |
+| q33 | Who were the notable historical figures that J.M.H. Gool knew personally? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: J.M.H. Gool & Co.] | 113ms |
+| q34 | What was the Group Areas Act and how did it affect District Six? | 0/6 (0%) | LEST WE FORGET -rev25.pdf, sequence_diagram:District Six, [Graph: District Six] | 114ms |
+| q35 | Who was Hassen Mall? | 0/4 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Hassen Mall] | 108ms |
+| q36 | What political organisations were active in the Cape Coloured community during the author's lifetime? | 0/4 (0%) | [Graph: Cape Coloured political organisations], LEST WE FORGET -rev25.pdf | 116ms |
+| q37 | Who was Mahatma Gandhi and why was he in South Africa? | 0/7 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Mohandas Karamchand Gandhi] | 119ms |
+| q38 | Who was Cissie Gool's father? | 0/5 (0%) | [Graph: Cissie Gool], LEST WE FORGET -rev25.pdf | 112ms |
+| q39 | What was District Six like as a neighbourhood before the forced removals? | 0/6 (0%) | [Graph: District Six], LEST WE FORGET -rev25.pdf | 109ms |
+| q40 | What was the Unity Movement's boycott policy? | 0/5 (0%) | LEST WE FORGET -rev25.pdf, [Graph: Non-European Unity Movement] | 103ms |
+
+## Answers
+
+### q01 — Who is the author?
+
+(no response)
+
+### q02 — Who are the author's children?
+
+(no response)
+
+### q03 — Who are the author's grandchildren?
+
+(no response)
+
+### q04 — To whom is the book dedicated?
+
+(no response)
+
+### q05 — Who was J.M.H. Gool?
+
+(no response)
+
+### q06 — Tell me about Buitencingle.
+
+(no response)
+
+### q07 — Who is the author's wife?
+
+(no response)
+
+### q08 — Tell me more about the author's wife.
+
+(no response)
+
+### q09 — Who was the author's grandfather?
+
+(no response)
+
+### q10 — Tell me about Kloof Nek.
+
+(no response)
+
+### q11 — What was the Teachers League of South Africa (TLSA)?
+
+(no response)
+
+### q12 — Who was Cissie Gool?
+
+(no response)
+
+### q13 — What was the All Africa Convention?
+
+(no response)
+
+### q14 — Where was District Six and what kind of place was it?
+
+(no response)
+
+### q15 — What were the forced removals from District Six?
+
+(no response)
+
+### q16 — Who was Gandhi and what was his connection to the Gool family?
+
+(no response)
+
+### q17 — What was Hewat Training College?
+
+(no response)
+
+### q18 — What was the New Era Fellowship?
+
+(no response)
+
+### q19 — What was the Non-European Unity Movement?
+
+(no response)
+
+### q20 — Describe the author's involvement in cricket.
+
+(no response)
+
+### q21 — Who was the author's mother?
+
+(no response)
+
+### q22 — Who was the author's father?
+
+(no response)
+
+### q23 — Who were the author's siblings?
+
+(no response)
+
+### q24 — Who were the children of J.M.H. Gool?
+
+(no response)
+
+### q25 — Who was I.B. Tabata?
+
+(no response)
+
+### q26 — Who was Dr. Abdullah Abdurahman?
+
+(no response)
+
+### q27 — What was the connection between Gandhi and J.M.H. Gool?
+
+(no response)
+
+### q28 — Which organisations was the author involved in?
+
+(no response)
+
+### q29 — What was the relationship between the TLSA and the Non-European Unity Movement?
+
+(no response)
+
+### q30 — When did J.M.H. Gool arrive in Cape Town and from where?
+
+(no response)
+
+### q31 — What was the Hanaffi Quwatul Islam Mosque?
+
+(no response)
+
+### q32 — How was Cissie Gool related to J.M.H. Gool?
+
+(no response)
+
+### q33 — Who were the notable historical figures that J.M.H. Gool knew personally?
+
+(no response)
+
+### q34 — What was the Group Areas Act and how did it affect District Six?
+
+(no response)
+
+### q35 — Who was Hassen Mall?
+
+(no response)
+
+### q36 — What political organisations were active in the Cape Coloured community during the author's lifetime?
+
+(no response)
+
+### q37 — Who was Mahatma Gandhi and why was he in South Africa?
+
+(no response)
+
+### q38 — Who was Cissie Gool's father?
+
+(no response)
+
+### q39 — What was District Six like as a neighbourhood before the forced removals?
+
+(no response)
+
+### q40 — What was the Unity Movement's boycott policy?
+
+(no response)
+

--- a/tests/kwaai-knowledge/results/native_p2p_d6_eval_metrowin_20260818_154848.md
+++ b/tests/kwaai-knowledge/results/native_p2p_d6_eval_metrowin_20260818_154848.md
@@ -1,0 +1,472 @@
+# RAG Eval Report
+
+**KB:** `D6_native`  **Model:** `llama3.1:8b`
+
+**Flags:** top_k=20  hyde=false  rerank=false  understand=false  llm_judge=false
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Questions | 40 |
+| Overall recall (token-overlap) | 83.5% (174.6/209) |
+| Avg latency | 5309ms |
+
+## Per-question results
+
+| ID | Question | Hit rate | Sources | Latency |
+|----|----------|----------|---------|--------|
+| q01 | Who is the author? | 3/3 (100%) | [Graph: Yousuf Rassool], LEST WE FORGET -rev25.pdf | 7054ms |
+| q02 | Who are the author's children? | 3/3 (100%) | LEST WE FORGET -rev25.pdf | 3564ms |
+| q03 | Who are the author's grandchildren? | 6/6 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Yousuf Rassool] | 3328ms |
+| q04 | To whom is the book dedicated? | 4/4 (100%) | LEST WE FORGET -rev25.pdf | 3248ms |
+| q05 | Who was J.M.H. Gool? | 5/8 (62%) | LEST WE FORGET -rev25.pdf, [Graph: Haji Joosub Maulvi Hamid Gool] | 7267ms |
+| q06 | Tell me about Buitencingle. | 6/8 (75%) | LEST WE FORGET -rev25.pdf, [Graph: 7 Buitencingle Street] | 6190ms |
+| q07 | Who is the author's wife? | 3/3 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Nazima Rassool] | 3253ms |
+| q08 | Tell me more about the author's wife. | 6/6 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Nazima Rassool] | 4426ms |
+| q09 | Who was the author's grandfather? | 5/9 (56%) | LEST WE FORGET -rev25.pdf, [Graph: Haji Joosub Maulvi Hamid Gool] | 3580ms |
+| q10 | Tell me about Kloof Nek. | 6/7 (86%) | [Graph: Kloof Nek], LEST WE FORGET -rev25.pdf | 6081ms |
+| q11 | What was the Teachers League of South Africa (TLSA)? | 4/4 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Teachers League of South Africa] | 6223ms |
+| q12 | Who was Cissie Gool? | 6/6 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Cissie Gool] | 6599ms |
+| q13 | What was the All Africa Convention? | 5/5 (100%) | [Graph: All African Convention], LEST WE FORGET -rev25.pdf | 4164ms |
+| q14 | Where was District Six and what kind of place was it? | 5/6 (83%) | [Graph: District Six], LEST WE FORGET -rev25.pdf | 4502ms |
+| q15 | What were the forced removals from District Six? | 3/5 (60%) | LEST WE FORGET -rev25.pdf, [Graph: District Six], sequence_diagram:District Six | 16023ms |
+| q16 | Who was Gandhi and what was his connection to the Gool family? | 4/5 (80%) | [Graph: Gool family], LEST WE FORGET -rev25.pdf | 7519ms |
+| q17 | What was Hewat Training College? | 5/5 (100%) | [Graph: Hewat Training College], LEST WE FORGET -rev25.pdf | 3648ms |
+| q18 | What was the New Era Fellowship? | 4/4 (100%) | [Graph: New Era Fellowship], LEST WE FORGET -rev25.pdf | 6571ms |
+| q19 | What was the Non-European Unity Movement? | 4/4 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Non-European Unity Movement] | 5187ms |
+| q20 | Describe the author's involvement in cricket. | 3/5 (60%) | [Graph: Kismets Cricket Club], LEST WE FORGET -rev25.pdf | 4568ms |
+| q21 | Who was the author's mother? | 5/5 (100%) | [Graph: Ayesha Rassool], LEST WE FORGET -rev25.pdf | 3557ms |
+| q22 | Who was the author's father? | 4/4 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Peter Alexander Rassool] | 3172ms |
+| q23 | Who were the author's siblings? | 5/5 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Yousuf Rassool] | 3668ms |
+| q24 | Who were the children of J.M.H. Gool? | 2/7 (29%) | LEST WE FORGET -rev25.pdf, [Graph: J.M.H. Gool & Co.] | 5456ms |
+| q25 | Who was I.B. Tabata? | 5/5 (100%) | LEST WE FORGET -rev25.pdf, [Graph: I.B. Tabata] | 5324ms |
+| q26 | Who was Dr. Abdullah Abdurahman? | 6/6 (100%) | [Graph: Dr. Abdulla Abdurahman], LEST WE FORGET -rev25.pdf | 5755ms |
+| q27 | What was the connection between Gandhi and J.M.H. Gool? | 3/5 (60%) | LEST WE FORGET -rev25.pdf, [Graph: Haji Joosub Maulvi Hamid Gool] | 5578ms |
+| q28 | Which organisations was the author involved in? | 3/3 (100%) | [Graph: Cape Coloured political organisations], LEST WE FORGET -rev25.pdf | 4705ms |
+| q29 | What was the relationship between the TLSA and the Non-European Unity Movement? | 2/4 (50%) | LEST WE FORGET -rev25.pdf, [Graph: Non-European Unity Movement] | 5237ms |
+| q30 | When did J.M.H. Gool arrive in Cape Town and from where? | 3.6/6 (60%) | sequence_diagram:Haji Joosub Maulvi Hamid Gool, [Graph: J.M.H. Gool & Co.], LEST WE FORGET -rev25.pdf | 4274ms |
+| q31 | What was the Hanaffi Quwatul Islam Mosque? | 6/6 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Hanaffi Quwatul Islam Mosque] | 4705ms |
+| q32 | How was Cissie Gool related to J.M.H. Gool? | 5/5 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Haji Joosub Maulvi Hamid Gool] | 5508ms |
+| q33 | Who were the notable historical figures that J.M.H. Gool knew personally? | 2/5 (40%) | LEST WE FORGET -rev25.pdf, [Graph: J.M.H. Gool & Co.] | 7944ms |
+| q34 | What was the Group Areas Act and how did it affect District Six? | 5/6 (83%) | sequence_diagram:District Six, [Graph: District Six], LEST WE FORGET -rev25.pdf | 5998ms |
+| q35 | Who was Hassen Mall? | 4/4 (100%) | LEST WE FORGET -rev25.pdf, [Graph: Hassen Mall] | 5603ms |
+| q36 | What political organisations were active in the Cape Coloured community during the author's lifetime? | 4/4 (100%) | [Graph: Cape Coloured political organisations], LEST WE FORGET -rev25.pdf | 4034ms |
+| q37 | Who was Mahatma Gandhi and why was he in South Africa? | 7/7 (100%) | [Graph: Mohandas Karamchand Gandhi], LEST WE FORGET -rev25.pdf | 4454ms |
+| q38 | Who was Cissie Gool's father? | 3/5 (60%) | [Graph: Cissie Gool], LEST WE FORGET -rev25.pdf | 3252ms |
+| q39 | What was District Six like as a neighbourhood before the forced removals? | 6/6 (100%) | LEST WE FORGET -rev25.pdf, [Graph: District Six] | 7494ms |
+| q40 | What was the Unity Movement's boycott policy? | 4/5 (80%) | LEST WE FORGET -rev25.pdf, [Graph: Non-European Unity Movement] | 3657ms |
+
+## Answers
+
+### q01 — Who is the author?
+
+Yousuf (Joe) Rassool [1].
+
+### q02 — Who are the author's children?
+
+The provided sources list the following as the author's children:
+
+1. Feyruz [17]
+2. Reza [17]
+3. Zarina [17]
+
+It is also mentioned that they have grandchildren, but their names are not provided in the text excerpts: 
+1. Joseph
+2. Samuel
+3. Alexander
+4. Leonardo
+5. Dylan
+6. Lewis [17]
+
+### q03 — Who are the author's grandchildren?
+
+The author's grandchildren are listed in the Dedication section of [19] as:
+
+1. Joseph
+2. Samuel
+3. Alexander
+4. Leonardo
+5. Dylan
+6. Lewis
+
+These names appear along with his children, Feyruz, Reza, and Zarina.
+
+### q04 — To whom is the book dedicated?
+
+The book is dedicated to the author's children: Feyruz, Reza, and Zarina [17], as well as his grandchildren: Joseph, Samuel, Alexander, Leonardo, Dylan, and Lewis [17].
+
+### q05 — Who was J.M.H. Gool?
+
+J.M.H. Gool (also known as Joosub Maulvi Hamid Gool) was a community leader, trader, and spice merchant who lived in District Six, Cape Town. He was born in 1874 or 1880 (the exact date is not specified), and his family originated from Mauritius via Swat, Gujarat. 
+
+According to the sources [1]–[20], he had two wives: Bibi Gool and Wahida Gool. From Bibi, he had children including Ayesha Rassool, Mohamed Saaid Gool, Zohra Abdurahman, and others. From Wahida, he had children including Abdul Hamid Gool, Mariam Margie Gool, Minnie Gool, Fatima Timmie Gool, and others.
+
+Gool was a highly respected citizen in the community, known for his achievements and contributions to society. He was described as an 'Oriental trader' in the Supreme Court transcripts of 1892. In addition to being a merchant, he was also involved in British Justice, demonstrating his standing within the Cape community.
+
+He lived at 7 Buitencingle Street in District Six and hosted notable visitors such as Mahatma Gandhi, Cecil John Rhodes, George Bernard Shaw, and Dr. Abdulla Abdurahman. He performed the Hajj pilgrimage in 1899.
+
+Gool's family was close to other prominent families in Cape Town, including the Dollie clan and the Abdurahmans. His son, Abdul Hamid Gool, married Cissie Gool (Zainunnissa), making her his daughter-in-law. He died on April 1, 1940.
+
+He had a notable impact on the community, as evident from the numerous events he hosted at his residence and the many visits he received from influential figures of his time.
+
+### q06 — Tell me about Buitencingle.
+
+Buitencingle was a grand 13-room mansion located in District Six, Cape Town. It was the home of J.M.H. Gool, the grandfather of the memoir's author (Joe Rassool). According to source [1], the street was wide and cobbled with traffic islands sporting stunted palm trees.
+
+Buitencingle was situated on 7 Buitenkingle Street (also known as No. 7 Buitencingle), which had a view of Table Mountain and Devil's Peak. The house had many rooms, making it necessary for the family to employ servants to manage them. Source [12] states that my grandmother tried to learn Afrikaans not only to interpret the insults of her rival but also to communicate with the servants.
+
+Source [9] shows an old photograph of Buitencingle (circa 1905) from the bell tower of St Martini German Lutheran Church, which gives a glimpse into what the mansion looked like during that time. 
+
+The author reminisces about his childhood at Buitencingle in various chapters. He recalls having more space than they could cope with and a garden with fruit trees (Source [2]). However, there were also signs of neglect and abandonment, such as burnt-down candles and newspapers piled on the floor as a makeshift bed.
+
+Buitencingle had a significant influence on the author's life and growth. In source [6], it is mentioned that Buitencingle was where he stayed and experienced the sovereign effect it had on his development.
+
+### q07 — Who is the author's wife?
+
+The author's wife is Professor Nazima Rassool [1]. She is an academic researcher who urged the author to ground his writing in background investigation [2, 14, 16].
+
+### q08 — Tell me more about the author's wife.
+
+The provided sources contain several references to the author's wife, Nazima Rassool [1, 9, 20]. Here are all the specific facts that can be gathered from these excerpts:
+
+* Her title is Professor [1].
+* She is an academic researcher [1, 8, 9, 20].
+* She urged her husband to ground his writing in background investigation and research, which transformed the book into a historically documented account of District Six [1, 8, 9].
+* She played a central role in shaping the memoir by encouraging her husband to undertake historical research [1].
+
+Note that there is no information available about Nazima's age, origin, ancestry, family connections, occupation, achievements, or historical associations beyond what is mentioned above.
+
+### q09 — Who was the author's grandfather?
+
+According to [1], the author's grandfather was Haji Joosub Maulvi Hamid Gool (J.M.H. Gool). He was a spice merchant, community leader, and founder of the Hanaffi Quwatul Islam Mosque in District Six.
+
+### q10 — Tell me about Kloof Nek.
+
+Kloof Nek is a natural saddle or mountain pass between Table Mountain and Lion's Head in Cape Town. It is a landmark of Cape Town's topography, offering views of both Table Mountain and Lion's Head [1]. The area is also known for its scenic beauty, with the Glen situated on its eastern flank being described as a "place of haunting beauty" [4], [17], [18].
+
+Kloof Nek was a popular spot for lovers, mountaineers, nature lovers, and ramblers, but it also had a downside, with many people finding refuge in the area's cavelets, culverts, and bushes to drink away their sorrows [5]. There were also instances of "Bergies", mountain dwellers who lived in poverty and drank cheap wine and methylated spirits.
+
+In addition to its natural beauty, Kloof Nek was also a hub for social and cultural activities. The area had a tram terminus, which connected the city bowl with Table Mountain [3]. It was also a place where people would gather to enjoy art, music, and politics, as described by the author in regards to his friend Cheops' house in Searle Street [9].
+
+Overall, Kloof Nek is a significant location in Cape Town's history and geography, serving as a connection between Table Mountain and Lion's Head and offering stunning views of the city.
+
+### q11 — What was the Teachers League of South Africa (TLSA)?
+
+The Teachers' League of South Africa (TLSA) was a professional and political organization for Coloured teachers. [1] It was affiliated with the Non-European Unity Movement and adopted the boycott and non-collaboration policy, challenging racial discrimination in education and fighting for equal opportunities for Coloured teachers and students. [1] The TLSA had an Education Journal where members received training in political/educational composition and had their articles published. [6]
+
+Its conferences were important civic occasions, opened by the mayor with a civic banquet at the ratepayers' expense. [2, 19] The organization was also social, as teachers from upcountry came to the city for its conferences during their winter vacation. [19]
+
+The TLSA had members who were part of the struggle for democracy, such as Alie Fataar, Edgar Maurice, Jane Gool, Ben Kies, Rev Gordon, Walter Parry, R.O.Dudley, Solly Edross, E.C Roberts, Abe Desmore, Rev Dan Wessels, and Frank Landsman. [15] They were seen as leaders in the community, but this was an untenable situation according to the authorities because it meant a teachers' union becoming political. [16, 20]
+
+Eventually, the TLSA was forced to change its leadership and strategies due to government pressures, leading to the development of new organizations such as the Teachers' Educational and Professional Association (TEPA). [18]
+
+### q12 — Who was Cissie Gool?
+
+Cissie Gool (Zainunnissa Gool) was a Cape Town city councillor, lawyer, and political activist closely associated with the Non-European Unity Movement and the anti-apartheid struggle [1].
+
+She was born on 1897-02-14 [1] and died on 1963-12-02 [1]. Her father was Dr. Abdulla Abdurahman, a Cape Town doctor and city councillor who was the first Coloured person elected to the Cape Town City Council [1].
+
+Cissie Gool was married to Abdul Hamid Gool and had at least one child, Shaheen Gool [1]. She was also related to other notable individuals, including her brother Goolam Gool and her cousin Nellie Abdurahman [7, 10].
+
+She was a member of the Unity Movement and an anti-apartheid activist. Cissie Gool was known for her strong personality and her ability to inspire loyalty in others. She was described as having "the aura of a leader" [4]. 
+
+Cissie Gool was involved in various public meetings and events, including speaking at a meeting in support of measures to deal with 'influx control' and the street gangs [5, 13, 14].
+
+She was also known for her role in organizing demonstrations against government policies. In 1937, she led a massive demonstration of the Liberation League on the Grand Parade to rally the vote-less masses against the government's plan to introduce residential segregation [15].
+
+### q13 — What was the All Africa Convention?
+
+The All African Convention (AAC) was a political organization founded in 1935. According to source [1], it was established "in response to the Hertzog Bills, which stripped Africans of their limited voting rights." The AAC united various African political organizations that sought unity against racial oppression.
+
+In source [3], the author mentions attending an All African Convention meeting and seeing some of its leaders, including Tsotsi, Honono, and Sihlali.
+
+### q14 — Where was District Six and what kind of place was it?
+
+According to [1], District Six was a district in Cape Town, South Africa.
+
+According to [2] and repeated in several other excerpts (e.g., [8], [11], [20]), it was a thriving, multicultural community that was home to people of various ethnic groups, including Coloured, African, Indian, and White residents. The community was known for its rich urban culture of music, jazz, and community life.
+
+It's also mentioned in several excerpts (e.g., [5], [11]) that under the Group Areas Act, the apartheid government declared District Six a White area in 1966 and carried out forced removals of all non-White residents to the Cape Flats, bulldozing and demolishing almost every building.
+
+### q15 — What were the forced removals from District Six?
+
+The sources do not provide specific details about the forced removals from District Six. However, they mention that the community was dispersed under the Group Areas Act (1950) and the haemorrhaging of shops in Hanover Street began in the early 1950s [10]. It is stated that all the vibrant community scattered and disintegrated "irrevocably pulverised by Apartheid" [10].
+
+### q16 — Who was Gandhi and what was his connection to the Gool family?
+
+Mahatma Gandhi is mentioned throughout the sources as a prominent figure in Indian independence movement and South African politics. He spent over 20 years in South Africa, where he developed his philosophy of non-violent resistance.
+
+According to [1] and [2], Gandhi was hosted by the Gool family at their home, 7 Buitencingle Street, District Six, Cape Town, in February 1914. This connection led to a friendship between Joe Rassool (the author) and the Gools, as stated in [2].
+
+Gandhi's relationship with the Gools is further highlighted in [3], where Gandhi extended his contacts among the poorer sections of the community, particularly through his association with the Gool family. In [4], a letter from J.M.H. Gool to M.K. Gandhi (1897) demonstrates their correspondence and close connection.
+
+Additionally, Gandhi was welcomed by the Prime Minister Botha at Groot Schuur in [2]. He also visited the residence of the Prime Minister and his wife, as well as Mrs. Gladstone, the wife of the Governor-General [2].
+
+Gandhi's personal connections with the Gool family are evident through various letters and interactions mentioned throughout the sources:
+
+* Gandhi's son fell in love with one of Goulam Gool's sisters, a Muslim girl, which led to Gandhi refusing their union due to concerns about religious barriers [6].
+* Gandhi helped putty and stain his uncle Dr. A. Gool's surgery floor [11].
+* The Gools welcomed Gandhi at Buitencingle Street multiple times, including in 1911 and 1914 [9] and [18].
+
+Gandhi also recognized the potential for community service in Dr. A. Gool, as mentioned in [15]. However, Dr. Gool chose not to pursue social activism despite his connections with Gandhi.
+
+Overall, Mahatma Gandhi had a close relationship with the Gool family, both professionally and personally, during his time in South Africa.
+
+### q17 — What was Hewat Training College?
+
+Hewat Training College was a teacher training college in Cape Town for Coloured students, established under the apartheid-era segregated education system [1]. It trained Coloured teachers and was associated with the Teachers League of South Africa (TLSA) [1]. The author, Yousuf Rassool, had connections to Hewat, having planned to attend it as a schoolteacher [4, 17].
+
+### q18 — What was the New Era Fellowship?
+
+The New Era Fellowship (NEF) was a cultural and political discussion society in Cape Town, associated with the Non-European Unity Movement. It held public lectures and debates on political, social, and philosophical topics, and served as a gathering place for progressive intellectuals, teachers, and activists in the Coloured community [1].
+
+The NEF was established in 1937 "to discuss everything under the sun" [15]. It had its own programme of events and lectures, which were overseen by the Organising Secretary [9]. The NEF played a significant role in uniting various organisations within the Non-European Unity Movement, including the Coloured branch of Smuts's United Party, sports clubs, churches, and trade unions [6].
+
+The New Era Fellowship was involved in activities such as boycotting the Van Riebeeck Festival and campaigning for democratic rights [11]. It also published a book titled "The Awakening of a People" by Mr. I.B. Tabata, which recorded the coming into existence of the All African Convention [13].
+
+Some notable individuals associated with the New Era Fellowship include Hassan Bavasah, who was an Organising Secretary and had a devastating debating style; Ben Kies, whose analysis of the international situation was criticized by SOYA (the Society of Young Africa); and Cassim Amra, a Natal Indian who was a member of the Communist Party [17].
+
+The New Era Fellowship was seen as a gathering place for progressive intellectuals, teachers, and activists in the Coloured community. It held lectures on various topics, including the Indian Question, and played a significant role in uniting different organisations within the Non-European Unity Movement [10].
+
+### q19 — What was the Non-European Unity Movement?
+
+The Non-European Unity Movement (NEUM) was a movement that emerged in 1943 to unite African, Coloured, and Indian people against apartheid and colonialism [1]. Its programme was based on the Ten Point plan for equal rights, which included demands such as the full unfettered franchise and free and equal education to the age of sixteen [5].
+
+The NEUM adopted a boycott and non-collaboration policy, refusing to participate in any apartheid government institutions, including the Coloured Advisory Council [1]. The movement was influenced by various individuals and groups, including Dr. Jabavu, who attempted to create a non-European unity movement on three occasions before the NEUM's establishment [3], [20].
+
+The NEUM revolutionised the political scene with its doctrine of non-collaboration and the boycott weapon, galvanising the non-white disenfranchised to a realisation of the need for a programme-based struggle that rejected the old tactics of deputations and appeals for justice at round table conferences [7].
+
+### q20 — Describe the author's involvement in cricket.
+
+The provided sources describe the author's involvement in cricket as follows:
+
+* The author was actively involved in cricket through Kismets Cricket Club and non-European cricket (Source [1]).
+* He played and administered club cricket in the Cape (Source [1]).
+* The author mentioned learning to play cricket seriously due to his friendship with Hassen Mall (Source [8]).
+* He began mastering the elements of the forward defensive stroke and built the foundation of the art of batting (Source [8]).
+* In a biennial cricket tournament, the author was not selected for the team despite having played an impressive innings at Rosmead (Source [12]).
+
+Overall, the author's involvement in cricket involved playing, administering, and learning about the game through his membership with Kismets Cricket Club and interactions with other cricketers.
+
+### q21 — Who was the author's mother?
+
+According to [1] Ayesha Rassool (also known as Lallie, Ayesha Gool, or Ayesha Lallie Gool) was the author's mother. She was a daughter of Bibi Gool and Haji Joosub Maulvi Hamid Gool.
+
+### q22 — Who was the author's father?
+
+The author's father was Peter Alexander Rassool. He was also known as Peerbhai or Peru (as the mother called him) [1].
+
+### q23 — Who were the author's siblings?
+
+The provided sources list the following siblings of Yousuf (Joe) Rassool:
+
+1. Fazil Rassool
+2. Abdul Rassool
+3. Berina Rassool
+4. Nasim Rassool
+5. Zain Rassool
+6. Rasheda Rassool
+7. Yasmin Rassool
+
+### q24 — Who were the children of J.M.H. Gool?
+
+According to source [20], J.M.H. Gool had a first son born in 1886, but the child's name is not specified. The text does mention that he had two wives: Bibi (from Gujarat, India) and Wahida Ta'al (a Dollie from the Cape). 
+
+In source [16], there is no specific information about J.M.H.'s children.
+
+However, in source [17] and [20], the names of some of his grandchildren are mentioned. In [17], the children mentioned as being at the Gool residence during an event are:
+- Abdul (age 9)
+- Fazil (age 6)
+- Zainunissa (or Zaironesa, age 4-ish)
+- Rasheda (age 2)
+- Berina (baby, with "large soulful eyes" and only a year old)
+- Lallie (Yasmin's mother) was pregnant with Yasmin at the time.
+
+In source [20], Kassim is mentioned as one of Bibi's children.
+
+### q25 — Who was I.B. Tabata?
+
+I.B. Tabata was a prominent political activist and leader in the Non-European Unity Movement (Unity Movement). He married Jane Gool, daughter of J.M.H. Gool [1]. 
+
+Tabata was deeply involved in the anti-apartheid struggle and the Unity Movement's non-collaboration policy [1].
+
+He completed his book "The Awakening of a People" as chairman of the New Era Fellowship [3][16].
+
+ Tabata himself had written an indictment against Kies, which was evident because he rose to attack him in a meeting [4].
+
+In 1952, we believed that his approach to political organisation was the way forward, as delineated by B.M. Tabata [14].
+
+His talk at the NEF on "One Day in the Life of Ivan Denisovich" made a tremendous impression on me at the time [17]. 
+
+Soon he appeared on the platform at public meetings and became a member of the inner sanctum of the National Anti-CAD [17].
+
+### q26 — Who was Dr. Abdullah Abdurahman?
+
+The provided sources state the following facts about Dr. Abdullah Abdurahman:
+
+1. Associated with: Haji Joosub Maulvi Hamid Gool, Non-European Unity Movement [1]
+2. Father of: Cissie Gool [1]
+3. Nationality: South Africa [1]
+4. Born: 1872-09-08 [1]
+5. Died: 1940-02-20 [1]
+
+Dr. Abdullah Abdurahman was a Cape Town doctor, physician, and city councillor who was the first Coloured person elected to the Cape Town City Council. He was also a leader of the African Political (later People's) Organisation (APO), a pioneering figure in Cape Coloured political life.
+
+In addition, the sources mention that:
+
+6. His mother, Gadija Dollie, was said to be a most beautiful woman [17]
+7. His grandfather was brought to South Africa as a slave and became prominent in the community [17]
+
+Dr. Abdurahman's involvement with Gandhi is also mentioned: 
+
+8. He helped Gandhis when they needed assistance in reading Gujarati accounts [4]
+
+### q27 — What was the connection between Gandhi and J.M.H. Gool?
+
+According to [2], Gandhi had a close relationship with the Gool family, particularly J.M.H. Gool, who received notable visitors including Mahatma Gandhi during his 1914 farewell visit to South Africa before returning to India.
+
+[3] mentions that Gandhi extended his contacts in the community, particularly among the poorer sections and devoted much time to public work for Indians.
+
+[7] states that Gandhi had a close relationship with Dr. J.M.H. Gool, who was a medical student at Guy's Hospital in London, as evident from their correspondence, which was published in Indian Opinion on October 6, 1906 ([18]).
+
+Excerpt [8] mentions that Gandhi saw great potential for community service in Dr. Gool and built up his image in the community through editorials reporting his career progress.
+
+[12] states that Gandhi helped to furbish my uncle’s surgery by puttying and staining the floor, indicating a close personal relationship between them.
+
+Overall, there was a strong connection between Gandhi and J.M.H. Gool, characterized by mutual respect, trust, and cooperation in promoting social activism and community service.
+
+### q28 — Which organisations was the author involved in?
+
+The author, Joe Rassool, was involved in the following organisations:
+
+1. The New Era Fellowship (NEF) [7], [17]
+2. The Non-European Unity Movement (NEUM) [1] 
+3. The Teachers League of South Africa (TLSA) [4]
+4. The Trafalgar High school cultural society [5]
+5. The Hewat Amateur Theatrical Society [11], [19]
+6. The Trafalgar Players [3]
+7. The All African Convention (AAC) [2] and later in life the Cape British Indian Union, of which he was joint secretary then president in 1911.
+ 
+The author also mentions involvement with other organisations such as the Liberation League, the Workers’ Party, and the Communist Party of South Africa.
+
+### q29 — What was the relationship between the TLSA and the Non-European Unity Movement?
+
+The sources do not explicitly state a formal organizational relationship between the Teachers' League of South Africa (TLSA) and the Non-European Unity Movement (NEUM). However, they are associated with each other.
+
+[1] mentions that the NEUM was affiliated with the All African Convention. [8] indicates that Grandpa's daughter, Aunt Jane, and her brother, Dr. Goolam, were "moving spirits" of the young Turks within the NEUM. [11] states that the TLSA worked with dedication to spread the Parent Teachers' Association movement throughout the Cape after a split in the movement was put behind them.
+
+[18] explicitly states that the Teachers' League of South Africa (TLSA) joined the Non-European Unity Movement, acknowledging that the struggle for equal education was also bound up with the struggle for a democratic society. This suggests that the TLSA and NEUM shared similar goals and values.
+
+The TLSA's involvement with the NEUM is not detailed in the sources. However, it appears to be a collaborative effort rather than a formal organizational relationship.
+
+### q30 — When did J.M.H. Gool arrive in Cape Town and from where?
+
+The provided sources do not contain specific information about when J.M.H. Gool arrived in Cape Town or from where he came. However, it is mentioned that Bibi Gool's family lived in Broach, Gujarat, India, and she was married to Haji Joosub Maulvi Hamid Gool (also known as J.M.H. Gool) in 1879 or 1880 [1].
+
+### q31 — What was the Hanaffi Quwatul Islam Mosque?
+
+The Hanaffi Quwatul Islam Mosque was an Islamic place of worship, specifically an mosque, located in Loop Street, Cape Town. It was founded in 1898 and was central to the history of the Gool family and the Cape Muslim community in District Six [1]. The author's grandfather, Dr. Abdullah Abdurahman (but text states J.M.H. Gool), was a founding trustee of the mosque [1].
+
+### q32 — How was Cissie Gool related to J.M.H. Gool?
+
+According to [1], Cissie Gool's husband Abdul Hamid Gool was the son of J.M.H. Gool. Therefore, Cissie Gool was the daughter-in-law of J.M.H. Gool. 
+
+However, according to [3] and [9], there is a more complex family relationship: J.M.H. Gool had two wives, Bibi (who left him) and Wahida Ta'Al. It is implied in these excerpts that Cissie Gool was the daughter of Dr. Abdurahman, making her J.M.H. Gool's step-daughter or possibly a foster child, given the close relationship between Cissie and J.M.H.'s family.
+
+The exact nature of their relationship is not specified in all sources, but it is clear that Abdul Hamid Gool was the son of J.M.H. Gool and Cissie Gool was his wife.
+
+### q33 — Who were the notable historical figures that J.M.H. Gool knew personally?
+
+Based on the provided sources:
+
+From source [3], J.M.H. Gool was a member of the Non-European Unity Movement (NEUM), and among other individuals, Robben Island's founder member Roberts presided over an event where Wilson, F Gow, James Currey, and Rev R.A. Jackson were also present.
+
+Source [8] mentions that J.M.H. Gool met luminaries such as Fred Bodmer, Gregoire Boonzaaier, Terence Macaw, Ben Kies, Paul Kostin, Wolf Kiebel, J.G., Dora Taylor, Jane Gool, I.B. Tabata, Eddie Roux, Goolam Gool, Eli Weinberg, Waradeya Abdurahman, Dr. Abdullah Abdurahman, Leah Solomon, and Zaid Gamiet.
+
+Source [12] mentions that Gandhi stayed at J.M.H. Gool's residence in 1914.
+
+From source [18], J.M.H. Gool is not mentioned in Ralph Bunche’s travel notes of his stay with the Gools in 1937.
+
+Therefore, some notable historical figures who were acquainted or associated with J.M.H. Gool include:
+
+* Gandhi
+* Dr. Abdulla Abdurahman
+* Eddie Roux
+* I.B. Tabata
+* Eli Weinberg
+* Waradeya Abdurahman
+
+Additionally, source [5] mentions that Mahomed was not related to J.M.H. Gool but may have shared a clan affiliation and was his senior, financier, and possibly mentor.
+
+The following individuals are mentioned as being on the same platform or present at events associated with J.M.H. Gool:
+
+* Wilson
+* F Gow
+* James Currey
+* Rev R.A. Jackson
+* Roberts (founder member of Robben Island)
+* Dr. A Abdurahman
+
+These individuals were likely acquaintances, associates, or fellow activists of J.M.H. Gool, but their exact relationships are not specified in the provided sources.
+
+### q34 — What was the Group Areas Act and how did it affect District Six?
+
+According to source [1], the period of recapturing subjugated cultural histories of Cape Town begins in 1897. By 1950, the Group Areas Act had been established (source [1] and [2]). The Group Areas Act was legislation that aimed to separate different racial groups into specific areas, with the goal of preserving White dominance.
+
+Source [2] states: "This is the story of the life and times of a family living in District Six, a thriving cosmopolitan area in the heart of Cape Town, before the Group Areas Act (1950) dispersed its people across the barren sandhills of the Cape Flats decimating the once vibrant community and way of life."
+
+Source [10] describes the effect of the Group Areas Act: "This obscene social experiment, that would devastate the lives of hundreds of thousands of the unfranchised of South Africa, occurred. To add insult to injury the Prime Minister, Daniel Francois Malan, declared sanctimoniously in his New Year's message to the nation..."
+
+Source [14] describes the Group Areas Act as "The crowning piece of the Government legislation... The Group Areas Act, was the lynch pin, the Big Bertha of the Apartheid weaponry."
+
+### q35 — Who was Hassen Mall?
+
+From sources [1]–[20], we can gather information about Hassen Mall as follows:
+
+* He was a close friend and fellow cricketer of the author Yousuf Rassool from District Six, Cape Town.
+* He is described as "dark, lean and athletic" with a "magnetism" that could not be denied. (Source [4])
+* He played cricket for various teams and was known for his skills in bowling and batting. In particular, he was the captain of a team participating in the biennial tournament at Curry's Fountain in Durban in 1951.
+* After completing his LLB degree, Hassen Mall left for Durban to study medicine (Source [4]). However, it is not clear whether he actually completed his medical studies or continued practicing law instead.
+* He was a member of The Indian Congress and had connections with other notable figures such as Dawood and Fatima (Sources [15] and [16]).
+* Hassen Mall was described by the author as "my hero" who profoundly affected the author's life in the years that followed their meeting.
+
+### q36 — What political organisations were active in the Cape Coloured community during the author's lifetime?
+
+The main political organisations active in the Cape Coloured community during the mid-twentieth century were: [1]
+
+* The Non-European Unity Movement (NEUM)
+* The Teachers League of South Africa (TLSA)
+* The New Era Fellowship (NEF)
+* The All African Convention (AAC)
+
+These organisations were united by the boycott and non-collaboration policy against apartheid institutions.
+
+### q37 — Who was Mahatma Gandhi and why was he in South Africa?
+
+According to [1], Mohandas Karamchand Gandhi, known as Mahatma Gandhi (Mahatma meaning "Great Soul"), came to South Africa in 1893 as a lawyer on a one-year assignment for the merchant Dada Abdullah. He stayed on for over 20 years developing satyagraha (non-violent resistance) after Natal moved to disenfranchise Indians in 1894.
+
+He was in South Africa to assist his attorney in a civil suit against a merchant in Pretoria, and he had been sent for because the accounts were kept in Gujarati, which was Gandhi's mother tongue [7].
+
+### q38 — Who was Cissie Gool's father?
+
+Cissie Gool's father was Dr. Abdulla Abdurahman [1].
+
+### q39 — What was District Six like as a neighbourhood before the forced removals?
+
+According to the sources, District Six was a vibrant and multicultural community near the centre of Cape Town. It was situated below Devil's Peak and was home to Coloured, African, Indian, and White residents who built a rich urban culture of music, jazz, and community life (Source [1]). The neighbourhood had a "pulsing life" with "more life, more zest, more fire, more warmth and care than many other places one could mention" (Source [2]).
+
+The author remembers the neighbourhood as having a strong sense of community, where people knew each other and looked out for one another. In Source [3], it is mentioned that the author's school grounds were undeveloped, but it was deemed good enough to be the site of the first Post Matriculation Teacher Training facility for Coloureds in the country.
+
+Source [17] mentions that a community of freed slaves from America and the West Indies thrived in District Six in Victorian times. Some of them would achieve great position and wealth. Their expulsion at the turn of the century foreshadowed the Apartheid era evictions of the same neighbourhood decades later.
+
+The author also describes the area as having a rich history, with many families living together in close proximity (Source [18]). The book tells the story of the life and times of a family living in District Six, which was a thriving cosmopolitan area in the heart of Cape Town before the Group Areas Act dispersed its people across the barren sandhills of the Cape Flats.
+
+It is worth noting that while the author's description of District Six is generally positive, some sources suggest that the neighbourhood also had its challenges. For example, Source [5] mentions that the area was plagued by crime and violence during World War II, with gangs gatecrashing house parties and terrorizing guests.
+
+Overall, based on the available sources, it appears that District Six was a vibrant and multicultural community before the forced removals, but also had its challenges and complexities.
+
+### q40 — What was the Unity Movement's boycott policy?
+
+The Unity Movement adopted a boycott and non-collaboration policy - refusing to participate in any apartheid government institutions. [1] Some members of the "Movement" simply ignored the injunction to boycott, but those who did boycott were mainly those who accepted service on the Coloured Affairs Council (CAC) and were boycotted in every aspect of their lives, socially, economically, and otherwise. [10]
+


### PR DESCRIPTION
End-to-end validation that the V1Lazy fix (#107) holds under sustained real
load, using a full D6 rebuild as the workload. Adds the harness and the eval
reports.

## The headline: native transport is accuracy-neutral

| Graph | Transport | Date | Recall |
|---|---|---|---|
| production D6 | p2pd | 2026-07-16 | 90.4% (189.0/209) |
| **production D6** | **native** | **today** | **90.0% (188.0/209)** |
| `D6_native` (fresh rebuild) | native | today | 83.5% (174.6/209) |

Same graph, same binary, same peer — only the transport differs. 0.4pp is inside
LLM nondeterminism.

**Throughput is at parity per peer.** 1152/1152 chunks, **zero** transport
errors, 0.12 chunks/s on one peer with 2 workers; the baseline was 0.24 across
two peers with 4 — the same 0.12 each. Extraction came out *richer*, not lossier:
2083 entities vs 1983.

The 83.5% is a valid clean run; it is lower only because a single-pass rebuild
lacks the refinement production D6 has accumulated. Notably it is **not** a dedup
failure — `D6_native` has zero normalized-name collisions and `dedup --auto`
merges exactly 1 entity, and its composition sits within ~4% of production D6 on
every entity type.

## Two invalid reports, committed on purpose

Two evals scored 9.6% and 0.5%. Both are the **circuit breaker opening** and
failing every remaining question in ~109 ms — once from a VRAM-starved peer
timing out, once from the loopback dial bug (#108). Neither is a RAG result.

They are kept as evidence of a failure mode that is easy to misread, and
`README_native_p2p_d6_20260818.md` states plainly which reports are valid and
which are not — so nobody finds a 9.6% D6 eval later and draws the obvious wrong
conclusion.

## Two lessons now encoded in the harness

- **Workers are per-run, not per-peer.** Four against a single peer overloads its
  Ollama into 502/503; dropping to two took errors from 142 to zero. Hence
  `WORKERS=`.
- **A peer can look perfectly healthy and be unusable.** metro-linux answered a
  probe in 22.5 ms and advertised 32/32 blocks VERIFIED while failing ~50% of
  inference calls. Liveness checks miss it; only the workload exposes it, and it
  surfaces as an *accuracy* regression. Hence `PEERS=`, and hence the standing
  advice to audit chunk and entity counts before believing any score.

Logs and the 1 MB coref intermediate are omitted — no `.log` is tracked anywhere
under `results/`. Production D6 was never modified; the rebuild targets
`D6_native`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP