### PR TITLE
fix(ci): repair the two v0.6.0 release publish jobs

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -36,12 +36,15 @@ jobs:
             DRY_RUN_FLAG="--dry-run"
             echo "=== DRY RUN MODE ==="
           fi
+          # Dependency order, leaves first. `kwaai-p2p` needs
+          # `kwaai-hivemind-dht` published before it; see the fuller note in
+          # release.yml. Keep the two lists in step.
           for crate in \
             kwaai-compression \
-            kwaai-trust \
-            kwaai-p2p \
-            kwaai-hivemind-dht \
             kwaai-inference \
+            kwaai-hivemind-dht \
+            kwaai-p2p \
+            kwaai-trust \
             kwaai-p2p-daemon \
             kwaai-distributed \
             kwaai-wasm \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -742,9 +742,10 @@ jobs:
           persist-credentials: true
           repository: "Kwaai-AI-Lab/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-      - name: fetch patched deps
-        run: bash core/patches/fetch-multistream-select.sh
-        working-directory: ${{ github.workspace }}
+      # No `fetch patched deps` step here, deliberately: this is the one job
+      # that checks out a *different* repository. `core/patches/` does not exist
+      # in homebrew-tap, so the script exits 127 before anything else runs — and
+      # this job only commits a formula file, so it never builds Rust at all.
       # So we have access to the formula
       - name: Fetch homebrew formulae
         uses: actions/download-artifact@v7
@@ -801,15 +802,23 @@ jobs:
       - name: Publish crates to crates.io
         working-directory: core
         run: |
-          # Ordered by dependency: leaves first, dependents last.
-          # kwaai-inference and kwaai-p2p-daemon have no internal deps and must
-          # precede kwaai-distributed (which depends on kwaai-inference).
+          # Ordered by dependency: leaves first, dependents last. The full
+          # internal graph is small — everything else is a leaf:
+          #   kwaai-p2p          -> kwaai-hivemind-dht
+          #   kwaai-p2p-daemon   -> kwaai-p2p
+          #   kwaai-distributed  -> kwaai-compression, kwaai-inference, kwaai-p2p
+          #   kwaainet           -> all of the above
+          # Order matters strictly now. It did not before v0.6.0, because the
+          # internal version constraints said `0.5.0` while crates.io already
+          # had 0.5.x published, so each dependency resolved against an
+          # *already-published* older version whatever the order. At 0.6.0
+          # nothing is published yet, so a dependency must go up first.
           for crate in \
             kwaai-compression \
-            kwaai-trust \
-            kwaai-p2p \
-            kwaai-hivemind-dht \
             kwaai-inference \
+            kwaai-hivemind-dht \
+            kwaai-p2p \
+            kwaai-trust \
             kwaai-p2p-daemon \
             kwaai-distributed \
             kwaai-wasm \


### PR DESCRIPTION
Both jobs failed **after** v0.6.0 was built and published, so artifacts,
installers and CUDA archives all shipped. These are distribution side-channels —
but `brew install` does not see 0.6.0, and crates.io is left inconsistent
(`kwaai-trust` at 0.6.0, everything else at 0.5.4).

## 1. `publish-homebrew-formula` exited 127

The job checks out `Kwaai-AI-Lab/homebrew-tap`, then runs
`bash core/patches/fetch-multistream-select.sh` — which lives in KwaaiNet and
does not exist in the tap. Command not found, seconds after checkout.

The step was evidently added blanket to every job when the multistream-select
vendoring landed. This is **the only job that checks out a different
repository**, and it merely commits a formula file — it never builds Rust.
Removed, with a comment so it does not come back.

Verified the other 21 occurrences of that step are all in jobs that check out
KwaaiNet itself, including `announce`.

## 2. `publish-crates` had `kwaai-p2p` before its own dependency

Failed with `failed to select a version for the requirement
kwaai-hivemind-dht = "^0.6.0"`, after `kwaai-trust` had already gone up.

**The version bump exposed this rather than caused it.** The internal
constraints previously said `0.5.0` while crates.io already had 0.5.x published,
so each dependency resolved against an *already-published* older version
whatever the order. At 0.6.0 nothing is published yet, so a dependency must
genuinely go up first.

Reordered from the actual graph rather than by swapping the one pair, in case
the loose constraints were masking more:

```
kwaai-p2p         -> kwaai-hivemind-dht
kwaai-p2p-daemon  -> kwaai-p2p
kwaai-distributed -> kwaai-compression, kwaai-inference, kwaai-p2p
kwaainet          -> all of the above
```

Everything else is a leaf. The old comment also claimed `kwaai-p2p-daemon` has
no internal deps — it depends on `kwaai-p2p`. It was ordered correctly by luck.

`publish-crates.yml` carried the identical bug and is fixed in step, since that
is the workflow a re-run would use.

## After merge

Both publish jobs can be re-run against the existing **v0.6.0** tag — no need to
recut the release. `cargo publish` skips crates already uploaded, so
`kwaai-trust` being up will not block the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP