### PR TITLE
fix(ci): publish-crates was missing three crates and choked on publish = false

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -48,11 +48,14 @@ jobs:
             kwaai-p2p-daemon \
             kwaai-distributed \
             kwaai-wasm \
+            kwaai-rpc \
+            kwaai-storage \
+            kwaai-rag \
             kwaainet; do
             echo "=== publishing ${crate} ==="
             out=$(cargo publish -p "${crate}" ${DRY_RUN_FLAG} 2>&1) && echo "$out" && { echo "waiting for crates.io index..."; sleep 30; } || {
-              if echo "$out" | grep -qE "already uploaded|already exists on crates"; then
-                echo "=== ${crate} already uploaded, skipping ==="
+              if echo "$out" | grep -qE "already uploaded|already exists on crates|cannot be published"; then
+                echo "=== ${crate} already uploaded or not publishable, skipping ==="
               else
                 echo "$out" >&2; exit 1
               fi


### PR DESCRIPTION
Follow-on from the v0.6.0 publish. The ordering fix in #120 worked — everything
went up in dependency order — but two further gaps left crates.io incomplete and
the job red.

## State after the last run

| Crate | crates.io |
|---|---|
| kwaai-compression, -inference, -hivemind-dht, -p2p, -trust, -p2p-daemon, -distributed, -wasm | **0.6.0** ✅ |
| kwaai-rpc | 0.5.4 ❌ |
| kwaai-storage, kwaai-rag | 0.5.0 ❌ |

## 1. Three crates were absent from the list

`release.yml` publishes twelve; this workflow published nine, silently omitting
`kwaai-rpc`, `kwaai-storage` and `kwaai-rag`. All three are leaves with no
internal dependencies, so they only need to precede `kwaainet`.

## 2. `kwaainet` is `publish = false`

It is the CLI binary, shipped through installers rather than crates.io. The loop
treated `cannot be published` as a hard error, so the job failed on the very last
entry after everything real had succeeded.

`release.yml` already greps for that string and skips. The two loops now match —
worth keeping them aligned, since this is the second divergence between them
found today.

After merge, one dispatch of this workflow brings the remaining three to 0.6.0;
`cargo publish` skips the eight already uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP