### PR TITLE
release(v0.6.0): cut over to the native p2p stack by default

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-compression"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "bincode",
  "candle-core",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-core"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-distributed"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-hivemind-dht"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-inference"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-network-tests"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-p2p"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-p2p-daemon"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-rag"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-rpc"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-storage"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-trust"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-wasm"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "kwaainet"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "map-server"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,7 @@ multistream-select = { path = "patches/multistream-select" }
 # Root package for examples
 [package]
 name = "kwaai-core"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2021"
 publish = false
 
@@ -139,7 +139,7 @@ name = "query_dht_state"
 path = "examples/query_dht_state.rs"
 
 [workspace.package]
-version = "0.5.5"
+version = "0.6.0"
 
 edition = "2021"
 authors = ["Kwaai AI Lab <dev@kwaai.ai>"]
@@ -150,18 +150,18 @@ keywords = ["ai", "decentralized", "p2p", "wasm", "inference"]
 categories = ["network-programming", "wasm", "science"]
 
 [workspace.dependencies]
-kwaai-compression  = { path = "crates/kwaai-compression",  version = "0.5.0" }
-kwaai-trust        = { path = "crates/kwaai-trust",        version = "0.5.0" }
-kwaai-p2p          = { path = "crates/kwaai-p2p",          version = "0.5.0" }
-kwaai-hivemind-dht = { path = "crates/kwaai-hivemind-dht", version = "0.5.0" }
-kwaai-distributed  = { path = "crates/kwaai-distributed",  version = "0.5.0" }
-kwaai-inference    = { path = "crates/kwaai-inference",    version = "0.5.0" }
-kwaai-cli          = { path = "crates/kwaai-cli",          version = "0.5.0" }
-kwaai-p2p-daemon   = { path = "crates/kwaai-p2p-daemon",   version = "0.5.0" }
-kwaai-wasm         = { path = "crates/kwaai-wasm",         version = "0.5.0" }
-kwaai-storage      = { path = "crates/kwaai-storage",      version = "0.5.0" }
-kwaai-rag          = { path = "crates/kwaai-rag",          version = "0.5.0" }
-kwaai-rpc          = { path = "crates/kwaai-rpc",          version = "0.5.0" }
+kwaai-compression  = { path = "crates/kwaai-compression",  version = "0.6.0" }
+kwaai-trust        = { path = "crates/kwaai-trust",        version = "0.6.0" }
+kwaai-p2p          = { path = "crates/kwaai-p2p",          version = "0.6.0" }
+kwaai-hivemind-dht = { path = "crates/kwaai-hivemind-dht", version = "0.6.0" }
+kwaai-distributed  = { path = "crates/kwaai-distributed",  version = "0.6.0" }
+kwaai-inference    = { path = "crates/kwaai-inference",    version = "0.6.0" }
+kwaai-cli          = { path = "crates/kwaai-cli",          version = "0.6.0" }
+kwaai-p2p-daemon   = { path = "crates/kwaai-p2p-daemon",   version = "0.6.0" }
+kwaai-wasm         = { path = "crates/kwaai-wasm",         version = "0.6.0" }
+kwaai-storage      = { path = "crates/kwaai-storage",      version = "0.6.0" }
+kwaai-rag          = { path = "crates/kwaai-rag",          version = "0.6.0" }
+kwaai-rpc          = { path = "crates/kwaai-rpc",          version = "0.6.0" }
 
 # Async runtime
 tokio = { version = "1.35", features = ["full"] }

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -738,11 +738,11 @@ impl Default for ReconnectionConfig {
 
 /// What `native_p2p` means when the user has never chosen.
 ///
-/// **This constant is the 0.6 cutover.** Flipping it to `true` moves every node
-/// that has not explicitly opted out onto the native stack; nodes with
-/// `native_p2p: false` written in their config keep the p2pd path regardless.
-/// Nothing else needs to change, and no config file is rewritten.
-pub const DEFAULT_NATIVE_P2P: bool = false;
+/// **This is the 0.6 cutover, flipped in v0.6.0.** Every node that has not
+/// explicitly opted out runs the native stack; nodes with `native_p2p: false`
+/// written in their config keep the p2pd path regardless. No config file is
+/// rewritten, and rolling back is the same one-line change.
+pub const DEFAULT_NATIVE_P2P: bool = true;
 
 impl KwaaiNetConfig {
     /// Whether to run the native stack: the explicit choice if there is one,

--- a/core/crates/kwaai-p2p-daemon/Cargo.toml
+++ b/core/crates/kwaai-p2p-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kwaai-p2p-daemon"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["KwaaiNet Contributors"]
 description = "Rust wrapper for go-libp2p-daemon providing Hivemind DHT compatibility"

--- a/core/crates/kwaai-rag/Cargo.toml
+++ b/core/crates/kwaai-rag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kwaai-rag"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/core/crates/kwaai-storage/Cargo.toml
+++ b/core/crates/kwaai-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kwaai-storage"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "Multi-tenant vector storage fabric for KwaaiNet (Eve role) — embedded, zero deps"


### PR DESCRIPTION
**This is the 0.6 cutover.** Flips `DEFAULT_NATIVE_P2P` to `true`.

| Config state | Transport after this release |
|---|---|
| `native_p2p` absent | **native** (the flip) |
| `native_p2p: false` | **p2pd** — explicit opt-out is honoured |
| `native_p2p: true` | native |

No config file is rewritten. No uninstall or reinstall — both stacks ship in the
same binary and the choice is a config branch in `node.rs`. p2pd stays bundled
deliberately, so rollback is the flag plus a restart; removing it comes a release
later.

The one-line change is only possible because #114 made the flag three-state.
A plain `bool` would have flipped some nodes and not others, decided by config
vintage rather than intent.

## Why it is safe to flip now

- **#107** — an accepted unary call cost two round trips against p2pd's one.
  V1Lazy brought it to parity: **159.4 ms accepted vs 160.2 ms refused** on
  metro-win, and per-peer throughput parity across a full 1152-chunk D6 rebuild
  with **zero** transport errors.
- **#108** — a node could dial its own advertised address and latch a circuit
  breaker against a healthy peer until restart. Tolerable while native was
  opt-in; not once it is the default.
- **Accuracy unaffected** — the same D6 graph scored 90.4% over p2pd and 90.0%
  over native, inside LLM nondeterminism.
- **Connectivity improves** — 18 connections, 15 direct on native, against
  3 direct / 3 relay on p2pd.

## Version bump

0.5.5 → 0.6.0 across the workspace, the three crates carrying their own version
(`kwaai-p2p-daemon`, `kwaai-rag`, `kwaai-storage`), and the internal
path-dependency constraints — those pinned `0.5.0` and would otherwise fail to
resolve against workspace-inherited crates.

## Verified at this head

`kwaainet 0.6.0` builds release; tri-state config tests green **with the flag
flipped**, including that an explicit opt-out survives it; kwaai-p2p 92 unit
tests green; clippy `--all-targets -D warnings` clean; fmt clean.

## Known, not blocking

#116 and #117: a fleet-wide restart has every node re-query the DHT for a block
range regardless of its configured `start_block`, and Macs can be assigned
partial shards Metal cannot serve. Independent of this change — it would bite on
any coordinated restart — but worth watching as nodes update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP