### PR TITLE
release(v0.6.2): auto-assign persists the whole range it chose

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-compression"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bincode",
  "candle-core",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-distributed"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-hivemind-dht"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-inference"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-network-tests"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-p2p"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-p2p-daemon"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-rag"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-rpc"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "prost 0.13.5",
  "tonic",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-storage"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-trust"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "kwaai-wasm"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "kwaainet"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "map-server"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,7 @@ multistream-select = { path = "patches/multistream-select" }
 # Root package for examples
 [package]
 name = "kwaai-core"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 publish = false
 
@@ -139,7 +139,7 @@ name = "query_dht_state"
 path = "examples/query_dht_state.rs"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 
 edition = "2021"
 authors = ["Kwaai AI Lab <dev@kwaai.ai>"]
@@ -150,18 +150,18 @@ keywords = ["ai", "decentralized", "p2p", "wasm", "inference"]
 categories = ["network-programming", "wasm", "science"]
 
 [workspace.dependencies]
-kwaai-compression  = { path = "crates/kwaai-compression",  version = "0.6.1" }
-kwaai-trust        = { path = "crates/kwaai-trust",        version = "0.6.1" }
-kwaai-p2p          = { path = "crates/kwaai-p2p",          version = "0.6.1" }
-kwaai-hivemind-dht = { path = "crates/kwaai-hivemind-dht", version = "0.6.1" }
-kwaai-distributed  = { path = "crates/kwaai-distributed",  version = "0.6.1" }
-kwaai-inference    = { path = "crates/kwaai-inference",    version = "0.6.1" }
-kwaai-cli          = { path = "crates/kwaai-cli",          version = "0.6.1" }
-kwaai-p2p-daemon   = { path = "crates/kwaai-p2p-daemon",   version = "0.6.1" }
-kwaai-wasm         = { path = "crates/kwaai-wasm",         version = "0.6.1" }
-kwaai-storage      = { path = "crates/kwaai-storage",      version = "0.6.1" }
-kwaai-rag          = { path = "crates/kwaai-rag",          version = "0.6.1" }
-kwaai-rpc          = { path = "crates/kwaai-rpc",          version = "0.6.1" }
+kwaai-compression  = { path = "crates/kwaai-compression",  version = "0.6.2" }
+kwaai-trust        = { path = "crates/kwaai-trust",        version = "0.6.2" }
+kwaai-p2p          = { path = "crates/kwaai-p2p",          version = "0.6.2" }
+kwaai-hivemind-dht = { path = "crates/kwaai-hivemind-dht", version = "0.6.2" }
+kwaai-distributed  = { path = "crates/kwaai-distributed",  version = "0.6.2" }
+kwaai-inference    = { path = "crates/kwaai-inference",    version = "0.6.2" }
+kwaai-cli          = { path = "crates/kwaai-cli",          version = "0.6.2" }
+kwaai-p2p-daemon   = { path = "crates/kwaai-p2p-daemon",   version = "0.6.2" }
+kwaai-wasm         = { path = "crates/kwaai-wasm",         version = "0.6.2" }
+kwaai-storage      = { path = "crates/kwaai-storage",      version = "0.6.2" }
+kwaai-rag          = { path = "crates/kwaai-rag",          version = "0.6.2" }
+kwaai-rpc          = { path = "crates/kwaai-rpc",          version = "0.6.2" }
 
 # Async runtime
 tokio = { version = "1.35", features = ["full"] }

--- a/core/crates/kwaai-p2p-daemon/Cargo.toml
+++ b/core/crates/kwaai-p2p-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kwaai-p2p-daemon"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["KwaaiNet Contributors"]
 description = "Rust wrapper for go-libp2p-daemon providing Hivemind DHT compatibility"

--- a/core/crates/kwaai-rag/Cargo.toml
+++ b/core/crates/kwaai-rag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kwaai-rag"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/core/crates/kwaai-storage/Cargo.toml
+++ b/core/crates/kwaai-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kwaai-storage"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "MIT"
 description = "Multi-tenant vector storage fabric for KwaaiNet (Eve role) — embedded, zero deps"


### PR DESCRIPTION
Second patch on the v0.6.0 cutover — and it matters **more** because of the first.

v0.6.1 stopped `shard serve` reassigning a node that already has a configured
range, and made the written value a **pin**. But the auto-assign write-back still
persisted only `start_block`, leaving `blocks` at whatever it happened to be. So
a node that *did* auto-assign could pin a range nothing had chosen — and stay
wrong, rather than merely move.

## What it looked like

Three simultaneous answers on rezas-mini-2:

| Source | Range |
|---|---|
| `config.yaml` (`start_block: 8`, `blocks: 32`) | `[8, 32)` |
| `shard status` | `[8, 32)` |
| **Announced to the DHT** | **`[8, 16)`** |

The assigner picked the start, an earlier `config set blocks 32` picked the
count, and nothing reconciled them.

## Change

The write-back persists both fields and compares both, so a changed block count
triggers a save even when the start is unchanged (#124).

**Cutover unaffected**: `DEFAULT_NATIVE_P2P` stays `true`, explicit opt-outs
still honoured.

Verified: `kwaainet 0.6.2` builds release, 115 tests green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP