### PR TITLE
feat(shard): macOS serves whole models via Ollama instead of slow blocks

### DIFF
--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -802,6 +802,13 @@ pub struct ShardServeArgs {
     #[arg(long)]
     pub auto_rebalance: bool,
 
+    /// macOS only: serve transformer blocks anyway, despite Metal being slower
+    /// than CPU for decode. A Mac normally serves whole models through its
+    /// local Ollama instead — this forces the block path for testing or
+    /// benchmarking. Ignored on other platforms, which always serve blocks.
+    #[arg(long)]
+    pub force_blocks: bool,
+
     /// HuggingFace access token for downloading private or gated models.
     /// Can also be set via the HF_TOKEN environment variable.
     #[arg(long, value_name = "TOKEN")]

--- a/core/crates/kwaai-cli/src/ollama.rs
+++ b/core/crates/kwaai-cli/src/ollama.rs
@@ -295,3 +295,96 @@ mod tests {
         );
     }
 }
+
+/// Why a node cannot serve inference through the local Ollama.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OllamaNotReady {
+    /// Nothing is listening on the Ollama port.
+    Unreachable { port: u16 },
+    /// Ollama is up but has no models pulled, so it can serve nothing.
+    NoModels,
+}
+
+impl std::fmt::Display for OllamaNotReady {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unreachable { port } => write!(
+                f,
+                "no Ollama on localhost:{port} — install it from https://ollama.com, \
+                 start it, and pull a model"
+            ),
+            Self::NoModels => write!(
+                f,
+                "Ollama is running but has no models — run `ollama pull llama3.1:8b`"
+            ),
+        }
+    }
+}
+
+/// Whether this machine can serve inference through its local Ollama, and which
+/// models it has.
+///
+/// Deliberately **not** checked against `config.model`. That is a HuggingFace
+/// reference used by the block-sharding path (`unsloth/Llama-3.1-8B-Instruct`),
+/// while Ollama has its own namespace (`llama3.1:8b`) — the same model under a
+/// different name, so comparing them fails on a correctly configured node. More
+/// to the point, `/kwaai/ollama-proxy/1.0.0` forwards HTTP verbatim: the
+/// *caller* names the model, and this node cannot know in advance which will be
+/// asked for. So the only questions worth answering are whether Ollama is up and
+/// whether it has anything at all to serve.
+///
+/// Used on macOS, where block sharding is not viable and Ollama is the whole
+/// serving story (`projects/kwaai-compute/plans/MacOllamaStopgap-plan.md`).
+pub async fn readiness(port: u16) -> Result<Vec<String>, OllamaNotReady> {
+    let url = format!("http://localhost:{port}/api/tags");
+    let up = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+    {
+        Ok(c) => matches!(c.get(&url).send().await, Ok(r) if r.status().is_success()),
+        Err(_) => false,
+    };
+    if !up {
+        return Err(OllamaNotReady::Unreachable { port });
+    }
+
+    let models = list_local_models();
+    if models.is_empty() {
+        Err(OllamaNotReady::NoModels)
+    } else {
+        Ok(models)
+    }
+}
+
+#[cfg(test)]
+mod readiness_tests {
+    use super::*;
+
+    #[test]
+    fn unreachable_names_the_port_and_what_to_do() {
+        let msg = OllamaNotReady::Unreachable { port: 11434 }.to_string();
+        assert!(msg.contains("11434"), "the operator needs the port: {msg}");
+        assert!(msg.contains("ollama.com"), "and where to get it: {msg}");
+    }
+
+    #[test]
+    fn no_models_says_how_to_pull_one() {
+        let msg = OllamaNotReady::NoModels.to_string();
+        assert!(msg.contains("ollama pull"), "must be actionable: {msg}");
+    }
+
+    #[tokio::test]
+    async fn a_dead_port_is_unreachable_not_a_hang() {
+        // Port 1 is reserved and never listening. Guards the timeout: without
+        // one, `shard serve` on a Mac would stall at startup instead of
+        // refusing, which is the failure mode this whole path exists to avoid.
+        let started = std::time::Instant::now();
+        let r = readiness(1).await;
+        assert_eq!(r, Err(OllamaNotReady::Unreachable { port: 1 }));
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(10),
+            "readiness must fail fast, took {:?}",
+            started.elapsed()
+        );
+    }
+}

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -221,12 +221,116 @@ async fn cmd_shard_gap() -> Result<()> {
 
 // ── serve ─────────────────────────────────────────────────────────────────────
 
+/// Serve the whole model through the local Ollama instead of serving blocks.
+///
+/// The macOS path — see the rationale at the call site in `cmd_shard_serve`.
+///
+/// Registers only the proxy protocols, so this node is reachable for
+/// whole-model inference at `p2p://<peer-id>` but never advertises a block
+/// range. Refuses outright when Ollama cannot serve, rather than idling: a node
+/// that looks available and answers slowly (or not at all) is worse than one
+/// that is plainly absent, which is the same reasoning as not advertising slow
+/// blocks in the first place.
+async fn serve_whole_model_via_ollama(cfg: &KwaaiNetConfig) -> Result<ShardServeExit> {
+    print_box_header("🍎 KwaaiNet Whole-Model Server (macOS)");
+    println!("  Backend: Ollama on localhost:{}", cfg.ollama_port);
+    println!("  Mode:    whole model — block sharding is not viable on Metal (#117)");
+    println!();
+
+    let models = match crate::ollama::readiness(cfg.ollama_port).await {
+        Ok(models) => models,
+        Err(why) => {
+            print_error(&format!("Cannot serve: {why}"));
+            print_info("macOS nodes serve whole models through Ollama until a native");
+            print_info("Apple fast path lands — candle's Metal decode is slower than CPU.");
+            print_info("To serve blocks anyway: kwaainet shard serve --force-blocks");
+            print_separator();
+            bail!("Ollama is not ready — refusing to advertise a path we cannot serve");
+        }
+    };
+    print_success(&format!("Ollama ready — serving: {}", models.join(", ")));
+
+    let daemon_addr = daemon_socket();
+    let client = match P2PClient::connect(&daemon_addr).await {
+        Ok(c) => c,
+        Err(_) => {
+            print_error("Cannot connect to the KwaaiNet node — is it running?");
+            print_info("Start it:     kwaainet start --daemon");
+            print_separator();
+            bail!("KwaaiNet node is not running");
+        }
+    };
+
+    // One lease table per process, matching the block path — it gates concurrent
+    // dispatch to this node's Ollama regardless of which transport asked.
+    let lease_max_concurrent = std::env::var("OLLAMA_NUM_PARALLEL")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(crate::capacity_lease::DEFAULT_MAX_CONCURRENT);
+    let lease_table =
+        crate::capacity_lease::LeaseTable::new(cfg.model.clone(), lease_max_concurrent);
+    let _sweep = lease_table.spawn_periodic_sweep(std::time::Duration::from_secs(5));
+
+    // `run-node` registers this same protocol at startup (`node.rs`,
+    // `node_native.rs`), so on a Mac the node is *already* serving whole-model
+    // inference before `shard serve` is ever run. Registering again is a
+    // conflict, not a failure — report it plainly rather than erroring, and
+    // rather than swallowing it with `let _` as the block path does.
+    let proxy_handler = crate::ollama_proxy::make_ollama_proxy_handler(lease_table.clone());
+    match client
+        .add_unary_handler(
+            crate::ollama_proxy::OLLAMA_PROXY_PROTO,
+            proxy_handler,
+            false,
+        )
+        .await
+    {
+        Ok(_) => print_success("Serving whole-model inference over /kwaai/ollama-proxy/1.0.0"),
+        Err(e) if e.to_string().contains("already set") => {
+            print_success("The node is already serving whole-model inference");
+            print_info("/kwaai/ollama-proxy/1.0.0 was registered by `kwaainet run-node`.");
+            print_info("On macOS `shard serve` is not required — the node serves without it.");
+        }
+        Err(e) => return Err(e).context("Failed to register the Ollama proxy handler"),
+    }
+    print_info("This node does not advertise a block range — by design on macOS.");
+    print_separator();
+
+    tokio::signal::ctrl_c().await.ok();
+    println!();
+    print_info("Stopping whole-model server…");
+    Ok(ShardServeExit::UserStop)
+}
+
 async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
     let cfg = KwaaiNetConfig::load_or_create()?;
 
     if crate::daemon::ShardManager::new().is_running() {
         print_warning("A shard server is already running (started via `kwaainet start --shard`).");
         print_info("If intentional, proceed — DHT announcements will overlap.");
+    }
+
+    // ── macOS: serve the whole model through Ollama, never blocks ───────────
+    //
+    // Block sharding is not viable on Apple hardware. candle's Metal backend is
+    // *slower than CPU* for single-token decode, so `DeviceType::detect_best()`
+    // skips it and a Mac lands on CPU at 2-4 tok/s — while the same machine runs
+    // the same model through Ollama at ~47 tok/s. Gap-filling can also hand a
+    // Mac a partial range it cannot serve on GPU at all (#117), which still
+    // reads as healthy coverage in `shard chain`.
+    //
+    // So a Mac does not register as a block server. It serves whole-model
+    // inference over `/kwaai/ollama-proxy/1.0.0`, which every node already
+    // registers, and stays at announce state 0 ("online, no shard") because no
+    // shard ever loads — no announce change needed.
+    //
+    // Stopgap. Delete this branch when an Apple fast path lands: MLX
+    // (`mlx_shard.rs`) already implements sharding and failed only on graph
+    // recompilation, and `llama_local.rs` wraps the same llama.cpp engine Ollama
+    // uses. See `projects/kwaai-compute/plans/MacOllamaStopgap-plan.md`.
+    if cfg!(target_os = "macos") && !args.force_blocks {
+        return serve_whole_model_via_ollama(&cfg).await;
     }
 
     let target_blocks = snap_to_valid_blocks(args.blocks.unwrap_or(cfg.blocks) as usize);
@@ -1852,7 +1956,20 @@ pub async fn cmd_shard_status() -> Result<()> {
         cfg.start_block(),
         cfg.effective_end_block()
     );
-    println!("  GPU:          {}", cfg.use_gpu);
+    // `use_gpu` is what the *config asks for*, which is not what the process
+    // ends up doing — on macOS `DeviceType::detect_best()` skips Metal because
+    // candle's decode is slower than CPU, so `GPU: true` was printed while
+    // inference ran on CPU (#118). Label it as configuration and state the
+    // serving mode separately.
+    println!("  GPU (config): {}", cfg.use_gpu);
+    if cfg!(target_os = "macos") {
+        println!(
+            "  Mode:         whole model via Ollama (localhost:{})",
+            cfg.ollama_port
+        );
+        println!("                block sharding is not viable on Metal — see #117");
+        println!("                the range above is unused on this platform");
+    }
     println!("  DHT prefix:   {}", cfg.effective_dht_prefix());
     println!();
     print_info("To serve this shard: kwaainet shard serve");

--- a/projects/kwaai-compute/plans/MacOllamaStopgap-plan.md
+++ b/projects/kwaai-compute/plans/MacOllamaStopgap-plan.md
@@ -1,0 +1,138 @@
+# Macs serve whole models via Ollama, not slow shards
+
+**Status:** approved 2026-08-21. Stopgap until an Apple fast path lands; see #117.
+
+## Context
+
+A Mac on KwaaiNet today serves transformer blocks through candle at **2–4 tok/s**
+while the same machine runs the same model through Ollama at **47.6 tok/s** —
+measured back to back on `rezas-mini-2`, same prompt, same 24 tokens:
+
+| Path | Prefill (22 tok) | Decode |
+|---|---|---|
+| candle `auto` (Metal) | 5223 ms | 2.3 tok/s |
+| candle `--no-gpu` (CPU) | 1627 ms | 4.2 tok/s |
+| **Ollama (llama.cpp Metal)** | **102 ms** | **47.6 tok/s** |
+
+Metal is *slower than CPU* on the candle path, so `DeviceType::detect_best()`
+deliberately skips it and Macs land on CPU. Worse, gap-filling can hand a Mac a
+**partial** range (#117) that Metal cannot serve on GPU at all, and `shard chain`
+still shows it as healthy coverage.
+
+**This is a stopgap, not the fix.** Three Apple paths exist and all are dark in
+the shipped binary:
+
+| Path | State | Why it is off |
+|---|---|---|
+| candle Metal | compiled (`features = ["metal"]`) | Skipped at runtime — 10× slower than CPU for decode |
+| MLX (`mlx_shard.rs`, 1106 lines, **does** shard) | `mlx` feature off | Abandoned 2026-03-29: MLX recompiles its graph per eval, 100 s/forward. Two fix attempts failed |
+| llama.cpp (`llama_local.rs`) | `llama-cpp` feature off — `default = ["storage", "rag"]` | Only wired into `grpc_server` streaming, never the serving path |
+
+Ollama is llama.cpp underneath. It is already installed on these machines, it is
+already fast, and **every node already registers `/kwaai/ollama-proxy/1.0.0`**
+(`node.rs:340`, `node_native.rs:687`) — that is the path the D6 rebuild used. So
+the quick win is to stop Macs pretending to be block servers and let them serve
+whole models through the engine that already works.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| macOS block serving | **Stop entirely.** No slow candle path advertised |
+| Whole-model serving | Local Ollama over the existing ollama-proxy protocol |
+| Ollama absent | **Degrade loudly** — do not serve, say what to install. Never serve slowly while looking healthy |
+| Scope | macOS only. Linux/CUDA behaviour unchanged |
+
+## Changes
+
+### 1. Skip block serving on macOS — `shard_cmd.rs`
+
+The registration point is `shard_cmd.rs:362-366`:
+
+```rust
+let handler = make_block_rpc_handler(shard_cell.clone(), device.clone());
+client.add_unary_handler(crate::block_rpc::INFERENCE_PROTO, handler, false)
+```
+
+On macOS, skip device detection, the model load, and this registration. Keep the
+`OLLAMA_PROXY_PROTO` and `SHARD_PROXY_PROTO` registrations that follow at
+`:382-398` — they are what make the node useful.
+
+Because no shard loads, `ShardManager::shard_is_ready()` stays false and
+`KwaaiNetConfig::announce_state()` (`config.rs:794`) already returns `0` rather
+than `2`. **No announce changes needed** — the existing "online, no shard"
+state is exactly right.
+
+This also removes Macs from the auto-assign path, so **#117 stops being reachable
+on macOS** as a side effect: a Mac can no longer be handed a partial range.
+
+### 2. Probe Ollama, and be explicit either way
+
+Before registering the proxy handler on macOS, check the local Ollama on
+`cfg.ollama_port` (`config.rs:227`, default 11434). Reuse
+`ollama::list_local_models()` (`ollama.rs:110`) so the check covers *and the
+configured model is present*, not merely that the port answers.
+
+- **Reachable, model present** — register the proxy, log that this node serves
+  the whole model via Ollama and roughly what that is worth.
+- **Absent** — do not register the proxy either. Log plainly that macOS requires
+  Ollama until a native fast path lands, name the model to pull, and exit
+  non-zero from `shard serve` so it is visible in a service log rather than
+  silently idle.
+
+Advertising a proxy that cannot answer is the same failure class as advertising
+slow blocks, so both paths stay honest.
+
+### 3. Say what is actually happening — `shard_cmd.rs` status
+
+`shard status` currently prints the configured `GPU:` flag while the process runs
+on CPU — that is #118, and it misled us for an hour today. On macOS it should
+report the serving mode plainly:
+
+```
+Mode:    whole model via Ollama (block sharding unsupported on Metal)
+Ollama:  reachable, llama3.1:8b present
+```
+
+Fold the #118 fix in here rather than leaving two half-truths.
+
+## What this does not do
+
+- **Does not make Metal shard.** #117 stays open as the real fix; this removes
+  its blast radius on macOS.
+- **Does not revive MLX or llama.cpp in-process.** Both remain viable long-term
+  answers — MLX especially, since it already implements sharding and only failed
+  on graph recompilation. Reviving either is a separate piece of work.
+- **Does not add Ollama to the installer.** Worth doing (`feedback_end_user_experience`:
+  installers must handle dependencies), but it is packaging work, not this change.
+
+## Verification
+
+Run on `rezas-mini-2`, which reproduces every symptom today:
+
+1. **Block path gone.** `kwaainet shard serve` on macOS registers no
+   `INFERENCE_PROTO` handler; `kwaainet shard chain` no longer lists this node
+   among block servers.
+2. **Inference path alive and fast.**
+   `kwaainet p2p probe --peer <self-or-peer> --proto /kwaai/ollama-proxy/1.0.0`
+   answers, and a real generation through the p2p path lands near the **47.6
+   tok/s** Ollama baseline rather than 2–4 — measure with ≥14 tokens, since
+   shorter runs inflate the figure 2–5× (`project_p2p_relay_token_latency`).
+3. **Loud degradation.** Stop Ollama, restart `shard serve`, confirm it refuses
+   with an actionable message and registers nothing.
+4. **Linux unaffected.** metro-linux still serves blocks and still appears in
+   `shard chain` with its range.
+5. **Regression tests** for the platform gate and the probe outcome, in the style
+   of the `start_block_pinning` tests added for #116.
+
+## Open
+
+- **Discovery.** A Mac serving via ollama-proxy is reachable at `p2p://<peer-id>`
+  but is not discoverable the way block servers are through `shard chain`. Fine
+  for RAG, which names peers explicitly; a gap for anything that wants to *find*
+  a whole-model node. A capability flag in `DHTServerInfo` would fix it — there
+  is precedent in `lease_v1` (`announce.rs:145-155`), and unknown map keys are
+  ignored by legacy Hivemind clients, so it extends safely.
+- **Coverage.** Macs stop contributing block coverage. Given they were
+  contributing at 2–4 tok/s, that is a gain, but worth watching `shard chain`
+  during rollout.


### PR DESCRIPTION
A Mac served transformer blocks at **2–4 tok/s** while the same machine ran the
same model through Ollama at **47.6 tok/s**. Measured back to back on
rezas-mini-2, same prompt, same 24 tokens:

| Path | Prefill (22 tok) | Decode |
|---|---|---|
| candle `auto` (Metal) | 5223 ms | 2.3 tok/s |
| candle `--no-gpu` (CPU) | 1627 ms | 4.2 tok/s |
| **Ollama (llama.cpp Metal)** | **102 ms** | **47.6 tok/s** |

Metal is *slower than CPU* on the candle path, so `DeviceType::detect_best()`
skips it and Macs land on CPU. Gap-filling could also hand a Mac a partial range
it cannot serve on GPU at all (#117) — which still read as healthy coverage.

## Change

A Mac no longer registers as a block server. It serves whole-model inference over
`/kwaai/ollama-proxy/1.0.0` and stays at announce state 0 ("online, no shard")
because no shard loads — **no announce change was needed**. This also puts #117
out of reach on macOS: a Mac can no longer be assigned a partial range.

It **refuses rather than idling** when Ollama cannot serve. Advertising a path we
cannot answer is the same failure class as advertising slow blocks.
`--force-blocks` keeps the old behaviour for benchmarking.

## Two things testing corrected

**The readiness check must not look at `config.model`.** That is a HuggingFace ref
used by the sharding path (`unsloth/Llama-3.1-8B-Instruct`) while Ollama has its
own namespace (`llama3.1:8b`) — same model, different name, so the check failed
on a *correctly* configured node. More fundamentally the proxy forwards HTTP
verbatim: the **caller** names the model, so this node cannot know in advance. It
now asks only whether Ollama is up and has anything to serve.

**`run-node` already registers the proxy**, so on a Mac the node serves whole
models before `shard serve` is ever run. A second registration is a conflict, not
a failure — now reported plainly rather than erroring, and rather than swallowed
by `let _` as the block path does.

## Also fixes #118

`shard status` printed `GPU: true` from config while inference ran on CPU. It now
labels that as configuration and states the serving mode. That one cost an hour
of misdiagnosis today.

```
GPU (config): true
Mode:         whole model via Ollama (localhost:11434)
              block sharding is not viable on Metal — see #117
              the range above is unused on this platform
```

## Stopgap, not the fix

#117 stays open. Both long-term Apple paths already exist and are dark:
`mlx_shard.rs` **implements sharding** and was abandoned on MLX graph
recompilation (100 s/forward, 2026-03-29); `llama_local.rs` wraps the same
llama.cpp engine Ollama uses, but its feature is off and it is only wired into
`grpc_server`. Either is a viable real fix. Plan:
`projects/kwaai-compute/plans/MacOllamaStopgap-plan.md`.

## Verification

118 tests green, clippy `--all-targets -D warnings` clean, fmt clean, and
exercised live on this Mac in both the ready and already-registered paths.

**Not yet verified:** that the Mac disappears from `shard chain` as a block
server — this machine is still running the 0.6.0 binary with an
`--auto-rebalance` server attached, so that needs the new binary installed and
the node restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP