### PR TITLE
fix(shard): respect a configured start_block instead of overwriting it (#116)

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -52,11 +52,21 @@ pub struct KwaaiNetConfig {
     #[serde(default = "default_blocks")]
     pub blocks: u32,
 
-    /// First transformer block this node serves (0-indexed).
-    /// The node serves blocks [start_block .. start_block + blocks).
-    /// Defaults to 0 (start of model); set this on non-first nodes.
-    #[serde(default)]
-    pub start_block: u32,
+    /// First transformer block this node serves (0-indexed). The node serves
+    /// blocks `[start_block .. start_block + blocks)`.
+    ///
+    /// **Three states.** `Some(n)` pins the range — set by the operator or
+    /// written back after an auto-assignment — and `None` means the node has
+    /// never been given one, so `shard serve` may pick a gap to fill.
+    ///
+    /// It is an `Option` because `0` is a legitimate pinned value and was
+    /// previously indistinguishable from "unset": the auto-assign condition
+    /// consulted only the CLI flag, so a node with `start_block: 0` in its
+    /// config was reassigned anyway and had its config overwritten. See #116.
+    ///
+    /// Read it through [`KwaaiNetConfig::start_block`], never directly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_block: Option<u32>,
 
     #[serde(default = "default_port")]
     pub port: u16,
@@ -660,7 +670,7 @@ impl Default for KwaaiNetConfig {
         Self {
             model: default_model(),
             blocks: default_blocks(),
-            start_block: 0,
+            start_block: None,
             port: default_port(),
             use_gpu: true,
             log_level: default_log_level(),
@@ -745,6 +755,19 @@ impl Default for ReconnectionConfig {
 pub const DEFAULT_NATIVE_P2P: bool = true;
 
 impl KwaaiNetConfig {
+    /// The block this node starts serving at — the pinned value if there is
+    /// one, otherwise 0.
+    pub fn start_block(&self) -> u32 {
+        self.start_block.unwrap_or(0)
+    }
+
+    /// True when a range has been pinned, by the operator or by a previous
+    /// auto-assignment. `shard serve` must not reassign a pinned node: doing so
+    /// was #116, which silently overwrote an operator's configured range.
+    pub fn start_block_pinned(&self) -> bool {
+        self.start_block.is_some()
+    }
+
     /// Whether to run the native stack: the explicit choice if there is one,
     /// otherwise [`DEFAULT_NATIVE_P2P`].
     ///
@@ -909,7 +932,7 @@ impl KwaaiNetConfig {
     /// size when the operator sets a large `blocks` value.
     pub fn effective_end_block(&self) -> u32 {
         let total = self.model_total_blocks() as u32;
-        (self.start_block + self.blocks).min(total)
+        (self.start_block() + self.blocks).min(total)
     }
 
     /// Resolve the effective contribution policy, honouring the CLI override.
@@ -941,9 +964,10 @@ impl KwaaiNetConfig {
             "native_p2p" => self.native_p2p = Some(parse_bool(value)?),
             "enable_upnp" => self.enable_upnp = parse_bool(value)?,
             "start_block" => {
-                self.start_block = value
-                    .parse()
-                    .map_err(|_| anyhow::anyhow!("start_block must be a non-negative integer"))?
+                self.start_block =
+                    Some(value.parse().map_err(|_| {
+                        anyhow::anyhow!("start_block must be a non-negative integer")
+                    })?)
             }
             "auto_rebalance" => self.auto_rebalance = parse_bool(value)?,
             "rebalance_interval_secs" => {
@@ -991,6 +1015,93 @@ mod dirs_sys {
     use std::path::PathBuf;
     pub fn home_dir() -> Option<PathBuf> {
         dirs::home_dir()
+    }
+}
+
+#[cfg(test)]
+mod start_block_pinning {
+    use super::*;
+
+    // #116: a node with a configured range was reassigned anyway, and its
+    // config overwritten, because the auto-assign condition consulted only the
+    // CLI flag. `0` is a legitimate pinned value, so the field has to be
+    // three-state for "configured 0" to differ from "never set".
+
+    #[test]
+    fn a_fresh_config_pins_nothing() {
+        let cfg = KwaaiNetConfig::default();
+        assert_eq!(cfg.start_block, None);
+        assert!(!cfg.start_block_pinned(), "a fresh node may auto-assign");
+        assert_eq!(cfg.start_block(), 0, "but still reads as 0");
+    }
+
+    #[test]
+    fn zero_is_a_real_pin_not_an_absence() {
+        // The heart of #116. Serving from block 0 is the most common explicit
+        // choice — a full-model node — and it must not read as "unset".
+        let cfg = KwaaiNetConfig {
+            start_block: Some(0),
+            ..Default::default()
+        };
+        assert!(
+            cfg.start_block_pinned(),
+            "start_block: 0 is a choice, not a default"
+        );
+        assert_eq!(cfg.start_block(), 0);
+    }
+
+    #[test]
+    fn set_records_a_pin() {
+        let mut cfg = KwaaiNetConfig::default();
+        cfg.set_key("start_block", "0").expect("set");
+        assert_eq!(
+            cfg.start_block,
+            Some(0),
+            "`config set start_block 0` must pin"
+        );
+        cfg.set_key("start_block", "8").expect("set");
+        assert_eq!(cfg.start_block, Some(8));
+    }
+
+    #[test]
+    fn an_unpinned_node_is_not_serialised() {
+        // Otherwise merely starting once would pin a range nobody chose.
+        let cfg = KwaaiNetConfig::default();
+        let y = serde_yaml::to_string(&cfg).expect("serialise");
+        assert!(
+            !y.contains("start_block"),
+            "an unmade choice must not be written:\n{y}"
+        );
+    }
+
+    #[test]
+    fn a_pin_round_trips_through_yaml() {
+        let cfg = KwaaiNetConfig {
+            start_block: Some(0),
+            blocks: 32,
+            ..Default::default()
+        };
+        let y = serde_yaml::to_string(&cfg).expect("serialise");
+        assert!(y.contains("start_block: 0"), "a pin must persist:\n{y}");
+        let back: KwaaiNetConfig = serde_yaml::from_str(&y).expect("round trip");
+        assert_eq!(back.start_block, Some(0));
+        assert!(back.start_block_pinned());
+    }
+
+    #[test]
+    fn end_block_is_computed_from_the_effective_start() {
+        let cfg = KwaaiNetConfig {
+            start_block: Some(8),
+            blocks: 8,
+            ..Default::default()
+        };
+        assert_eq!(cfg.effective_end_block(), 16);
+        let unpinned = KwaaiNetConfig {
+            start_block: None,
+            blocks: 8,
+            ..Default::default()
+        };
+        assert_eq!(unpinned.effective_end_block(), 8, "unset starts at 0");
     }
 }
 
@@ -1099,7 +1210,7 @@ mod tests {
     fn cfg(start: u32, blocks: u32, total_hint: &str) -> KwaaiNetConfig {
         KwaaiNetConfig {
             model: total_hint.to_string(), // name heuristic drives model_total_blocks()
-            start_block: start,
+            start_block: Some(start),
             blocks,
             ..KwaaiNetConfig::default()
         }

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -486,7 +486,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     let vpk_info = initial_vpk_info(config, &public_name).await;
 
     // Always announce the configured block range so the node appears on the map.
-    let announce_start = config.start_block as i32;
+    let announce_start = config.start_block() as i32;
     let announce_end = config.effective_end_block() as i32;
 
     let mut server_info = DHTServerInfo::new(
@@ -567,7 +567,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     info!("   Model   : {}", config.model);
     info!(
         "   Blocks  : {}–{}",
-        config.start_block,
+        config.start_block(),
         config.effective_end_block()
     );
     info!("   Map     : https://map.kwaai.ai");
@@ -668,14 +668,14 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                     if fresh.start_block != config.start_block || fresh.blocks != config.blocks {
                         info!(
                             "Block range updated: [{}–{}) → [{}–{})",
-                            config.start_block, config.effective_end_block(),
-                            fresh.start_block, fresh.start_block + fresh.blocks,
+                            config.start_block(), config.effective_end_block(),
+                            fresh.start_block(), fresh.start_block() + fresh.blocks,
                         );
                         config.start_block = fresh.start_block;
                         config.blocks = fresh.blocks;
                     }
                 }
-                let sb = config.start_block as i32;
+                let sb = config.start_block() as i32;
                 let eb = config.effective_end_block() as i32;
                 server_info.start_block = sb;
                 server_info.end_block = eb;
@@ -763,8 +763,8 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                     if fresh.start_block != config.start_block || fresh.blocks != config.blocks {
                         info!(
                             "Block range updated: [{}–{}) → [{}–{})",
-                            config.start_block, config.effective_end_block(),
-                            fresh.start_block, fresh.start_block + fresh.blocks,
+                            config.start_block(), config.effective_end_block(),
+                            fresh.start_block(), fresh.start_block() + fresh.blocks,
                         );
                         config.start_block = fresh.start_block;
                         config.blocks = fresh.blocks;
@@ -801,7 +801,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
                     }
                 }
 
-                let sb = config.start_block as i32;
+                let sb = config.start_block() as i32;
                 let eb = config.effective_end_block() as i32;
                 server_info.start_block = sb;
                 server_info.end_block = eb;
@@ -897,7 +897,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             // waiting for the next 300 s tick.
             Some(()) = ollama_recovery_rx.recv() => {
                 info!("Ollama recovered — triggering immediate re-announce");
-                let sb = config.start_block as i32;
+                let sb = config.start_block() as i32;
                 let eb = config.effective_end_block() as i32;
                 server_info.start_block = sb;
                 server_info.end_block = eb;

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -382,7 +382,7 @@ pub async fn run_native_node(
 
     let mut config = config.clone();
     let mut server_info = DHTServerInfo::new(
-        config.start_block as i32,
+        config.start_block() as i32,
         config.effective_end_block() as i32,
         public_name,
         using_relay,
@@ -404,7 +404,7 @@ pub async fn run_native_node(
     info!("   Model   : {}", config.model);
     info!(
         "   Blocks  : {}–{}",
-        config.start_block,
+        config.start_block(),
         config.effective_end_block()
     );
     info!("   Map     : https://map.kwaai.ai");
@@ -593,10 +593,10 @@ fn reload_block_range(config: &mut KwaaiNetConfig) {
     }
     info!(
         "Block range updated: [{}–{}) → [{}–{})",
-        config.start_block,
+        config.start_block(),
         config.effective_end_block(),
-        fresh.start_block,
-        fresh.start_block + fresh.blocks,
+        fresh.start_block(),
+        fresh.start_block() + fresh.blocks,
     );
     config.start_block = fresh.start_block;
     config.blocks = fresh.blocks;
@@ -604,7 +604,7 @@ fn reload_block_range(config: &mut KwaaiNetConfig) {
 
 /// Sync the announced block range and readiness state from the live config.
 fn refresh_server_info(server_info: &mut DHTServerInfo, config: &KwaaiNetConfig) {
-    server_info.start_block = config.start_block as i32;
+    server_info.start_block = config.start_block() as i32;
     server_info.end_block = config.effective_end_block() as i32;
     server_info.state = KwaaiNetConfig::announce_state();
 }

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -233,9 +233,13 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
 
     // ── Gap detection — also yields a P2PClient we reuse for handler registration
     // to avoid a drop/reconnect race that causes "early eof" from p2pd.
-    let (start_block, end_block, initial_client) = if !args.no_auto
-        && (args.auto || args.start_block.is_none())
-    {
+    // Auto-assign only when nothing has pinned a range — neither `--start-block`
+    // on the command line nor `start_block` in config. Consulting only the CLI
+    // flag was #116: a node with `start_block` configured was reassigned anyway
+    // and had its config overwritten, so config-based pinning did not work at
+    // all. `--auto` still forces a fresh gap query.
+    let pinned = args.start_block.is_some() || cfg.start_block_pinned();
+    let (start_block, end_block, initial_client) = if !args.no_auto && (args.auto || !pinned) {
         let daemon_addr = daemon_socket();
         let mut qc = P2PClient::connect(&daemon_addr)
             .await
@@ -282,9 +286,11 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
         // Only update config + signal daemon when the range actually changed.
         // If pick_gap returns the same range already in config the daemon is
         // already announcing the correct blocks — nothing to do.
-        if s as u32 != cfg.start_block {
+        if Some(s as u32) != cfg.start_block {
             let mut updated = cfg.clone();
-            updated.start_block = s as u32;
+            // Records a pin, so the next start keeps this range instead of
+            // re-querying the DHT and possibly moving again.
+            updated.start_block = Some(s as u32);
             updated.save().context("Failed to save config.yaml")?;
             print_info("Updated config.yaml — signalling daemon to re-announce…");
             crate::daemon::DaemonManager::new().signal_reannounce();
@@ -296,11 +302,11 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
     } else {
         // Explicit range: --start-block N was given, or --no-auto was passed.
         // Falls back to config.start_block when neither --start-block nor --no-auto gave a value.
-        let s = args.start_block.unwrap_or(cfg.start_block) as usize;
+        let s = args.start_block.unwrap_or_else(|| cfg.start_block()) as usize;
         let total = cfg.model_total_blocks() as usize;
         let e = (s + target_blocks).min(total);
         let mut updated = cfg.clone();
-        updated.start_block = s as u32;
+        updated.start_block = Some(s as u32);
         updated.blocks = (e - s) as u32;
         if updated.start_block != cfg.start_block || updated.blocks != cfg.blocks {
             updated.save().context("Failed to save config.yaml")?;
@@ -1833,11 +1839,11 @@ pub async fn cmd_shard_status() -> Result<()> {
 
     print_box_header("🧩 KwaaiNet Shard Status");
     println!("  Model:        {}", cfg.model);
-    println!("  Start block:  {}", cfg.start_block);
+    println!("  Start block:  {}", cfg.start_block());
     println!("  Blocks:       {}", cfg.blocks);
     println!(
         "  Range:        [{}, {})",
-        cfg.start_block,
+        cfg.start_block(),
         cfg.effective_end_block()
     );
     println!("  GPU:          {}", cfg.use_gpu);


### PR DESCRIPTION
Closes #116. **Urgent ahead of the fleet roll** — see timing below.

`shard serve` auto-assigned a block range even when one was configured, then
wrote its choice over the operator's. Config-based pinning did not work at all.

## The bug

The condition consulted the **CLI** flag, not the effective configuration:

```rust
if !args.no_auto && (args.auto || args.start_block.is_none())
```

`args.start_block` is documented as *"Override start_block from config.yaml"*, so
`is_none()` is true whenever `--start-block` is absent from the command line —
whatever the config says.

A node with `blocks: 32, start_block: 0` was reassigned to `[8, 16)` and its
config rewritten to match. **Reproduced twice today on rezas-mini-2**, the second
time within an hour of restoring the range by hand — a plain restart was enough.

## The fix

`start_block` becomes `Option<u32>`. `0` is a legitimate pinned value — a
full-model node — and was previously indistinguishable from "never set". Same
three-state shape as `native_p2p` in #114, for the same reason.

Auto-assign now runs only when **neither** the CLI **nor** the config pins a
range. `--auto` still forces a fresh gap query; `--no-auto` still suppresses one.

Write-backs record `Some(n)`, so a node that auto-assigns once stays put on the
next start instead of re-querying and possibly moving again.

## Why now

The fleet updates as each node's 24-hour update cache expires. Without this,
**every node re-queries the DHT on restart regardless of its configured range** —
and per #117 a Mac can land on a partial shard Metal cannot serve, while
`shard chain` still shows healthy coverage.

## Tests

Six, including that `start_block: 0` is a pin rather than an absence, that an
unpinned node writes nothing to disk, and that a pin round-trips through YAML.

Verified: kwaainet 112 tests green, clippy `--all-targets -D warnings` clean, fmt
clean, `shard status` reads the live config correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP