### PR TITLE
docs(trust): draft proposal to DTGWG for a libp2p Trust Tasks binding

### DIFF
--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-discussion-draft.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-discussion-draft.md
@@ -1,0 +1,138 @@
+# GitHub Discussion draft — libp2p binding
+
+**Where:** `trustoverip/dtgwg-trust-tasks-tf` → Discussions → **Ideas**
+**Status:** **ON HOLD — do not post yet.** See "Erika Bjune" below.
+
+**Why this exists:** Glenn Gore's feedback on the 2026-08-19 call — *"it seems to
+me that this should be a Discussion on the TF GH so that the decision is
+documented and the PR can be linked against it."* He is right, and he authored
+the HTTPS binding, so this follows his process rather than ours. He also asked a
+clarifying question — *"You are talking about a Trust Task Binding for libp2p?"* —
+which the opening line answers directly.
+
+Keep it short. It is a Discussion opener asking one decision, not the proposal
+document.
+
+---
+
+## Title
+
+`Proposal: a libp2p transport binding`
+
+## Body
+
+Yes — a **Trust Task Binding** for libp2p, in the sense of
+[`bindings/`](https://github.com/trustoverip/dtgwg-trust-tasks-tf/tree/main/bindings)
+and https://trusttasks.org/bindings, alongside `https`, `didcomm`, `push` and
+`tsp`. Raising it here per Glenn's suggestion on the 19 August call, so the
+decision is documented and a PR can be linked against it.
+
+### What
+
+A binding specification at `bindings/libp2p/0.1/spec.md` plus a
+`trust-tasks-libp2p` crate, following the shape of the HTTPS binding — a client
+and a listener over a libp2p `Swarm`, mirroring `HttpsClient` / `HttpsServer`.
+
+### Why libp2p rather than another transport
+
+Two gaps in the current set, both specific:
+
+**Transport-derived identity is cryptographic.** [SPEC §4.8.1](https://github.com/trustoverip/dtgwg-trust-tasks-tf/blob/main/SPEC.md#481-precedence-of-in-band-over-transport-derived-identity)
+governs precedence of in-band over transport-derived identity. The HTTPS binding
+satisfies it with a bearer token mapped to a VID, where the strength of the
+mapping is a deployment concern. libp2p authenticates every connection with a
+Noise handshake over the peer's long-term key — the peer ID *is* the public key —
+so transport-derived identity is established before the first byte of a Trust
+Task document is read. That may make it a useful second data point for §4.8.1:
+a binding where the precedence rule is doing real work rather than deferring to
+in-band identity by default.
+
+**Neither party needs a public endpoint.** HTTPS requires a reachable server, and
+DIDComm in practice usually needs a mediator. libp2p reaches peers behind NAT via
+circuit relay and upgrades to direct connections with DCUtR. For a decentralised
+trust graph where all parties hold their own subgraph, two agents on personal
+devices exchanging Trust Tasks without either running infrastructure seems worth
+supporting.
+
+Secondary: a libp2p connection is full-duplex and multiplexed, so a consumer
+behind NAT can receive Trust Tasks over the connection it opened, rather than
+polling or relying on mediator callbacks.
+
+### What we are asking
+
+Whether a libp2p binding is **in scope for the task force**. If it is, we would
+also like to settle a reserved slug and binding URI (`libp2p` /
+`https://trusttasks.org/binding/libp2p/0.1`), and which framework version a new
+binding should target — the HTTPS binding targets `0.2`.
+
+### Open questions we would rather the task force decide
+
+- **Which DID method for the peer ID → VID mapping?** Both `did:key` and
+  `did:peer` derive from the same Ed25519 key. Key rotation and multi-key peers
+  need a stated rule either way, and we would rather the binding specify it than
+  have each implementation guess.
+- **Relayed connections.** A circuit relay sees traffic shape and endpoints,
+  though not content. Whether that warrants anything in the binding spec is a
+  question for the group.
+
+### Who is proposing
+
+Kwaai AI Lab. We run [KwaaiNet](https://github.com/Kwaai-AI-Lab/KwaaiNet), a
+decentralised AI fabric on rust-libp2p — Kademlia DHT, circuit relay, AutoNAT,
+DCUtR, Noise, yamux — across macOS, Linux and Windows nodes behind residential
+NAT. Four Kwaai people already participate in DTGWG, and we would want this
+maintained in-tree and published alongside the other bindings rather than carried
+out-of-tree, so upstream changes keep it working.
+
+Longer write-up:
+[`TrustTasksLibp2pBinding-proposal.md`](https://github.com/Kwaai-AI-Lab/KwaaiNet/blob/main/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md)
+
+Happy to be told this belongs somewhere else in the process.
+
+---
+
+## Blocking: talk to Erika Bjune first
+
+On the same call (2026-08-19, 08:41), Erika Bjune: *"Hi Reza, we really need to
+talk. Ours is a libp2p stack and we're working on these issues as well."*
+
+**Do not post this as a Kwaai proposal until that conversation happens.** Posting
+hours after someone says they are already working on the problem reads as
+claiming the `libp2p` slug ahead of them, which is a poor first move in a group
+we want a long relationship with.
+
+It is also a worse proposal alone than it would be together. A task force
+deciding whether to reserve a binding identifier wants evidence of more than one
+implementation. Two independent libp2p stacks asking for the same binding turns
+"Kwaai wants this" into "the libp2p constituency needs this" — a much easier yes.
+
+Three ways this could go, in rough order of preference:
+
+1. **Joint Discussion**, co-authored. Strongest signal, and it makes the slug
+   reservation obviously worth doing.
+2. **We post, naming her effort** and inviting her in. Faster, still collegial,
+   but it puts Kwaai's name on the identifier first.
+3. **She posts, we support.** Fine if her work is further along than ours — the
+   binding existing matters more to us than whose name is on it, given we are not
+   scheduled to build it until Q1 2027 anyway.
+
+Worth establishing early: whether her stack is rust-libp2p or go-libp2p. If Go,
+the binding needs to specify the wire contract carefully enough that both
+implementations interoperate — which is a better specification either way, and is
+exactly the kind of thing that justifies a binding spec rather than one crate.
+
+---
+
+## Notes for Reza before posting
+
+- **Link only works once #113 is merged to `main`.** Until then it 404s — merge
+  first, or drop the link.
+- **Do not link the Google Doc.** The share URL carries your `ouid`, and this
+  Discussion is public.
+- The in-tree/publication ask is softened here to one clause at the end. In the
+  full proposal it is ask 4 with the reasoning spelled out. That seemed right for
+  an opener — it is the commercially meaningful ask, and leading with it in a
+  first Discussion post would read badly.
+- Glenn is at Affinidi, who maintain `affinidi-tsp` behind the `trust-tasks-tsp`
+  binding. He wrote the HTTPS binding spec. Worth @-mentioning him as the person
+  who suggested the Discussion.

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-discussion-draft.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-discussion-draft.md
@@ -1,7 +1,8 @@
 # GitHub Discussion draft — libp2p binding
 
 **Where:** `trustoverip/dtgwg-trust-tasks-tf` → Discussions → **Ideas**
-**Status:** **ON HOLD — do not post yet.** See "Erika Bjune" below.
+**Status:** ready to post. The conversation belongs here rather than in a Google
+Doc so it is tracked — Glenn's point, and Reza's decision on 2026-08-19.
 
 **Why this exists:** Glenn Gore's feedback on the 2026-08-19 call — *"it seems to
 me that this should be a Discussion on the TF GH so that the decision is
@@ -58,6 +59,19 @@ Secondary: a libp2p connection is full-duplex and multiplexed, so a consumer
 behind NAT can receive Trust Tasks over the connection it opened, rather than
 polling or relying on mediator callbacks.
 
+### We would rather co-author this than own it
+
+We understand we are not the only group here running a libp2p stack and working
+on these problems. That is welcome — a binding identifier is worth reserving
+precisely when more than one implementation needs it, and a specification written
+against two independent stacks will pin the wire contract far better than one
+written against a single crate.
+
+If another group is further along, say so here and we will support your
+specification rather than advance our own. The binding existing matters
+considerably more to us than whose name is on it, particularly as our own
+implementation is not scheduled before Q1 2027.
+
 ### What we are asking
 
 Whether a libp2p binding is **in scope for the task force**. If it is, we would
@@ -91,35 +105,22 @@ Happy to be told this belongs somewhere else in the process.
 
 ---
 
-## Blocking: talk to Erika Bjune first
+## Why post rather than take it private first
 
-On the same call (2026-08-19, 08:41), Erika Bjune: *"Hi Reza, we really need to
-talk. Ours is a libp2p stack and we're working on these issues as well."*
+The earlier draft of this file said to hold until we had spoken privately with
+the other libp2p group in DTGWG. That was the wrong instinct once the venue moved
+to GitHub.
 
-**Do not post this as a Kwaai proposal until that conversation happens.** Posting
-hours after someone says they are already working on the problem reads as
-claiming the `libp2p` slug ahead of them, which is a poor first move in a group
-we want a long relationship with.
+The risk was never *proposing* — it was proposing in a way that ignored a known
+parallel effort, which reads as claiming the `libp2p` slug. A public Discussion
+that says plainly we would rather co-author than own removes that risk, and does
+it in the open where the group can see it. A private conversation followed by a
+public proposal is strictly worse: same outcome, less visible, and it leaves the
+task force's decision undocumented — the exact problem Glenn raised.
 
-It is also a worse proposal alone than it would be together. A task force
-deciding whether to reserve a binding identifier wants evidence of more than one
-implementation. Two independent libp2p stacks asking for the same binding turns
-"Kwaai wants this" into "the libp2p constituency needs this" — a much easier yes.
-
-Three ways this could go, in rough order of preference:
-
-1. **Joint Discussion**, co-authored. Strongest signal, and it makes the slug
-   reservation obviously worth doing.
-2. **We post, naming her effort** and inviting her in. Faster, still collegial,
-   but it puts Kwaai's name on the identifier first.
-3. **She posts, we support.** Fine if her work is further along than ours — the
-   binding existing matters more to us than whose name is on it, given we are not
-   scheduled to build it until Q1 2027 anyway.
-
-Worth establishing early: whether her stack is rust-libp2p or go-libp2p. If Go,
-the binding needs to specify the wire contract carefully enough that both
-implementations interoperate — which is a better specification either way, and is
-exactly the kind of thing that justifies a binding spec rather than one crate.
+So the collaboration invitation is in the post itself, near the top. If their work
+is further along, the Discussion is where they say so and we support their
+specification instead.
 
 ---
 

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
@@ -67,9 +67,11 @@ the polling or mediator-callback patterns the request/response bindings imply.
 - **A production libp2p deployment.** KwaaiNet is a decentralised AI fabric built
   on rust-libp2p 0.56 — Kademlia DHT, circuit relay, AutoNAT, DCUtR, Noise,
   yamux — running across macOS, Linux and Windows nodes in the field.
-- **Measured interop experience.** Our fabric is mixed Rust and Go libp2p, and we
-  maintain a tiered interop harness between the two. We have carried protocol
-  changes across that boundary and know where it is sharp.
+- **Operational experience under real network conditions.** Those nodes sit
+  behind residential NAT, reach each other over circuit relay, and upgrade to
+  direct connections via DCUtR. We maintain a tiered integration harness and
+  measure per-call round-trip latency in the field, so we can characterise a
+  binding's cost rather than assert it.
 - **Four Kwaai volunteers already participate in DTGWG.** This contribution is
   intended as ongoing participation rather than a code drop.
 
@@ -80,7 +82,7 @@ the polling or mediator-callback patterns the request/response bindings imply.
 | `bindings/libp2p/0.1/spec.md` | Binding specification following the HTTPS binding's structure — YAML front matter, document carriage, identity handling under §4.8.1, error mapping to the §8.3 vocabulary |
 | `trust-tasks-libp2p` crate | Client and listener over a libp2p `Swarm`, mirroring the `HttpsClient` / `HttpsServer` shape |
 | Binding URI | `https://trusttasks.org/binding/libp2p/0.1` (slug `libp2p`, subject to the task force's preference) |
-| Interop evidence | Round-trip against an existing binding, plus Rust↔Go libp2p interop results |
+| Interop evidence | Round-trip against an existing binding — the relevant comparison for a transport binding — plus measured latency over direct and relayed connections |
 
 We would follow `CONTRIBUTING-SPECS.md`: fork, branch, folder, `npm run build`
 to validate, PR for CODEOWNERS routing. DCO and CLA as required.

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
@@ -1,133 +1,80 @@
-# A libp2p binding for Trust Tasks — revised
+<!--
+POST AS: a reply comment in dtgwg-trust-tasks-tf#248
+These HTML comments do not render on GitHub — paste the whole file.
+Paragraphs are deliberately unwrapped: GitHub joins soft-wrapped lines, and long
+lines survive copy-paste into the comment box unchanged.
+-->
 
-**From:** Kwaai AI Lab
-**Revised:** 2026-08-19, after @stormer78's review
-**Discussion:** [dtgwg-trust-tasks-tf#248](https://github.com/trustoverip/dtgwg-trust-tasks-tf/discussions/248)
-
-*Written to be posted as a reply in the Discussion, and to replace the shared
-document.*
-
----
-
-Thanks @stormer78 — the review corrected three things we had wrong and pointed at
-a better idea than the one we brought. This is the revised version.
+Thanks @stormer78 — the review corrected three things we had wrong and pointed at a better idea than the one we brought. Here is the revised version.
 
 ## What we got wrong
 
 Our case rested on three claimed gaps. All three were mistaken:
 
-- **"None of the existing bindings derives sender identity from a cryptographic
-  transport handshake."** Not true — the delivery implementation is swappable.
-- **"Neither party needs a public endpoint" as a libp2p advantage.** DIDComm and
-  TSP are messages and can travel peer-to-peer. Mediators are a choice, not a
-  requirement, and multi-relay hopping provides sender privacy that plain libp2p
-  circuit relay does not.
-- **"Full-duplex removes polling or mediator-callback patterns."** Mediators
-  already use bi-directional websockets with event-based delivery.
+- **"None of the existing bindings derives sender identity from a cryptographic transport handshake."** Not true — the delivery implementation is swappable.
+- **"Neither party needs a public endpoint" as a libp2p advantage.** DIDComm and TSP are messages and can travel peer-to-peer. Mediators are a choice, not a requirement, and multi-relay hopping provides sender privacy that plain libp2p circuit relay does not.
+- **"Full-duplex removes polling or mediator-callback patterns."** Mediators already use bi-directional websockets with event-based delivery.
 
-The error was ours: we read the HTTPS binding specification closely and then
-generalised its properties to DIDComm and TSP, which we had not read. Those are
-messaging protocols with their own identity and routing models, and the
-generalisation does not hold.
+The error was ours: we read the HTTPS binding specification closely and then generalised its properties to DIDComm and TSP, which we had not read. Those are messaging protocols with their own identity and routing models, and the generalisation does not hold.
 
-**libp2p is not technically superior to what Trust Tasks already supports.** The
-honest case is narrower, and it is below.
+**libp2p is not technically superior to what Trust Tasks already supports.** The honest case is narrower, and it is below.
 
 ## The revised proposal: start with the bridge
 
-@stormer78's suggestion:
+> a real innovation here would be a bridge between libp2p and TSP/DIDComm where you could mix the protocols together. We do this already with TSP+DIDComm where you can use TSP for routing, and the final delivery is via DIDComm for example. So you could use TSP for routing, carrying a libp2p payload or vice-versa.
 
-> a real innovation here would be a bridge between libp2p and TSP/DIDComm where
-> you could mix the protocols together. We do this already with TSP+DIDComm where
-> you can use TSP for routing, and the final delivery is via DIDComm for example.
-> So you could use TSP for routing, carrying a libp2p payload or vice-versa.
+This is a better proposition than another transport binding, and we would rather pursue it. Composing protocols so each does what it is best at — TSP routing with libp2p delivery, or libp2p routing carrying a TSP payload — is more interesting than adding a fifth way to move the same document.
 
-This is a better proposition than another transport binding, and we would rather
-pursue it. Composing protocols so each does what it is best at — TSP routing with
-libp2p delivery, or libp2p routing carrying a TSP payload — is more interesting
-than adding a fifth way to move the same document.
-
-It also matches what we can actually offer. Kwaai's contribution is not a novel
-transport; it is a production libp2p fabric that could serve as one leg of such a
-bridge, plus people to do the work.
+It also matches what we can actually offer. Kwaai's contribution is not a novel transport; it is a production libp2p fabric that could serve as one leg of such a bridge, plus people to do the work.
 
 ## The honest case for a libp2p binding underneath it
 
 Narrower than our first version, and we think it still holds:
 
-**libp2p is a transport a lot of people already run.** Meeting an existing
-deployment where it is has value even when it offers no new capability — much the
-reason a REST binding would be worth having. We are aware of at least one other
-libp2p stack in this group, which suggests the constituency is real.
+**libp2p is a transport a lot of people already run.** Meeting an existing deployment where it is has value even when it offers no new capability — much the reason a REST binding would be worth having. We are aware of at least one other libp2p stack in this group, which suggests the constituency is real.
 
-**Addressing maps cleanly onto `did:peer`.** A peer's multiaddrs, including
-circuit-relay addresses, can ride in the DID's service endpoints. That makes the
-libp2p-addressing-to-VID conversion concrete rather than aspirational, which
-matters for the cross-binding interoperability below.
+**Addressing maps cleanly onto `did:peer`.** A peer's multiaddrs, including circuit-relay addresses, can ride in the DID's service endpoints. That makes the libp2p-addressing-to-VID conversion concrete rather than aspirational, which matters for the cross-binding interoperability below.
 
-That is the whole argument. A binding is worth having because people are already
-on libp2p, not because libp2p does something the others cannot.
+That is the whole argument. A binding is worth having because people are already on libp2p, not because libp2p does something the others cannot.
 
 ## Accepting the guidance
 
-**Shim architecture — agreed.** A thin shim producing the payload, with a trait
-overlay and pluggable libp2p behind it, exactly as the TSP and DIDComm bindings
-do. It keeps spec churn in the shim and the transport out of the framework's way,
-and it is a better fit than the `HttpsClient`/`HttpsServer` shape we originally
-described.
-
-**Target the latest framework — agreed**, rather than pinning to `0.2`.
-
-**§4.8.1 unchanged — agreed.** Converting libp2p addressing to a DID/VID for
-interoperability inside a VTC is a better outcome than a special case: a libp2p
-peer and a TSP peer in the same VTC should be able to talk.
-
-**Relay properties documented, not editorialised — agreed.** The binding should
-explain how libp2p behaves and let implementers make an informed choice.
-
-**Maintainers keeping the binding in sync — thank you.** That was our main
-reservation about tracking a pre-1.0 framework, and it resolves it.
+| Guidance | Our response |
+| --- | --- |
+| Shim producing the payload, trait overlay, pluggable libp2p behind it | Agreed — and a better fit than the `HttpsClient`/`HttpsServer` shape we first described. Keeps spec churn in the shim and the transport out of the framework's way |
+| Target the latest framework, not `0.2` | Agreed |
+| §4.8.1 unchanged; convert libp2p addressing to a DID/VID | Agreed. A libp2p peer and a TSP peer in the same VTC being able to talk is a better outcome than a special case |
+| Document relay properties rather than editorialise | Agreed — explain how libp2p behaves, let implementers choose |
+| Maintainers keep the binding in sync with the framework | Thank you. That was our main reservation about tracking a pre-1.0 framework, and it resolves it |
 
 ## Answering the two questions
 
 **"Is `libp2p` the right protocol name (aka DIDComm or TSP)?"**
 
-We think so, by analogy with `https`. That binding is named for the transport and
-then specifies the particulars — `POST` to `/trust-tasks`. A libp2p binding would
-be named for the transport and specify the libp2p **protocol ID** carrying a Trust
-Task document — say `/trust-tasks/1.0.0` — negotiated by multistream-select on a
-libp2p stream. So `https` : `/trust-tasks` :: `libp2p` : `/trust-tasks/1.0.0`.
+We think so, by analogy with `https`. That binding is named for the transport and then specifies the particulars — `POST` to `/trust-tasks`. A libp2p binding would be named for the transport and specify the libp2p **protocol ID** carrying a Trust Task document — say `/trust-tasks/1.0.0` — negotiated by multistream-select on a libp2p stream:
 
-That said, you raised it, so you may have a reason to prefer otherwise. And if
-the bridge is the more interesting artefact, the naming question may want
-settling in that context instead.
+| Binding | Names | Specifies |
+| --- | --- | --- |
+| `https` | the transport | `POST /trust-tasks` |
+| `libp2p` | the transport | protocol ID `/trust-tasks/1.0.0` |
+
+That said, you raised it, so you may have a reason to prefer otherwise. And if the bridge is the more interesting artefact, the naming question may want settling in that context instead.
 
 **Which DID method?**
 
-`did:peer`, on your recommendation and for your reason — routing information in
-the DID. KwaaiNet already issues `did:peer`, so this needs no change on our side.
+`did:peer`, on your recommendation and for your reason — routing information in the DID. KwaaiNet already issues `did:peer`, so this needs no change on our side.
 
 ## What we would contribute
 
-- A production rust-libp2p fabric — Kademlia DHT, circuit relay, AutoNAT, DCUtR,
-  Noise, yamux — running across macOS, Linux and Windows nodes behind residential
-  NAT, with a tiered integration harness and measured per-call latency.
+- A production rust-libp2p fabric — Kademlia DHT, circuit relay, AutoNAT, DCUtR, Noise, yamux — running across macOS, Linux and Windows nodes behind residential NAT, with a tiered integration harness and measured per-call latency.
 - Four Kwaai people already participating in DTGWG.
 - Work on the shim, and on the bridge if the task force wants to pursue it.
 
 ## Still open
 
-- **Whether to lead with the bridge or the binding.** The bridge is the more
-  valuable artefact; the binding may be the necessary substrate. We have no
-  strong view on sequencing and would follow the task force's.
-- **Whether another group should lead.** We are not the only libp2p stack here.
-  If someone else is further along, we would rather support their specification
-  than advance our own — the binding existing matters more to us than whose name
-  is on it.
+- **Whether to lead with the bridge or the binding.** The bridge is the more valuable artefact; the binding may be the necessary substrate. We have no strong view on sequencing and would follow the task force's.
+- **Whether another group should lead.** We are not the only libp2p stack here. If someone else is further along, we would rather support their specification than advance our own — the binding existing matters more to us than whose name is on it.
 
 ## Timing
 
-This is not in Kwaai's committed engineering scope for 2026; our year-end release
-is platform hardening. Realistically we would begin in Q1 2027. We would rather
-say that plainly than commit to a date we would miss — and it is another reason
-we are glad for someone else to lead if they are ready sooner.
+This is not in Kwaai's committed engineering scope for 2026; our year-end release is platform hardening. Realistically we would begin in Q1 2027. We would rather say that plainly than commit to a date we would miss — and it is another reason we are glad for someone else to lead if they are ready sooner.

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
@@ -1,0 +1,143 @@
+# Proposal: a libp2p transport binding for Trust Tasks
+
+**To:** LF ToIP Decentralized Trust Graph Working Group, Trust Tasks Task Force
+**From:** Kwaai AI Lab
+**Date:** 2026-08-19
+**Status:** draft for Kwaai internal review — **not yet submitted**
+
+---
+
+## Summary
+
+Kwaai AI Lab proposes to contribute a **libp2p transport binding** for the Trust
+Tasks framework — a binding specification under
+`bindings/libp2p/<version>/spec.md` and a `trust-tasks-libp2p` crate alongside
+the existing `-https`, `-didcomm` and `-tsp` implementations.
+
+Trust Tasks currently ships bindings for HTTPS, DIDComm v1/v2, push and TSP.
+None of them carries Trust Tasks between two parties where **neither has a
+reachable public endpoint**, and none derives sender identity from a
+cryptographic transport handshake. A libp2p binding addresses both.
+
+We are asking the task force for agreement in principle, a reserved binding slug
+and URI, and guidance on the target framework version — not for a decision on
+merge today.
+
+## Why libp2p, specifically
+
+### 1. Transport-derived identity that is cryptographic, not configured
+
+SPEC §4.8.1 defines the precedence of in-band over transport-derived identity,
+and the HTTPS binding satisfies it with a bearer token mapped to a *Verifiable
+Identifier*. That mapping is a deployment concern: its strength depends on how
+the token was issued and how carefully the receiver maintains the mapping.
+
+libp2p authenticates **every** connection with a Noise handshake over the peer's
+long-term key. The peer ID *is* the public key. Transport-derived identity is
+therefore established cryptographically before the first byte of a Trust Task
+document is read, and mapping a peer ID to a `did:key` VID is a direct derivation
+rather than a lookup table.
+
+We think that makes libp2p a useful second data point for §4.8.1 — a binding
+where transport-derived identity is strong enough that the precedence rule is
+doing real work, rather than deferring to in-band identity by default.
+
+### 2. Neither party needs a public endpoint
+
+The HTTPS binding requires a reachable server; DIDComm in practice usually does
+too, via a mediator. That excludes a class of deployment the DTGWG charter
+speaks directly to: two agents, each on a personal device, each behind NAT, with
+no server between them.
+
+libp2p handles this natively — circuit relay for reachability plus DCUtR hole
+punching to upgrade to a direct connection where the network allows it. A trust
+graph in which "all parties control their own subgraph" is more credible when
+two parties can exchange Trust Tasks without either of them running
+infrastructure.
+
+### 3. Full-duplex and multiplexed
+
+A libp2p connection carries many concurrent streams in both directions. A
+consumer behind NAT can *receive* Trust Tasks, not only send them, over the same
+connection it opened. For long-lived agent-to-agent relationships this removes
+the polling or mediator-callback patterns the request/response bindings imply.
+
+## What Kwaai brings
+
+- **A production libp2p deployment.** KwaaiNet is a decentralised AI fabric built
+  on rust-libp2p 0.56 — Kademlia DHT, circuit relay, AutoNAT, DCUtR, Noise,
+  yamux — running across macOS, Linux and Windows nodes in the field.
+- **Measured interop experience.** Our fabric is mixed Rust and Go libp2p, and we
+  maintain a tiered interop harness between the two. We have carried protocol
+  changes across that boundary and know where it is sharp.
+- **Four Kwaai volunteers already participate in DTGWG.** This contribution is
+  intended as ongoing participation rather than a code drop.
+
+## What we propose to deliver
+
+| Deliverable | Shape |
+|---|---|
+| `bindings/libp2p/0.1/spec.md` | Binding specification following the HTTPS binding's structure — YAML front matter, document carriage, identity handling under §4.8.1, error mapping to the §8.3 vocabulary |
+| `trust-tasks-libp2p` crate | Client and listener over a libp2p `Swarm`, mirroring the `HttpsClient` / `HttpsServer` shape |
+| Binding URI | `https://trusttasks.org/binding/libp2p/0.1` (slug `libp2p`, subject to the task force's preference) |
+| Interop evidence | Round-trip against an existing binding, plus Rust↔Go libp2p interop results |
+
+We would follow `CONTRIBUTING-SPECS.md`: fork, branch, folder, `npm run build`
+to validate, PR for CODEOWNERS routing. DCO and CLA as required.
+
+## What we are asking for
+
+1. **Agreement in principle** that a libp2p binding is in scope for the task
+   force, before we invest in the specification.
+2. **A reserved slug and binding URI**, so the work targets a stable identifier.
+3. **Target framework version.** The HTTPS binding targets framework `0.2`;
+   we would like to know whether a new binding should target `0.2` or a later
+   draft.
+4. **Maintenance in-tree, published to crates.io.** The existing bindings are
+   versioned in lockstep with `trust-tasks-rs` — `-https`, `-didcomm`, `-proof`
+   and `-tsp` each have thirteen releases tracking the core's minor line. We are
+   explicitly asking for the same treatment rather than maintaining a binding
+   out-of-tree, and we should be transparent that this is as much to our benefit
+   as to the framework's: it is the mechanism by which upstream refactors keep
+   our binding working. We note `bindings/push` exists in-repo without a
+   published crate, so publication is worth agreeing rather than assuming.
+
+## Open questions we would raise, not resolve
+
+- **Identity precedence.** Does a cryptographically-authenticated transport
+  change how §4.8.1 should be applied, or is the existing precedence rule
+  sufficient as written? We have a view but not a strong one, and it is properly
+  the task force's call.
+- **Relayed connections.** When a connection traverses a circuit relay, the relay
+  sees traffic shape and endpoints though not content. Whether that warrants
+  anything in the binding specification is worth discussing.
+- **Peer ID to VID.** Deriving `did:key` from the Ed25519 peer ID is the obvious
+  mapping, but multi-key peers and key rotation deserve a stated rule rather than
+  an implied one.
+- **Framework stability.** `trust-tasks-rs` has published 86 versions since May
+  2026, moving 0.5 → 0.9 in eight days. We are comfortable tracking that, but the
+  binding's own version cadence should be agreed rather than discovered.
+
+## Timing
+
+Kwaai's committed engineering scope for 2026 does not include this work; our
+year-end release is platform hardening. We would expect to begin the
+specification once the task force agrees in principle, with implementation
+following the framework reaching a stable enough surface — realistically Q1
+2027. We would rather say that plainly than commit to a date we would miss.
+
+---
+
+### Internal notes — remove before submission
+
+- **This has not been reviewed by the four Kwaai DTGWG volunteers.** They should
+  see it first; they know the room and whether this lands as useful or as
+  overreach.
+- Licence checked: framework source is Apache-2.0 (`SOURCE_CODE.md`, and
+  `license = "Apache-2.0"` in `Cargo.toml`); specifications are OWFa 1.0.
+  Compatible with KwaaiNet's MIT, and contributing requires DCO plus CLA.
+- The ask in point 5 (in-tree, published) is the commercially meaningful one for
+  us. Worth deciding whether to lead with it or leave it where it is.
+- No claim in this document should outrun what we can show. The interop harness
+  and the production deployment are real; the Q1 2027 timing is a genuine
+  estimate, not a hedge.

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
@@ -3,7 +3,8 @@
 **To:** LF ToIP Decentralized Trust Graph Working Group, Trust Tasks Task Force
 **From:** Kwaai AI Lab
 **Date:** 2026-08-19
-**Status:** draft for Kwaai internal review — **not yet submitted**
+**Status:** **shared with the DTGWG weekly call, 2026-08-19.** Awaiting task-force
+response on the four asks below. Superseded by that response, not by this draft.
 
 ---
 
@@ -133,11 +134,12 @@ following the framework reaching a stable enough surface — realistically Q1
 
 ---
 
-### Internal notes — remove before submission
+### Internal notes
 
-- **This has not been reviewed by the four Kwaai DTGWG volunteers.** They should
-  see it first; they know the room and whether this lands as useful or as
-  overreach.
+*(These were present in the version shared on 2026-08-19. Retained rather than
+quietly deleted, so the record matches what the working group actually saw.)*
+
+- This was shared without prior review by the four Kwaai DTGWG volunteers.
 - Licence checked: framework source is Apache-2.0 (`SOURCE_CODE.md`, and
   `license = "Apache-2.0"` in `Cargo.toml`); specifications are OWFa 1.0.
   Compatible with KwaaiNet's MIT, and contributing requires DCO plus CLA.

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
@@ -3,8 +3,8 @@
 **To:** LF ToIP Decentralized Trust Graph Working Group, Trust Tasks Task Force
 **From:** Kwaai AI Lab
 **Date:** 2026-08-19
-**Status:** **shared with the DTGWG weekly call, 2026-08-19.** Awaiting task-force
-response on the four asks below. Superseded by that response, not by this draft.
+**Status:** shared with the DTGWG weekly call, 2026-08-19. Revised 2026-08-19
+following feedback on that call.
 
 ---
 
@@ -99,11 +99,25 @@ to validate, PR for CODEOWNERS routing. DCO and CLA as required.
 4. **Maintenance in-tree, published to crates.io.** The existing bindings are
    versioned in lockstep with `trust-tasks-rs` — `-https`, `-didcomm`, `-proof`
    and `-tsp` each have thirteen releases tracking the core's minor line. We are
-   explicitly asking for the same treatment rather than maintaining a binding
-   out-of-tree, and we should be transparent that this is as much to our benefit
-   as to the framework's: it is the mechanism by which upstream refactors keep
-   our binding working. We note `bindings/push` exists in-repo without a
-   published crate, so publication is worth agreeing rather than assuming.
+   asking for the same treatment rather than carrying a binding out-of-tree.
+   To be plain about the incentive: this serves us as much as the framework —
+   lockstep maintenance is how upstream refactors keep our binding working. We
+   note `bindings/push` exists in-repo without a published crate, so publication
+   seems worth agreeing rather than assuming.
+
+## On other libp2p implementations
+
+We understand from the 19 August call that Kwaai is not the only group in DTGWG
+running a libp2p stack and working on these problems. That is welcome, and it
+strengthens rather than complicates the case: a binding identifier is worth
+reserving precisely when more than one implementation needs it.
+
+We would rather co-author this than own it. If another group is further along, we
+are glad to support their specification instead of advancing our own — the
+binding existing matters considerably more to us than whose name is on it. We
+would also want the specification to pin the wire contract tightly enough that
+independent implementations interoperate, whichever libp2p stack they are built
+on.
 
 ## Open questions we would raise, not resolve
 
@@ -131,20 +145,3 @@ year-end release is platform hardening. We would expect to begin the
 specification once the task force agrees in principle, with implementation
 following the framework reaching a stable enough surface — realistically Q1
 2027. We would rather say that plainly than commit to a date we would miss.
-
----
-
-### Internal notes
-
-*(These were present in the version shared on 2026-08-19. Retained rather than
-quietly deleted, so the record matches what the working group actually saw.)*
-
-- This was shared without prior review by the four Kwaai DTGWG volunteers.
-- Licence checked: framework source is Apache-2.0 (`SOURCE_CODE.md`, and
-  `license = "Apache-2.0"` in `Cargo.toml`); specifications are OWFa 1.0.
-  Compatible with KwaaiNet's MIT, and contributing requires DCO plus CLA.
-- The ask in point 4 (in-tree, published) is the commercially meaningful one for
-  us. Worth deciding whether to lead with it or leave it where it is.
-- No claim in this document should outrun what we can show. The interop harness
-  and the production deployment are real; the Q1 2027 timing is a genuine
-  estimate, not a hedge.

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
@@ -35,8 +35,8 @@ the token was issued and how carefully the receiver maintains the mapping.
 libp2p authenticates **every** connection with a Noise handshake over the peer's
 long-term key. The peer ID *is* the public key. Transport-derived identity is
 therefore established cryptographically before the first byte of a Trust Task
-document is read, and mapping a peer ID to a `did:key` VID is a direct derivation
-rather than a lookup table.
+document is read, and the peer ID resolves to a *Verifiable Identifier* by
+derivation from that same key rather than by a lookup table.
 
 We think that makes libp2p a useful second data point for §4.8.1 — a binding
 where transport-derived identity is strong enough that the precedence rule is
@@ -76,7 +76,7 @@ the polling or mediator-callback patterns the request/response bindings imply.
 ## What we propose to deliver
 
 | Deliverable | Shape |
-|---|---|
+| --- | --- |
 | `bindings/libp2p/0.1/spec.md` | Binding specification following the HTTPS binding's structure — YAML front matter, document carriage, identity handling under §4.8.1, error mapping to the §8.3 vocabulary |
 | `trust-tasks-libp2p` crate | Client and listener over a libp2p `Swarm`, mirroring the `HttpsClient` / `HttpsServer` shape |
 | Binding URI | `https://trusttasks.org/binding/libp2p/0.1` (slug `libp2p`, subject to the task force's preference) |
@@ -111,9 +111,12 @@ to validate, PR for CODEOWNERS routing. DCO and CLA as required.
 - **Relayed connections.** When a connection traverses a circuit relay, the relay
   sees traffic shape and endpoints though not content. Whether that warrants
   anything in the binding specification is worth discussing.
-- **Peer ID to VID.** Deriving `did:key` from the Ed25519 peer ID is the obvious
-  mapping, but multi-key peers and key rotation deserve a stated rule rather than
-  an implied one.
+- **Peer ID to VID — which DID method?** Both `did:key` and `did:peer` are
+  derivable from the same Ed25519 key, and the choice is not obvious. KwaaiNet
+  uses `did:peer` today; the framework's other bindings lean toward `did:key`.
+  Whichever the task force prefers, key rotation and multi-key peers deserve a
+  stated rule rather than an implied one. We would rather the binding specify
+  this than leave each implementation to guess.
 - **Framework stability.** `trust-tasks-rs` has published 86 versions since May
   2026, moving 0.5 → 0.9 in eight days. We are comfortable tracking that, but the
   binding's own version cadence should be agreed rather than discovered.
@@ -136,7 +139,7 @@ following the framework reaching a stable enough surface — realistically Q1
 - Licence checked: framework source is Apache-2.0 (`SOURCE_CODE.md`, and
   `license = "Apache-2.0"` in `Cargo.toml`); specifications are OWFa 1.0.
   Compatible with KwaaiNet's MIT, and contributing requires DCO plus CLA.
-- The ask in point 5 (in-tree, published) is the commercially meaningful one for
+- The ask in point 4 (in-tree, published) is the commercially meaningful one for
   us. Worth deciding whether to lead with it or leave it where it is.
 - No claim in this document should outrun what we can show. The interop harness
   and the production deployment are real; the Q1 2027 timing is a genuine

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-proposal.md
@@ -1,147 +1,133 @@
-# Proposal: a libp2p transport binding for Trust Tasks
+# A libp2p binding for Trust Tasks — revised
 
-**To:** LF ToIP Decentralized Trust Graph Working Group, Trust Tasks Task Force
 **From:** Kwaai AI Lab
-**Date:** 2026-08-19
-**Status:** shared with the DTGWG weekly call, 2026-08-19. Revised 2026-08-19
-following feedback on that call.
+**Revised:** 2026-08-19, after @stormer78's review
+**Discussion:** [dtgwg-trust-tasks-tf#248](https://github.com/trustoverip/dtgwg-trust-tasks-tf/discussions/248)
+
+*Written to be posted as a reply in the Discussion, and to replace the shared
+document.*
 
 ---
 
-## Summary
+Thanks @stormer78 — the review corrected three things we had wrong and pointed at
+a better idea than the one we brought. This is the revised version.
 
-Kwaai AI Lab proposes to contribute a **libp2p transport binding** for the Trust
-Tasks framework — a binding specification under
-`bindings/libp2p/<version>/spec.md` and a `trust-tasks-libp2p` crate alongside
-the existing `-https`, `-didcomm` and `-tsp` implementations.
+## What we got wrong
 
-Trust Tasks currently ships bindings for HTTPS, DIDComm v1/v2, push and TSP.
-None of them carries Trust Tasks between two parties where **neither has a
-reachable public endpoint**, and none derives sender identity from a
-cryptographic transport handshake. A libp2p binding addresses both.
+Our case rested on three claimed gaps. All three were mistaken:
 
-We are asking the task force for agreement in principle, a reserved binding slug
-and URI, and guidance on the target framework version — not for a decision on
-merge today.
+- **"None of the existing bindings derives sender identity from a cryptographic
+  transport handshake."** Not true — the delivery implementation is swappable.
+- **"Neither party needs a public endpoint" as a libp2p advantage.** DIDComm and
+  TSP are messages and can travel peer-to-peer. Mediators are a choice, not a
+  requirement, and multi-relay hopping provides sender privacy that plain libp2p
+  circuit relay does not.
+- **"Full-duplex removes polling or mediator-callback patterns."** Mediators
+  already use bi-directional websockets with event-based delivery.
 
-## Why libp2p, specifically
+The error was ours: we read the HTTPS binding specification closely and then
+generalised its properties to DIDComm and TSP, which we had not read. Those are
+messaging protocols with their own identity and routing models, and the
+generalisation does not hold.
 
-### 1. Transport-derived identity that is cryptographic, not configured
+**libp2p is not technically superior to what Trust Tasks already supports.** The
+honest case is narrower, and it is below.
 
-SPEC §4.8.1 defines the precedence of in-band over transport-derived identity,
-and the HTTPS binding satisfies it with a bearer token mapped to a *Verifiable
-Identifier*. That mapping is a deployment concern: its strength depends on how
-the token was issued and how carefully the receiver maintains the mapping.
+## The revised proposal: start with the bridge
 
-libp2p authenticates **every** connection with a Noise handshake over the peer's
-long-term key. The peer ID *is* the public key. Transport-derived identity is
-therefore established cryptographically before the first byte of a Trust Task
-document is read, and the peer ID resolves to a *Verifiable Identifier* by
-derivation from that same key rather than by a lookup table.
+@stormer78's suggestion:
 
-We think that makes libp2p a useful second data point for §4.8.1 — a binding
-where transport-derived identity is strong enough that the precedence rule is
-doing real work, rather than deferring to in-band identity by default.
+> a real innovation here would be a bridge between libp2p and TSP/DIDComm where
+> you could mix the protocols together. We do this already with TSP+DIDComm where
+> you can use TSP for routing, and the final delivery is via DIDComm for example.
+> So you could use TSP for routing, carrying a libp2p payload or vice-versa.
 
-### 2. Neither party needs a public endpoint
+This is a better proposition than another transport binding, and we would rather
+pursue it. Composing protocols so each does what it is best at — TSP routing with
+libp2p delivery, or libp2p routing carrying a TSP payload — is more interesting
+than adding a fifth way to move the same document.
 
-The HTTPS binding requires a reachable server; DIDComm in practice usually does
-too, via a mediator. That excludes a class of deployment the DTGWG charter
-speaks directly to: two agents, each on a personal device, each behind NAT, with
-no server between them.
+It also matches what we can actually offer. Kwaai's contribution is not a novel
+transport; it is a production libp2p fabric that could serve as one leg of such a
+bridge, plus people to do the work.
 
-libp2p handles this natively — circuit relay for reachability plus DCUtR hole
-punching to upgrade to a direct connection where the network allows it. A trust
-graph in which "all parties control their own subgraph" is more credible when
-two parties can exchange Trust Tasks without either of them running
-infrastructure.
+## The honest case for a libp2p binding underneath it
 
-### 3. Full-duplex and multiplexed
+Narrower than our first version, and we think it still holds:
 
-A libp2p connection carries many concurrent streams in both directions. A
-consumer behind NAT can *receive* Trust Tasks, not only send them, over the same
-connection it opened. For long-lived agent-to-agent relationships this removes
-the polling or mediator-callback patterns the request/response bindings imply.
+**libp2p is a transport a lot of people already run.** Meeting an existing
+deployment where it is has value even when it offers no new capability — much the
+reason a REST binding would be worth having. We are aware of at least one other
+libp2p stack in this group, which suggests the constituency is real.
 
-## What Kwaai brings
+**Addressing maps cleanly onto `did:peer`.** A peer's multiaddrs, including
+circuit-relay addresses, can ride in the DID's service endpoints. That makes the
+libp2p-addressing-to-VID conversion concrete rather than aspirational, which
+matters for the cross-binding interoperability below.
 
-- **A production libp2p deployment.** KwaaiNet is a decentralised AI fabric built
-  on rust-libp2p 0.56 — Kademlia DHT, circuit relay, AutoNAT, DCUtR, Noise,
-  yamux — running across macOS, Linux and Windows nodes in the field.
-- **Operational experience under real network conditions.** Those nodes sit
-  behind residential NAT, reach each other over circuit relay, and upgrade to
-  direct connections via DCUtR. We maintain a tiered integration harness and
-  measure per-call round-trip latency in the field, so we can characterise a
-  binding's cost rather than assert it.
-- **Four Kwaai volunteers already participate in DTGWG.** This contribution is
-  intended as ongoing participation rather than a code drop.
+That is the whole argument. A binding is worth having because people are already
+on libp2p, not because libp2p does something the others cannot.
 
-## What we propose to deliver
+## Accepting the guidance
 
-| Deliverable | Shape |
-| --- | --- |
-| `bindings/libp2p/0.1/spec.md` | Binding specification following the HTTPS binding's structure — YAML front matter, document carriage, identity handling under §4.8.1, error mapping to the §8.3 vocabulary |
-| `trust-tasks-libp2p` crate | Client and listener over a libp2p `Swarm`, mirroring the `HttpsClient` / `HttpsServer` shape |
-| Binding URI | `https://trusttasks.org/binding/libp2p/0.1` (slug `libp2p`, subject to the task force's preference) |
-| Interop evidence | Round-trip against an existing binding — the relevant comparison for a transport binding — plus measured latency over direct and relayed connections |
+**Shim architecture — agreed.** A thin shim producing the payload, with a trait
+overlay and pluggable libp2p behind it, exactly as the TSP and DIDComm bindings
+do. It keeps spec churn in the shim and the transport out of the framework's way,
+and it is a better fit than the `HttpsClient`/`HttpsServer` shape we originally
+described.
 
-We would follow `CONTRIBUTING-SPECS.md`: fork, branch, folder, `npm run build`
-to validate, PR for CODEOWNERS routing. DCO and CLA as required.
+**Target the latest framework — agreed**, rather than pinning to `0.2`.
 
-## What we are asking for
+**§4.8.1 unchanged — agreed.** Converting libp2p addressing to a DID/VID for
+interoperability inside a VTC is a better outcome than a special case: a libp2p
+peer and a TSP peer in the same VTC should be able to talk.
 
-1. **Agreement in principle** that a libp2p binding is in scope for the task
-   force, before we invest in the specification.
-2. **A reserved slug and binding URI**, so the work targets a stable identifier.
-3. **Target framework version.** The HTTPS binding targets framework `0.2`;
-   we would like to know whether a new binding should target `0.2` or a later
-   draft.
-4. **Maintenance in-tree, published to crates.io.** The existing bindings are
-   versioned in lockstep with `trust-tasks-rs` — `-https`, `-didcomm`, `-proof`
-   and `-tsp` each have thirteen releases tracking the core's minor line. We are
-   asking for the same treatment rather than carrying a binding out-of-tree.
-   To be plain about the incentive: this serves us as much as the framework —
-   lockstep maintenance is how upstream refactors keep our binding working. We
-   note `bindings/push` exists in-repo without a published crate, so publication
-   seems worth agreeing rather than assuming.
+**Relay properties documented, not editorialised — agreed.** The binding should
+explain how libp2p behaves and let implementers make an informed choice.
 
-## On other libp2p implementations
+**Maintainers keeping the binding in sync — thank you.** That was our main
+reservation about tracking a pre-1.0 framework, and it resolves it.
 
-We understand from the 19 August call that Kwaai is not the only group in DTGWG
-running a libp2p stack and working on these problems. That is welcome, and it
-strengthens rather than complicates the case: a binding identifier is worth
-reserving precisely when more than one implementation needs it.
+## Answering the two questions
 
-We would rather co-author this than own it. If another group is further along, we
-are glad to support their specification instead of advancing our own — the
-binding existing matters considerably more to us than whose name is on it. We
-would also want the specification to pin the wire contract tightly enough that
-independent implementations interoperate, whichever libp2p stack they are built
-on.
+**"Is `libp2p` the right protocol name (aka DIDComm or TSP)?"**
 
-## Open questions we would raise, not resolve
+We think so, by analogy with `https`. That binding is named for the transport and
+then specifies the particulars — `POST` to `/trust-tasks`. A libp2p binding would
+be named for the transport and specify the libp2p **protocol ID** carrying a Trust
+Task document — say `/trust-tasks/1.0.0` — negotiated by multistream-select on a
+libp2p stream. So `https` : `/trust-tasks` :: `libp2p` : `/trust-tasks/1.0.0`.
 
-- **Identity precedence.** Does a cryptographically-authenticated transport
-  change how §4.8.1 should be applied, or is the existing precedence rule
-  sufficient as written? We have a view but not a strong one, and it is properly
-  the task force's call.
-- **Relayed connections.** When a connection traverses a circuit relay, the relay
-  sees traffic shape and endpoints though not content. Whether that warrants
-  anything in the binding specification is worth discussing.
-- **Peer ID to VID — which DID method?** Both `did:key` and `did:peer` are
-  derivable from the same Ed25519 key, and the choice is not obvious. KwaaiNet
-  uses `did:peer` today; the framework's other bindings lean toward `did:key`.
-  Whichever the task force prefers, key rotation and multi-key peers deserve a
-  stated rule rather than an implied one. We would rather the binding specify
-  this than leave each implementation to guess.
-- **Framework stability.** `trust-tasks-rs` has published 86 versions since May
-  2026, moving 0.5 → 0.9 in eight days. We are comfortable tracking that, but the
-  binding's own version cadence should be agreed rather than discovered.
+That said, you raised it, so you may have a reason to prefer otherwise. And if
+the bridge is the more interesting artefact, the naming question may want
+settling in that context instead.
+
+**Which DID method?**
+
+`did:peer`, on your recommendation and for your reason — routing information in
+the DID. KwaaiNet already issues `did:peer`, so this needs no change on our side.
+
+## What we would contribute
+
+- A production rust-libp2p fabric — Kademlia DHT, circuit relay, AutoNAT, DCUtR,
+  Noise, yamux — running across macOS, Linux and Windows nodes behind residential
+  NAT, with a tiered integration harness and measured per-call latency.
+- Four Kwaai people already participating in DTGWG.
+- Work on the shim, and on the bridge if the task force wants to pursue it.
+
+## Still open
+
+- **Whether to lead with the bridge or the binding.** The bridge is the more
+  valuable artefact; the binding may be the necessary substrate. We have no
+  strong view on sequencing and would follow the task force's.
+- **Whether another group should lead.** We are not the only libp2p stack here.
+  If someone else is further along, we would rather support their specification
+  than advance our own — the binding existing matters more to us than whose name
+  is on it.
 
 ## Timing
 
-Kwaai's committed engineering scope for 2026 does not include this work; our
-year-end release is platform hardening. We would expect to begin the
-specification once the task force agrees in principle, with implementation
-following the framework reaching a stable enough surface — realistically Q1
-2027. We would rather say that plainly than commit to a date we would miss.
+This is not in Kwaai's committed engineering scope for 2026; our year-end release
+is platform hardening. Realistically we would begin in Q1 2027. We would rather
+say that plainly than commit to a date we would miss — and it is another reason
+we are glad for someone else to lead if they are ready sooner.

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-response.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-response.md
@@ -3,9 +3,10 @@
 **Source:** Glenn Gore (Affinidi), 2026-08-19, comments on the shared proposal.
 **Discussion:** https://github.com/trustoverip/dtgwg-trust-tasks-tf/discussions/248
 
-All four asks answered affirmatively, with architectural guidance that makes the
-work smaller than proposed. Recorded here because Glenn's original point was that
-decisions should be documented and linkable from the PR.
+All four asks answered affirmatively — **and every technical argument we made for
+libp2p was rebutted.** The process outcome is good; the case we built for it was
+not. Both are recorded here, because Glenn's original point was that decisions
+should be documented and linkable from the PR.
 
 ## The four asks — all answered
 
@@ -19,6 +20,56 @@ decisions should be documented and linkable from the PR.
 Ask 4 is the significant one. We asked to be maintained in lockstep; the answer
 is that *they* carry the sync burden. That removes the pre-1.0 churn risk which
 was the main reservation in our own planning.
+
+## Correction: our technical case was wrong on all three points
+
+Glenn rebutted every differentiator in the proposal. Recording this plainly,
+because the shared document still carries the incorrect claims.
+
+**"None derives sender identity from a cryptographic transport handshake."**
+> *"This is technically not true. You can swap the delivery implementation."* (9:29)
+
+**"Neither party needs a public endpoint."**
+> *"I would state this differently. With DIDComm and TSP you also do not need to
+> use a mediator. They are just messages, you can send them peer-to-peer if you
+> want. We use mediators/relays though where they can be neutrally hosted for
+> public good and you can nest (hide) behind multi relay hopping so no one knows
+> where you are and as each client connects out to a mediator, it also operates
+> behind NAT etc — you can punch holes through networks."* (9:23)
+
+Worse for us than merely being wrong: multi-relay hopping gives *sender privacy*
+that plain libp2p circuit relay does not.
+
+**"Full-duplex removes the polling or mediator-callback patterns."**
+> *"this is how the mediator works — there is no polling… It is bi-directional
+> websockets with event based delivery."* (9:25)
+
+### Where the error came from
+
+I read the HTTPS binding specification closely and then generalised its
+properties — bearer-token identity, a reachable server, request/response — to
+DIDComm and TSP, which I did not read. Those are messaging protocols with their
+own identity and routing models, and the generalisation does not hold. The
+lesson is narrow and worth keeping: **do not characterise a peer technology from
+a sibling's specification.**
+
+## The constructive redirect: a bridge, not another transport
+
+> *"a real innovation here would be a bridge between libp2p and TSP/DIDComm where
+> you could mix the protocols together. We do this already with TSP+DIDComm where
+> you can use TSP for routing, and the final delivery is via DIDComm for example.
+> So you could use TSP for routing, carrying a libp2p payload or vice-versa."* (9:24)
+
+This is the part worth pursuing. It is a genuinely different proposition from
+"another transport binding": composing protocols so each does what it is best at
+— TSP routing with libp2p delivery, or libp2p routing carrying a TSP payload.
+
+It also plays to what KwaaiNet actually has. Our contribution is not a novel
+transport; it is a production libp2p fabric that could be one leg of such a
+bridge. And it fits the shim architecture below rather than fighting it.
+
+**We should lead the revised proposal with the bridge**, and treat the plain
+binding as the necessary substrate beneath it rather than as the headline.
 
 ## The architecture guidance — a shim, not a full binding
 
@@ -91,15 +142,36 @@ question, so he may have a reason to prefer otherwise.
 
 ## What we should do next
 
-1. **Reply in the Discussion** — answer the slug question, accept the shim
-   architecture, confirm `did:peer`, and thank him for taking on sync.
-2. **Fix the public comment.** The follow-up comment on discussion #248 links the
-   Google Doc including Reza's `ouid`. Replace it with the GitHub proposal link
-   once #113 merges.
-3. **Ask Glenn to repost these comments in the thread**, or paste them ourselves
-   with attribution — they are currently only in a Google Doc, which defeats his
-   own point about documenting the decision where the PR can link to it.
-4. **Update the proposal** to reflect the shim architecture and the resolved
-   questions, so the document and the decision do not drift.
-5. **Nothing changes in the 2026 plan.** This remains Q1 2027 work; rung 1 is
-   unaffected.
+1. **Correct the shared document before anything else.** It still asserts three
+   rebutted claims to a public audience. Rewrite "Why libp2p, specifically"
+   around the bridge, and drop the differentiators rather than defending them.
+2. **Reply in the Discussion**, and lead with the concession. Accept the
+   corrections plainly, take the bridge idea, accept the shim architecture,
+   confirm `did:peer`, and answer the slug question. Conceding accurately is
+   worth more here than being right — it is the first substantive exchange we
+   have had with this group.
+3. **Fix the public comment.** Discussion #248's follow-up links the Google Doc
+   including Reza's `ouid`. Replace it with the GitHub proposal link once #113
+   merges.
+4. **Ask Glenn to repost his comments in the thread**, or paste them with
+   attribution. They exist only in a Google Doc, which defeats his own point.
+5. **Nothing changes in the 2026 plan.** Still Q1 2027; rung 1 is unaffected.
+
+## What is actually left of our case
+
+Worth being clear-eyed, because the revised proposal has to stand on this:
+
+- **Not** unique cryptographic transport identity. Delivery is swappable.
+- **Not** unique NAT traversal or serverless operation. DIDComm and TSP do
+  peer-to-peer, and mediators add sender privacy we do not have.
+- **Not** unique full-duplex or event-driven delivery. Mediators are
+  bi-directional websockets already.
+- **Yes:** a bridge composing libp2p with TSP/DIDComm — Glenn's own suggestion,
+  and he called it "a real innovation".
+- **Yes:** a production libp2p fabric to be one leg of that bridge, with
+  `did:peer` already in use and multiaddrs that can ride in the DID.
+- **Yes:** a constituency. We are not the only libp2p stack in the group.
+
+The honest framing for the revised proposal is that libp2p is a transport many
+people already run, so meeting them where they are has value — not that it is
+technically superior to what Trust Tasks already supports.

--- a/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-response.md
+++ b/projects/kwaai-trust/proposals/TrustTasksLibp2pBinding-response.md
@@ -1,0 +1,105 @@
+# DTGWG response and our reply — libp2p binding
+
+**Source:** Glenn Gore (Affinidi), 2026-08-19, comments on the shared proposal.
+**Discussion:** https://github.com/trustoverip/dtgwg-trust-tasks-tf/discussions/248
+
+All four asks answered affirmatively, with architectural guidance that makes the
+work smaller than proposed. Recorded here because Glenn's original point was that
+decisions should be documented and linkable from the PR.
+
+## The four asks — all answered
+
+| Ask | Answer |
+|-----|--------|
+| 1. In scope? | **Yes.** *"Agreed that libp2p binding would be in scope of Trust Tasks and be a good addition."* |
+| 2. Reserved slug and URI? | **Yes**, with a naming question — see below. *"I am happy to reserve a slug and URI for libp2p."* |
+| 3. Target framework version? | **Latest, not `0.2`.** *"It should target the latest framework, where possible, given that this is pre-1.0, and the spec is moving fast and has breaking changes."* |
+| 4. In-tree maintenance? | **Yes, and stronger than we asked.** *"The maintainers of trust-tasks would take on the responsibility of ensuring the binding is kept in sync with the features of Trust Tasks."* |
+
+Ask 4 is the significant one. We asked to be maintained in lockstep; the answer
+is that *they* carry the sync burden. That removes the pre-1.0 churn risk which
+was the main reservation in our own planning.
+
+## The architecture guidance — a shim, not a full binding
+
+> "There is an option here to have the libp2p binding be a shim that creates a
+> payload, with a trait overlay that allows a pluggable libp2p behind the shim.
+> This would allow fast-moving changes to the shim when the Trust Task spec adds
+> an attribute, while keeping control of the heavy lifting protocol elsewhere (as
+> the TSP and DIDComm bindings do)."
+
+This is how `trust-tasks-tsp` already works — it wraps `affinidi-tsp` rather than
+implementing TSP. **We should adopt it**, for three reasons:
+
+1. **It shrinks our deliverable.** `trust-tasks-libp2p` becomes a thin shim, not
+   a transport implementation. Our rust-libp2p sits behind the trait.
+2. **It decouples release cadences.** Spec changes hit the shim, which they
+   maintain. Our stack moves on its own schedule.
+3. **It matches the existing pattern**, so it needs no special pleading.
+
+**This supersedes the deliverable in the proposal**, which described a client and
+listener over a libp2p `Swarm` mirroring `HttpsClient`/`HttpsServer`. That was the
+HTTPS model; the TSP model is the right one here.
+
+## Open questions — resolved
+
+**§4.8.1 stays as written.** *"It should not change 4.8.1, if addressing in libp2p
+can be converted to a DID/VID then you will get greater interoperability (i.e.
+libp2p connection within a VTC could still talk to a TSP connected peer in the
+same VTC)."* Better than we hoped: convert libp2p addressing to a DID/VID and you
+get cross-binding interoperability inside a VTC, not merely a working libp2p path.
+
+**Relay privacy needs nothing special.** *"Nothing special apart from explaining
+how libp2p works… that is not the responsibility of Trust Tasks to help someone
+pick libp2p or TSP or DIDComm or REST."* Document the properties, do not
+editorialise about the choice.
+
+**DID method: `did:peer` recommended — which is what we already use.** *"Trust
+Tasks does not care… if you are looking for an ephemeral self-supporting DID then
+I would strongly suggest `did:peer` as it allows you more flexibility to put some
+routing information in the DID vs. `did:key` which would be very limiting from a
+routing perspective."*
+
+Three consequences for us:
+
+- KwaaiNet already issues `did:peer` (`kwaai-trust/src/did.rs`). No change needed,
+  and the earlier draft's `did:key` assumption was wrong in exactly the direction
+  Glenn warns against.
+- **Routing information in the DID is the interesting part.** `did:peer` can carry
+  service endpoints, so a peer's multiaddrs — including circuit-relay addresses —
+  can travel in the DID itself. That is a real fit for libp2p rather than a
+  compromise.
+- It settles the `did:key` vs `did:peer` verification mismatch recorded in
+  `Ledger-plan.md`, in favour of what we already do.
+
+## Still open: is `libp2p` the right slug?
+
+> "Is 'libp2p' the right protocol name (aka DIDComm or TSP)?"
+
+A fair challenge: DIDComm and TSP are messaging protocols with defined envelopes;
+libp2p is a networking stack that carries many protocols.
+
+**Our answer should be that `libp2p` is right, by exact analogy with `https`.**
+The HTTPS binding is named for the transport and then specifies the particulars —
+`POST` to `/trust-tasks`. A libp2p binding is named for the transport and
+specifies the libp2p **protocol ID** that carries a Trust Task document, e.g.
+`/trust-tasks/1.0.0`, negotiated by multistream-select on a libp2p stream.
+
+So the parallel is `https` : `/trust-tasks` :: `libp2p` : `/trust-tasks/1.0.0`.
+Worth stating plainly in the reply, and inviting correction — Glenn asked the
+question, so he may have a reason to prefer otherwise.
+
+## What we should do next
+
+1. **Reply in the Discussion** — answer the slug question, accept the shim
+   architecture, confirm `did:peer`, and thank him for taking on sync.
+2. **Fix the public comment.** The follow-up comment on discussion #248 links the
+   Google Doc including Reza's `ouid`. Replace it with the GitHub proposal link
+   once #113 merges.
+3. **Ask Glenn to repost these comments in the thread**, or paste them ourselves
+   with attribution — they are currently only in a Google Doc, which defeats his
+   own point about documenting the decision where the PR can link to it.
+4. **Update the proposal** to reflect the shim architecture and the resolved
+   questions, so the document and the decision do not drift.
+5. **Nothing changes in the 2026 plan.** This remains Q1 2027 work; rung 1 is
+   unaffected.


### PR DESCRIPTION
Draft of Kwaai's proposal to contribute **`trust-tasks-libp2p`** — a binding
specification plus crate alongside the existing `-https`, `-didcomm` and `-tsp`
implementations.

**Marked draft, not yet submitted.** It represents Kwaai to an external standards
body, so it should go to our four DTGWG volunteers before it goes to the task
force — they know the room and whether this reads as useful or as overreach.

## The technical case

Two gaps in the current bindings, not "libp2p is nice":

**Identity.** SPEC §4.8.1 governs precedence of in-band over transport-derived
identity. The HTTPS binding satisfies it with a bearer token mapped to a VID — a
deployment concern whose strength depends on issuance and mapping hygiene. libp2p
authenticates every connection with a Noise handshake over the peer's long-term
key, so the peer ID **is** the public key: transport-derived identity is
established cryptographically before the first byte is read, and peer-ID-to-`did:key`
is a derivation rather than a lookup table.

**Reachability.** No existing binding carries Trust Tasks between two parties
where *neither* has a public endpoint. That is exactly the personal-device case
the DTGWG charter speaks to — "all parties control their own subgraph" is more
credible when neither party runs infrastructure. Circuit relay plus DCUtR covers
it, and libp2p's full-duplex multiplexing lets a consumer behind NAT receive
tasks rather than only send them.

## The ask

Deliberately modest: agreement in principle, a reserved slug and binding URI,
target framework version, and **in-tree maintenance published to crates.io**.

That last point is stated as mutually beneficial rather than dressed as
generosity — lockstep versioning is the mechanism by which upstream refactors
keep our binding working. `bindings/push` exists in-repo without a published
crate, so publication is worth agreeing rather than assuming.

## What it does not do

Open questions are raised, not answered: whether a cryptographic transport
changes how §4.8.1 should apply, relay visibility, key rotation in the peer-ID
mapping, and binding cadence against a framework that shipped 86 versions since
May.

Timing is stated plainly — not in Kwaai's committed 2026 scope, realistically Q1
2027 — rather than a date we would miss.

Contains an **internal notes** section to be removed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP