### PR TITLE
feat(config): make native_p2p three-state so the cutover cannot override an opt-out

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -143,10 +143,21 @@ pub struct KwaaiNetConfig {
     /// this path (see `node_native`'s module docs for the flag-by-flag mapping
     /// against p2pd).
     ///
-    /// Defaults to false — the p2pd path stays the default until the NAT slice
-    /// lands and the cutover in Phase 5 flips it.
-    #[serde(default)]
-    pub native_p2p: bool,
+    /// **Three states, deliberately.** `Some(true)` runs native, `Some(false)`
+    /// is an explicit opt-out, and `None` means "never chosen" and takes
+    /// [`DEFAULT_NATIVE_P2P`].
+    ///
+    /// It is an `Option` so the cutover can flip the default without overriding
+    /// anyone who has already said no. A plain `bool` could not distinguish the
+    /// two: `load()` only writes the config file when it is absent, so an
+    /// existing `config.yaml` is never rewritten on upgrade, and whether the key
+    /// is present at all depends on which version first created that file.
+    /// Flipping a `bool` default would therefore have flipped some nodes and not
+    /// others, decided by config vintage rather than by anyone's intent.
+    ///
+    /// Read it through [`KwaaiNetConfig::native_p2p`], never directly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_p2p: Option<bool>,
     /// Ask the local gateway to map our listen port via UPnP/IGD
     /// (`-natPortMap`).
     ///
@@ -668,7 +679,7 @@ impl Default for KwaaiNetConfig {
             initial_peers: default_peers(),
             trusted_relays: default_trusted_relays(),
             force_private: default_force_private(),
-            native_p2p: false,
+            native_p2p: None,
             enable_upnp: default_enable_upnp(),
             health_monitoring: HealthConfig::default(),
             model_dht_prefix: None,
@@ -725,7 +736,32 @@ impl Default for ReconnectionConfig {
 // Load / save
 // ---------------------------------------------------------------------------
 
+/// What `native_p2p` means when the user has never chosen.
+///
+/// **This constant is the 0.6 cutover.** Flipping it to `true` moves every node
+/// that has not explicitly opted out onto the native stack; nodes with
+/// `native_p2p: false` written in their config keep the p2pd path regardless.
+/// Nothing else needs to change, and no config file is rewritten.
+pub const DEFAULT_NATIVE_P2P: bool = false;
+
 impl KwaaiNetConfig {
+    /// Whether to run the native stack: the explicit choice if there is one,
+    /// otherwise [`DEFAULT_NATIVE_P2P`].
+    ///
+    /// Always read the flag through this — `self.native_p2p` is three-state and
+    /// `Some(false)` must keep beating a flipped default.
+    pub fn native_p2p(&self) -> bool {
+        self.native_p2p.unwrap_or(DEFAULT_NATIVE_P2P)
+    }
+
+    /// True when the user has explicitly opted out of the native stack, as
+    /// opposed to simply never having chosen. Callers that want to say
+    /// something about the cutover need the distinction; callers that just want
+    /// the behaviour want [`Self::native_p2p`].
+    pub fn opted_out_of_native_p2p(&self) -> bool {
+        self.native_p2p == Some(false)
+    }
+
     /// The `state` field for a DHT announcement: `2` ONLINE, `0` JOINING.
     ///
     /// ONLINE means "this node will serve inference", not merely "this node is
@@ -902,7 +938,7 @@ impl KwaaiNetConfig {
             }
             "announce_addr" => self.announce_addr = Some(value.to_string()),
             "no_relay" => self.no_relay = parse_bool(value)?,
-            "native_p2p" => self.native_p2p = parse_bool(value)?,
+            "native_p2p" => self.native_p2p = Some(parse_bool(value)?),
             "enable_upnp" => self.enable_upnp = parse_bool(value)?,
             "start_block" => {
                 self.start_block = value
@@ -955,6 +991,104 @@ mod dirs_sys {
     use std::path::PathBuf;
     pub fn home_dir() -> Option<PathBuf> {
         dirs::home_dir()
+    }
+}
+
+#[cfg(test)]
+mod native_p2p_tri_state {
+    use super::*;
+
+    // The whole reason the field is an `Option`: the cutover must be able to
+    // flip the default without overriding anyone who already said no.
+
+    #[test]
+    fn unset_takes_the_default() {
+        let cfg = KwaaiNetConfig::default();
+        assert_eq!(cfg.native_p2p, None, "a fresh config records no choice");
+        assert_eq!(cfg.native_p2p(), DEFAULT_NATIVE_P2P);
+    }
+
+    #[test]
+    fn an_explicit_choice_beats_the_default_both_ways() {
+        let on = KwaaiNetConfig {
+            native_p2p: Some(true),
+            ..Default::default()
+        };
+        assert!(on.native_p2p());
+        let off = KwaaiNetConfig {
+            native_p2p: Some(false),
+            ..Default::default()
+        };
+        assert!(!off.native_p2p());
+    }
+
+    #[test]
+    fn opting_out_survives_a_flipped_default() {
+        // Simulates the cutover: whatever DEFAULT_NATIVE_P2P becomes, an
+        // explicit `false` must still mean the p2pd path. Expressed without
+        // reading the constant so the test keeps its meaning after the flip.
+        let off = KwaaiNetConfig {
+            native_p2p: Some(false),
+            ..Default::default()
+        };
+        assert!(!off.native_p2p(), "an explicit opt-out is never overridden");
+        assert!(off.opted_out_of_native_p2p());
+
+        let unset = KwaaiNetConfig {
+            native_p2p: None,
+            ..Default::default()
+        };
+        assert!(
+            !unset.opted_out_of_native_p2p(),
+            "never having chosen is not the same as opting out"
+        );
+    }
+
+    #[test]
+    fn set_records_an_explicit_choice() {
+        // `config set native_p2p false` must write `Some(false)`, not leave the
+        // field unset — otherwise the opt-out evaporates at the cutover.
+        let mut cfg = KwaaiNetConfig::default();
+        cfg.set_key("native_p2p", "false").expect("set");
+        assert_eq!(cfg.native_p2p, Some(false));
+        cfg.set_key("native_p2p", "true").expect("set");
+        assert_eq!(cfg.native_p2p, Some(true));
+    }
+
+    #[test]
+    fn an_unset_flag_is_not_serialised() {
+        // Absent must stay absent on save, or every node that has merely
+        // started once would acquire a pinned choice it never made.
+        let cfg = KwaaiNetConfig::default();
+        let y = serde_yaml::to_string(&cfg).expect("serialise");
+        assert!(
+            !y.contains("native_p2p"),
+            "an unmade choice must not be written to disk:\n{y}"
+        );
+    }
+
+    #[test]
+    fn a_legacy_config_without_the_key_loads_as_unset() {
+        // Configs written before the flag existed have no key at all.
+        let y = "port: 8080\nnative_p2p_absent_marker: true\n";
+        let cfg: KwaaiNetConfig = serde_yaml::from_str(y).expect("legacy config parses");
+        assert_eq!(cfg.native_p2p, None);
+        assert_eq!(cfg.native_p2p(), DEFAULT_NATIVE_P2P);
+    }
+
+    #[test]
+    fn an_explicit_false_round_trips_through_yaml() {
+        let cfg = KwaaiNetConfig {
+            native_p2p: Some(false),
+            ..Default::default()
+        };
+        let y = serde_yaml::to_string(&cfg).expect("serialise");
+        assert!(
+            y.contains("native_p2p: false"),
+            "opt-out must persist:\n{y}"
+        );
+        let back: KwaaiNetConfig = serde_yaml::from_str(&y).expect("round trip");
+        assert_eq!(back.native_p2p, Some(false));
     }
 }
 

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -141,7 +141,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
 
     // The native stack has its own whole lifecycle — no child process to spawn,
     // watch, restart or shut down — so it lives in `node_native`.
-    if config.native_p2p {
+    if config.native_p2p() {
         info!("native_p2p enabled — running without the Go p2p daemon");
         let pending_update_version = crate::node_native::run_native_node(
             config,
@@ -156,6 +156,13 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
         respawn_after_update(pending_update_version);
         info!("KwaaiNet node stopped");
         return Ok(());
+    }
+
+    // Say *why* this node is on p2pd. During the cutover the two reasons are
+    // operationally different: an explicit opt-out is a decision to respect,
+    // while an unset flag simply means the default has not moved yet.
+    if config.opted_out_of_native_p2p() {
+        info!("native_p2p is explicitly disabled in the config — using the Go p2p daemon");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Preparation for the 0.6 cutover. `native_p2p` becomes `Option<bool>`:

| Value | Meaning |
|---|---|
| `Some(true)` | run native |
| `Some(false)` | **explicit opt-out — survives the cutover** |
| `None` | never chosen; takes `DEFAULT_NATIVE_P2P` |

## Why a plain `bool` could not work

`load()` writes the config file only when it is **absent**:

```rust
} else {
    let cfg = KwaaiNetConfig::default();
    cfg.save()?;   // only on first run
}
```

So an existing `config.yaml` is never rewritten on upgrade, and whether the
`native_p2p` key is present depends on which version first created that file.
Flipping a `bool` default would have flipped **some** nodes and not others —
decided by config vintage rather than by anyone's intent. That is worse than
either extreme, and it would have been near-impossible to debug in the field.

## What the cutover becomes

A one-line change to `DEFAULT_NATIVE_P2P`. Every node that never chose moves to
native; every node carrying `native_p2p: false` keeps p2pd; no config file is
rewritten.

Verified by temporarily flipping the constant:

```
DEFAULT_NATIVE_P2P=true -> unset resolves true | explicit-false resolves false
```

## Details

- Read through `KwaaiNetConfig::native_p2p()`, never the field. `node.rs` uses the accessor.
- `skip_serializing_if = "Option::is_none"` — merely starting a node must not pin a choice it never made.
- `config set native_p2p false` writes `Some(false)`, so an opt-out made **today** survives the flip.
- `opted_out_of_native_p2p()` separates "said no" from "never asked", and `node.rs` logs the difference — during the cutover those are operationally distinct reasons to be on p2pd.

Seven tests pin the semantics, written to keep their meaning after the flip: the
opt-out test asserts behaviour directly rather than against the constant, plus
coverage for legacy configs with no key, absent staying absent on save, and an
explicit `false` round-tripping through YAML.

**This does not flip the default.** That is a separate, deliberate commit.

Verified: `cargo test -p kwaainet` 106 passed, clippy `--all-targets -D warnings`
clean, fmt clean, dependent crates compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP