### PR TITLE
fix(p2p): never dial our own address (#108)

### DIFF
--- a/core/crates/kwaai-p2p/src/addresses.rs
+++ b/core/crates/kwaai-p2p/src/addresses.rs
@@ -29,8 +29,10 @@
 //! the swarm itself do no address-class filtering whatsoever, so AutoNAT's knob
 //! is the only lever, and it has to be off for the test bed to work.
 
+use std::collections::HashSet;
 use std::net::Ipv4Addr;
 
+use libp2p::swarm::FromSwarm;
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 
 /// Whether `addr` is worth advertising to other peers.
@@ -649,6 +651,170 @@ mod tests {
         assert!(
             !is_announceable_with(&nat_test, true),
             "and must not pass once the operator declares a real-internet node"
+        );
+    }
+}
+
+/// This node's own addresses, so a behaviour never dials itself.
+///
+/// A peer may advertise an address that happens to be *ours* — most obviously
+/// `127.0.0.1` on our own listen port, which peers do publish and which nothing
+/// in libp2p filters. Dialing it connects us to ourselves, the handshake
+/// reports the wrong peer ID, and the dial fails. That is not merely wasteful:
+/// the failures feed the circuit breaker, and three in a row latch it against a
+/// peer that is perfectly healthy, until the process restarts. See issue #108.
+///
+/// Filtering by *routability* would be wrong here — `is_routable_v4` rejects
+/// loopback and RFC1918 alike, which would break both the local two-node test
+/// topology and any two peers on the same LAN. The precise invariant is
+/// narrower and exact: **do not dial an address that is one of ours.** A second
+/// local node on a different port is still reachable, because its address is
+/// not ours.
+///
+/// Addresses arrive concrete: listening on `0.0.0.0` makes the transport emit
+/// one `NewListenAddr` per interface, including the loopback one, so exact
+/// comparison is enough. `/p2p/…` is stripped from both sides before comparing,
+/// since dial candidates often carry it and listen addresses do not.
+#[derive(Debug, Default)]
+pub struct OwnAddresses {
+    addrs: HashSet<Multiaddr>,
+}
+
+impl OwnAddresses {
+    /// Track our own listen and confirmed-external addresses. Call from every
+    /// behaviour's `on_swarm_event`, before using [`Self::is_ours`].
+    pub fn on_swarm_event(&mut self, event: &FromSwarm) {
+        match event {
+            FromSwarm::NewListenAddr(e) => {
+                self.addrs.insert(strip_p2p(e.addr));
+            }
+            FromSwarm::ExpiredListenAddr(e) => {
+                self.addrs.remove(&strip_p2p(e.addr));
+            }
+            FromSwarm::ExternalAddrConfirmed(e) => {
+                self.addrs.insert(strip_p2p(e.addr));
+            }
+            FromSwarm::ExternalAddrExpired(e) => {
+                self.addrs.remove(&strip_p2p(e.addr));
+            }
+            _ => {}
+        }
+    }
+
+    /// True when `addr` is one of ours and must not be dialed.
+    pub fn is_ours(&self, addr: &Multiaddr) -> bool {
+        self.addrs.contains(&strip_p2p(addr))
+    }
+
+    /// Drop our own addresses from a set of dial candidates.
+    pub fn reject_self<I>(&self, candidates: I) -> Vec<Multiaddr>
+    where
+        I: IntoIterator<Item = Multiaddr>,
+    {
+        candidates
+            .into_iter()
+            .filter(|a| !self.is_ours(a))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod own_addresses {
+    use super::*;
+
+    fn ma(s: &str) -> Multiaddr {
+        s.parse().expect("test multiaddr")
+    }
+
+    fn with(addrs: &[&str]) -> OwnAddresses {
+        let mut own = OwnAddresses::default();
+        for a in addrs {
+            own.addrs.insert(strip_p2p(&ma(a)));
+        }
+        own
+    }
+
+    // -- the bug in issue #108 -------------------------------------------
+
+    #[test]
+    fn our_own_loopback_listener_is_not_a_dial_candidate() {
+        let own = with(&["/ip4/127.0.0.1/tcp/8080"]);
+        assert!(own.is_ours(&ma("/ip4/127.0.0.1/tcp/8080")));
+        assert!(own
+            .reject_self(vec![ma("/ip4/127.0.0.1/tcp/8080")])
+            .is_empty());
+    }
+
+    #[test]
+    fn a_p2p_suffix_does_not_hide_our_own_address() {
+        // Dial candidates learned from identify/DHT usually carry `/p2p/…`;
+        // listen addresses do not. Both sides are stripped before comparing.
+        let own = with(&["/ip4/127.0.0.1/tcp/8080"]);
+        let candidate =
+            ma("/ip4/127.0.0.1/tcp/8080/p2p/12D3KooWLMizEbViSoL4WGJUMsLVRyLccyymosX36MDKdbYgGFzE");
+        assert!(
+            own.is_ours(&candidate),
+            "the /p2p/ suffix must not defeat the check"
+        );
+    }
+
+    // -- what a routability filter would have broken ----------------------
+
+    #[test]
+    fn another_local_node_on_a_different_port_is_still_dialable() {
+        // The two-node local test topology. Rejecting loopback wholesale would
+        // have broken this; rejecting only *our own* address does not.
+        let own = with(&["/ip4/127.0.0.1/tcp/8080"]);
+        let peer = ma("/ip4/127.0.0.1/tcp/8081");
+        assert!(!own.is_ours(&peer));
+        assert_eq!(own.reject_self(vec![peer.clone()]), vec![peer]);
+    }
+
+    #[test]
+    fn a_lan_peer_is_still_dialable() {
+        // `is_routable_v4` rejects RFC1918, so filtering by routability would
+        // have stopped two peers on the same LAN from reaching each other.
+        let own = with(&["/ip4/192.168.1.10/tcp/8080"]);
+        let peer = ma("/ip4/192.168.1.11/tcp/8080");
+        assert!(!own.is_ours(&peer));
+        assert!(!is_routable_v4("192.168.1.11".parse().unwrap()));
+    }
+
+    #[test]
+    fn only_the_exact_address_is_rejected() {
+        let own = with(&["/ip4/127.0.0.1/tcp/8080"]);
+        for other in [
+            "/ip4/127.0.0.2/tcp/8080",
+            "/ip4/127.0.0.1/udp/8080/quic-v1",
+            "/ip4/10.0.0.5/tcp/8080",
+        ] {
+            assert!(!own.is_ours(&ma(other)), "{other} is not ours");
+        }
+    }
+
+    // -- lifecycle --------------------------------------------------------
+
+    #[test]
+    fn an_expired_listener_stops_being_ours() {
+        let mut own = with(&["/ip4/127.0.0.1/tcp/8080"]);
+        let a = ma("/ip4/127.0.0.1/tcp/8080");
+        assert!(own.is_ours(&a));
+        own.addrs.remove(&strip_p2p(&a));
+        assert!(
+            !own.is_ours(&a),
+            "a released port may legitimately belong to someone else later"
+        );
+    }
+
+    #[test]
+    fn nothing_is_ours_before_we_listen() {
+        let own = OwnAddresses::default();
+        assert!(!own.is_ours(&ma("/ip4/127.0.0.1/tcp/8080")));
+        let c = vec![ma("/ip4/1.2.3.4/tcp/8080")];
+        assert_eq!(
+            own.reject_self(c.clone()),
+            c,
+            "an empty set filters nothing"
         );
     }
 }

--- a/core/crates/kwaai-p2p/src/raw_stream.rs
+++ b/core/crates/kwaai-p2p/src/raw_stream.rs
@@ -382,6 +382,8 @@ pub struct Behaviour {
     pending_events: VecDeque<ToSwarm<Event, OutboundOpen>>,
     /// Peer addresses learned from the swarm, served back on dial-on-demand.
     addresses: PeerAddresses,
+    /// Our own addresses, so we never dial ourselves — see issue #108.
+    own_addrs: crate::addresses::OwnAddresses,
 }
 
 impl Behaviour {
@@ -520,14 +522,18 @@ impl NetworkBehaviour for Behaviour {
         _addresses: &[Multiaddr],
         _effective_role: Endpoint,
     ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        // Never hand back one of our own addresses: a peer that advertises
+        // our loopback listener would otherwise have us dial ourselves, fail
+        // the peer-ID check, and feed the circuit breaker. Issue #108.
         Ok(match maybe_peer {
-            Some(peer) => self.addresses.get(&peer).collect(),
+            Some(peer) => self.own_addrs.reject_self(self.addresses.get(&peer)),
             None => Vec::new(),
         })
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm) {
         self.addresses.on_swarm_event(&event);
+        self.own_addrs.on_swarm_event(&event);
         match event {
             FromSwarm::ConnectionClosed(closed) => {
                 if let Some(connections) = self.connected.get_mut(&closed.peer_id) {

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -729,6 +729,8 @@ pub struct Behaviour {
     /// most dial addresses; this cache covers hints injected via
     /// `Swarm::add_peer_address`.
     addresses: PeerAddresses,
+    /// Our own addresses, so we never dial ourselves — see issue #108.
+    own_addrs: crate::addresses::OwnAddresses,
 }
 
 impl Behaviour {
@@ -740,6 +742,7 @@ impl Behaviour {
             pending_outbound_requests: HashMap::new(),
             pending_events: VecDeque::new(),
             addresses: PeerAddresses::default(),
+            own_addrs: crate::addresses::OwnAddresses::default(),
         }
     }
 
@@ -859,14 +862,18 @@ impl NetworkBehaviour for Behaviour {
         _addresses: &[Multiaddr],
         _effective_role: Endpoint,
     ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        // Never hand back one of our own addresses: a peer that advertises
+        // our loopback listener would otherwise have us dial ourselves, fail
+        // the peer-ID check, and feed the circuit breaker. Issue #108.
         Ok(match maybe_peer {
-            Some(peer) => self.addresses.get(&peer).collect(),
+            Some(peer) => self.own_addrs.reject_self(self.addresses.get(&peer)),
             None => Vec::new(),
         })
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm) {
         self.addresses.on_swarm_event(&event);
+        self.own_addrs.on_swarm_event(&event);
         match event {
             FromSwarm::ConnectionClosed(closed) => {
                 if let Some(connections) = self.connected.get_mut(&closed.peer_id) {


### PR DESCRIPTION
Closes #108.

A peer that advertises one of *our* addresses — most obviously `127.0.0.1` on our
own listen port, which peers do publish and nothing in libp2p filters — had us
dial ourselves. The handshake reported the wrong peer ID and the dial failed:

```
Dial failed: Unexpected peer ID 12D3KooWAourfFox…
  at /ip4/127.0.0.1/tcp/8080/p2p/12D3KooWLMizEbVi…
```

**The waste was not the problem.** Those failures fed the circuit breaker, and
three in a row latched it against a healthy peer until the process restarted.
Observed live: it took down an entire D6 accuracy eval — 37 of 40 questions
failing in ~109 ms having never reached the peer — which reads as a RAG
regression and is nothing of the sort.

## Root cause

`unary.rs` and `raw_stream.rs` both feed a `PeerAddresses` cache straight from
`on_swarm_event` (which absorbs `NewExternalAddrOfPeer`) and hand the whole cache
back as dial candidates from `handle_pending_outbound_connection`. Nothing
filtered it.

## Why not `is_routable_v4`

The obvious fix — the predicate already exists in `addresses.rs` and rejects
loopback — **would have been wrong**. It also rejects RFC1918, so it would have
broken the local two-node test topology *and* any two peers on the same LAN.

The precise invariant is narrower and exact: **do not dial an address that is one
of ours.** A second local node on a different port stays reachable, because its
address is not ours.

## The fix

`addresses::OwnAddresses` tracks our own listen and confirmed-external addresses
from the same `FromSwarm` stream both behaviours already consume, and filters
them out of dial candidates.

Addresses arrive concrete — listening on `0.0.0.0` makes the transport emit one
`NewListenAddr` per interface, including the loopback one — so exact comparison
suffices. `/p2p/…` is stripped from both sides, since candidates usually carry it
and listen addresses do not.

## Tests

Seven, including the two cases a routability filter would have broken:

- `another_local_node_on_a_different_port_is_still_dialable`
- `a_lan_peer_is_still_dialable` (asserts `is_routable_v4` rejects it, so the
  test documents *why* that predicate was not used)

Plus the bug itself, the `/p2p/` suffix not defeating the check, exact-match-only
rejection, and listener expiry.

Verified: kwaai-p2p 92 unit + all integration green, kwaai-p2p-daemon green,
interop tiers 07–13 green under `KWAAI_INTEGRATION_TESTS=1`, clippy
`--all-targets -D warnings` clean, fmt clean.

**Cutover relevance:** this was the last item gating a safe default flip. A node
that can latch a breaker against a healthy peer until restart is survivable while
native is opt-in, and not once it is the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP