### PR TITLE
release(v0.6.1): stop shard serve overwriting a configured block range

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-compression"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bincode",
  "candle-core",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-distributed"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-hivemind-dht"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-inference"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-network-tests"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-p2p"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-p2p-daemon"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-rag"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-rpc"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-storage"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-trust"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-wasm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "kwaainet"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "map-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,7 @@ multistream-select = { path = "patches/multistream-select" }
 # Root package for examples
 [package]
 name = "kwaai-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 publish = false
 
@@ -139,7 +139,7 @@ name = "query_dht_state"
 path = "examples/query_dht_state.rs"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 
 edition = "2021"
 authors = ["Kwaai AI Lab <dev@kwaai.ai>"]
@@ -150,18 +150,18 @@ keywords = ["ai", "decentralized", "p2p", "wasm", "inference"]
 categories = ["network-programming", "wasm", "science"]
 
 [workspace.dependencies]
-kwaai-compression  = { path = "crates/kwaai-compression",  version = "0.6.0" }
-kwaai-trust        = { path = "crates/kwaai-trust",        version = "0.6.0" }
-kwaai-p2p          = { path = "crates/kwaai-p2p",          version = "0.6.0" }
-kwaai-hivemind-dht = { path = "crates/kwaai-hivemind-dht", version = "0.6.0" }
-kwaai-distributed  = { path = "crates/kwaai-distributed",  version = "0.6.0" }
-kwaai-inference    = { path = "crates/kwaai-inference",    version = "0.6.0" }
-kwaai-cli          = { path = "crates/kwaai-cli",          version = "0.6.0" }
-kwaai-p2p-daemon   = { path = "crates/kwaai-p2p-daemon",   version = "0.6.0" }
-kwaai-wasm         = { path = "crates/kwaai-wasm",         version = "0.6.0" }
-kwaai-storage      = { path = "crates/kwaai-storage",      version = "0.6.0" }
-kwaai-rag          = { path = "crates/kwaai-rag",          version = "0.6.0" }
-kwaai-rpc          = { path = "crates/kwaai-rpc",          version = "0.6.0" }
+kwaai-compression  = { path = "crates/kwaai-compression",  version = "0.6.1" }
+kwaai-trust        = { path = "crates/kwaai-trust",        version = "0.6.1" }
+kwaai-p2p          = { path = "crates/kwaai-p2p",          version = "0.6.1" }
+kwaai-hivemind-dht = { path = "crates/kwaai-hivemind-dht", version = "0.6.1" }
+kwaai-distributed  = { path = "crates/kwaai-distributed",  version = "0.6.1" }
+kwaai-inference    = { path = "crates/kwaai-inference",    version = "0.6.1" }
+kwaai-cli          = { path = "crates/kwaai-cli",          version = "0.6.1" }
+kwaai-p2p-daemon   = { path = "crates/kwaai-p2p-daemon",   version = "0.6.1" }
+kwaai-wasm         = { path = "crates/kwaai-wasm",         version = "0.6.1" }
+kwaai-storage      = { path = "crates/kwaai-storage",      version = "0.6.1" }
+kwaai-rag          = { path = "crates/kwaai-rag",          version = "0.6.1" }
+kwaai-rpc          = { path = "crates/kwaai-rpc",          version = "0.6.1" }
 
 # Async runtime
 tokio = { version = "1.35", features = ["full"] }

--- a/core/crates/kwaai-p2p-daemon/Cargo.toml
+++ b/core/crates/kwaai-p2p-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kwaai-p2p-daemon"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["KwaaiNet Contributors"]
 description = "Rust wrapper for go-libp2p-daemon providing Hivemind DHT compatibility"

--- a/core/crates/kwaai-rag/Cargo.toml
+++ b/core/crates/kwaai-rag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kwaai-rag"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/core/crates/kwaai-storage/Cargo.toml
+++ b/core/crates/kwaai-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kwaai-storage"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 description = "Multi-tenant vector storage fabric for KwaaiNet (Eve role) — embedded, zero deps"


### PR DESCRIPTION
Patch release for #116, cut **ahead of the fleet roll**.

## Why now

v0.6.0 nodes update as each node's 24-hour update cache expires. Every one
restarts — and on the v0.6.0 binary a restart re-queries the DHT for a block
range **regardless of what is configured**, then overwrites the config with the
result. Reproduced twice on rezas-mini-2 yesterday, the second time within an
hour of restoring the range by hand.

Per #117 that also lands Mac nodes on partial shards Metal cannot serve, while
`shard chain` still reports healthy coverage. Shipping this before the roll means
nodes keep the ranges their operators chose.

## What changed

Only #116. `start_block` is now `Option<u32>` — `0` is a legitimate pin (a
full-model node) and was previously indistinguishable from unset. Auto-assign
runs only when neither the CLI nor the config pins a range.

**The 0.6 cutover is unaffected**: `DEFAULT_NATIVE_P2P` stays `true`, explicit
opt-outs still honoured.

## Version sites

Workspace, the three crates carrying their own version (`kwaai-p2p-daemon`,
`kwaai-rag`, `kwaai-storage`), and the internal path-dependency constraints. All
four groups must move together or the workspace fails to resolve — as v0.6.0
discovered mid-release.

Verified: `kwaainet 0.6.1` builds release, 112 tests green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP