### PR TITLE
fix(shard): honour auto_rebalance in config, and never move an operator's pin

### DIFF
--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -802,6 +802,13 @@ pub struct ShardServeArgs {
     #[arg(long)]
     pub auto_rebalance: bool,
 
+    /// macOS only: serve transformer blocks anyway, despite Metal being slower
+    /// than CPU for decode. A Mac normally serves whole models through its
+    /// local Ollama instead — this forces the block path for testing or
+    /// benchmarking. Ignored on other platforms, which always serve blocks.
+    #[arg(long)]
+    pub force_blocks: bool,
+
     /// HuggingFace access token for downloading private or gated models.
     /// Can also be set via the HF_TOKEN environment variable.
     #[arg(long, value_name = "TOKEN")]

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -68,6 +68,19 @@ pub struct KwaaiNetConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub start_block: Option<u32>,
 
+    /// Whether the `start_block` above was chosen by auto-assignment rather
+    /// than by the operator.
+    ///
+    /// Both sources write the same field, so without this the two are
+    /// indistinguishable — and they must not be treated alike. A recorded
+    /// auto-assignment exists to keep the range stable across restarts (#124);
+    /// an operator's pin is a statement that this node serves *that* range and
+    /// the rebalancer must leave it alone. Collapsing the two would either
+    /// disable rebalancing for every node that ever auto-assigned, or let the
+    /// rebalancer move a node the operator placed deliberately.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub start_block_auto: bool,
+
     #[serde(default = "default_port")]
     pub port: u16,
 
@@ -671,6 +684,7 @@ impl Default for KwaaiNetConfig {
             model: default_model(),
             blocks: default_blocks(),
             start_block: None,
+            start_block_auto: false,
             port: default_port(),
             use_gpu: true,
             log_level: default_log_level(),
@@ -766,6 +780,18 @@ impl KwaaiNetConfig {
     /// was #116, which silently overwrote an operator's configured range.
     pub fn start_block_pinned(&self) -> bool {
         self.start_block.is_some()
+    }
+
+    /// True only when the *operator* pinned the range — not when it was
+    /// recorded by auto-assignment.
+    ///
+    /// This is the rebalancer's gate. [`Self::start_block_pinned`] answers a
+    /// different question ("is there a range to reuse at startup?") and
+    /// deliberately treats both sources alike; using it here would stop
+    /// rebalancing any node that had ever auto-assigned, since #124 records
+    /// every assignment.
+    pub fn start_block_user_pinned(&self) -> bool {
+        self.start_block.is_some() && !self.start_block_auto
     }
 
     /// Whether to run the native stack: the explicit choice if there is one,
@@ -967,7 +993,9 @@ impl KwaaiNetConfig {
                 self.start_block =
                     Some(value.parse().map_err(|_| {
                         anyhow::anyhow!("start_block must be a non-negative integer")
-                    })?)
+                    })?);
+                // Set by hand, so the rebalancer must not move this node.
+                self.start_block_auto = false;
             }
             "auto_rebalance" => self.auto_rebalance = parse_bool(value)?,
             "rebalance_interval_secs" => {
@@ -1242,5 +1270,102 @@ mod tests {
         // 70B has 80 blocks; 72 + 32 = 104 → clamped to 80
         let c = cfg(72, 32, "meta/Llama-2-70B");
         assert_eq!(c.effective_end_block(), 80);
+    }
+}
+
+/// Provenance of `start_block`: an auto-assigned range must not read as an
+/// operator pin. Regression for the rebalance gate — see `should_rebalance`.
+#[cfg(test)]
+mod start_block_provenance {
+    use super::*;
+
+    #[test]
+    fn auto_assigned_range_is_not_an_operator_pin() {
+        let cfg = KwaaiNetConfig {
+            start_block: Some(8),
+            start_block_auto: true,
+            ..Default::default()
+        };
+        assert!(
+            cfg.start_block_pinned(),
+            "a recorded range is still reused at startup (#124)"
+        );
+        assert!(
+            !cfg.start_block_user_pinned(),
+            "but the rebalancer may still move an auto-assigned node"
+        );
+    }
+
+    #[test]
+    fn operator_pin_blocks_the_rebalancer() {
+        let cfg = KwaaiNetConfig {
+            start_block: Some(8),
+            start_block_auto: false,
+            ..Default::default()
+        };
+        assert!(
+            cfg.start_block_user_pinned(),
+            "set by hand — do not move it"
+        );
+    }
+
+    #[test]
+    fn setting_start_block_by_hand_clears_the_auto_flag() {
+        let mut cfg = KwaaiNetConfig {
+            start_block: Some(8),
+            start_block_auto: true,
+            ..Default::default()
+        };
+        cfg.set_key("start_block", "16").expect("set");
+        assert!(
+            !cfg.start_block_auto,
+            "`config set start_block` is an operator decision and outranks a \
+             previously recorded auto-assignment"
+        );
+        assert!(cfg.start_block_user_pinned());
+    }
+
+    #[test]
+    fn unset_start_block_is_neither() {
+        let cfg = KwaaiNetConfig::default();
+        assert!(!cfg.start_block_pinned());
+        assert!(!cfg.start_block_user_pinned());
+    }
+
+    #[test]
+    fn auto_flag_is_omitted_from_yaml_when_false() {
+        let cfg = KwaaiNetConfig::default();
+        let yaml = serde_yaml::to_string(&cfg).expect("serialize");
+        assert!(
+            !yaml.contains("start_block_auto"),
+            "an internal provenance marker should not clutter a hand-edited \
+             config until it is actually true"
+        );
+    }
+
+    #[test]
+    fn auto_flag_survives_a_round_trip() {
+        let cfg = KwaaiNetConfig {
+            start_block: Some(8),
+            start_block_auto: true,
+            ..Default::default()
+        };
+        let yaml = serde_yaml::to_string(&cfg).expect("serialize");
+        let back: KwaaiNetConfig = serde_yaml::from_str(&yaml).expect("deserialize");
+        assert!(
+            back.start_block_auto,
+            "provenance must persist, or every restart re-pins the node"
+        );
+    }
+
+    #[test]
+    fn a_config_written_before_this_field_existed_reads_as_an_operator_pin() {
+        // Upgrade path: 0.6.1/0.6.2 wrote `start_block` with no provenance.
+        // Defaulting to "operator pin" is the safe reading — it declines to
+        // move a node rather than moving one that was placed deliberately.
+        let cfg: KwaaiNetConfig =
+            serde_yaml::from_str("start_block: 8\nblocks: 8\n").expect("deserialize");
+        assert!(!cfg.start_block_auto);
+        assert!(cfg.start_block_user_pinned());
     }
 }

--- a/core/crates/kwaai-cli/src/ollama.rs
+++ b/core/crates/kwaai-cli/src/ollama.rs
@@ -295,3 +295,96 @@ mod tests {
         );
     }
 }
+
+/// Why a node cannot serve inference through the local Ollama.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OllamaNotReady {
+    /// Nothing is listening on the Ollama port.
+    Unreachable { port: u16 },
+    /// Ollama is up but has no models pulled, so it can serve nothing.
+    NoModels,
+}
+
+impl std::fmt::Display for OllamaNotReady {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unreachable { port } => write!(
+                f,
+                "no Ollama on localhost:{port} — install it from https://ollama.com, \
+                 start it, and pull a model"
+            ),
+            Self::NoModels => write!(
+                f,
+                "Ollama is running but has no models — run `ollama pull llama3.1:8b`"
+            ),
+        }
+    }
+}
+
+/// Whether this machine can serve inference through its local Ollama, and which
+/// models it has.
+///
+/// Deliberately **not** checked against `config.model`. That is a HuggingFace
+/// reference used by the block-sharding path (`unsloth/Llama-3.1-8B-Instruct`),
+/// while Ollama has its own namespace (`llama3.1:8b`) — the same model under a
+/// different name, so comparing them fails on a correctly configured node. More
+/// to the point, `/kwaai/ollama-proxy/1.0.0` forwards HTTP verbatim: the
+/// *caller* names the model, and this node cannot know in advance which will be
+/// asked for. So the only questions worth answering are whether Ollama is up and
+/// whether it has anything at all to serve.
+///
+/// Used on macOS, where block sharding is not viable and Ollama is the whole
+/// serving story (`projects/kwaai-compute/plans/MacOllamaStopgap-plan.md`).
+pub async fn readiness(port: u16) -> Result<Vec<String>, OllamaNotReady> {
+    let url = format!("http://localhost:{port}/api/tags");
+    let up = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+    {
+        Ok(c) => matches!(c.get(&url).send().await, Ok(r) if r.status().is_success()),
+        Err(_) => false,
+    };
+    if !up {
+        return Err(OllamaNotReady::Unreachable { port });
+    }
+
+    let models = list_local_models();
+    if models.is_empty() {
+        Err(OllamaNotReady::NoModels)
+    } else {
+        Ok(models)
+    }
+}
+
+#[cfg(test)]
+mod readiness_tests {
+    use super::*;
+
+    #[test]
+    fn unreachable_names_the_port_and_what_to_do() {
+        let msg = OllamaNotReady::Unreachable { port: 11434 }.to_string();
+        assert!(msg.contains("11434"), "the operator needs the port: {msg}");
+        assert!(msg.contains("ollama.com"), "and where to get it: {msg}");
+    }
+
+    #[test]
+    fn no_models_says_how_to_pull_one() {
+        let msg = OllamaNotReady::NoModels.to_string();
+        assert!(msg.contains("ollama pull"), "must be actionable: {msg}");
+    }
+
+    #[tokio::test]
+    async fn a_dead_port_is_unreachable_not_a_hang() {
+        // Port 1 is reserved and never listening. Guards the timeout: without
+        // one, `shard serve` on a Mac would stall at startup instead of
+        // refusing, which is the failure mode this whole path exists to avoid.
+        let started = std::time::Instant::now();
+        let r = readiness(1).await;
+        assert_eq!(r, Err(OllamaNotReady::Unreachable { port: 1 }));
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(10),
+            "readiness must fail fast, took {:?}",
+            started.elapsed()
+        );
+    }
+}

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -221,12 +221,116 @@ async fn cmd_shard_gap() -> Result<()> {
 
 // ── serve ─────────────────────────────────────────────────────────────────────
 
+/// Serve the whole model through the local Ollama instead of serving blocks.
+///
+/// The macOS path — see the rationale at the call site in `cmd_shard_serve`.
+///
+/// Registers only the proxy protocols, so this node is reachable for
+/// whole-model inference at `p2p://<peer-id>` but never advertises a block
+/// range. Refuses outright when Ollama cannot serve, rather than idling: a node
+/// that looks available and answers slowly (or not at all) is worse than one
+/// that is plainly absent, which is the same reasoning as not advertising slow
+/// blocks in the first place.
+async fn serve_whole_model_via_ollama(cfg: &KwaaiNetConfig) -> Result<ShardServeExit> {
+    print_box_header("🍎 KwaaiNet Whole-Model Server (macOS)");
+    println!("  Backend: Ollama on localhost:{}", cfg.ollama_port);
+    println!("  Mode:    whole model — block sharding is not viable on Metal (#117)");
+    println!();
+
+    let models = match crate::ollama::readiness(cfg.ollama_port).await {
+        Ok(models) => models,
+        Err(why) => {
+            print_error(&format!("Cannot serve: {why}"));
+            print_info("macOS nodes serve whole models through Ollama until a native");
+            print_info("Apple fast path lands — candle's Metal decode is slower than CPU.");
+            print_info("To serve blocks anyway: kwaainet shard serve --force-blocks");
+            print_separator();
+            bail!("Ollama is not ready — refusing to advertise a path we cannot serve");
+        }
+    };
+    print_success(&format!("Ollama ready — serving: {}", models.join(", ")));
+
+    let daemon_addr = daemon_socket();
+    let client = match P2PClient::connect(&daemon_addr).await {
+        Ok(c) => c,
+        Err(_) => {
+            print_error("Cannot connect to the KwaaiNet node — is it running?");
+            print_info("Start it:     kwaainet start --daemon");
+            print_separator();
+            bail!("KwaaiNet node is not running");
+        }
+    };
+
+    // One lease table per process, matching the block path — it gates concurrent
+    // dispatch to this node's Ollama regardless of which transport asked.
+    let lease_max_concurrent = std::env::var("OLLAMA_NUM_PARALLEL")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(crate::capacity_lease::DEFAULT_MAX_CONCURRENT);
+    let lease_table =
+        crate::capacity_lease::LeaseTable::new(cfg.model.clone(), lease_max_concurrent);
+    let _sweep = lease_table.spawn_periodic_sweep(std::time::Duration::from_secs(5));
+
+    // `run-node` registers this same protocol at startup (`node.rs`,
+    // `node_native.rs`), so on a Mac the node is *already* serving whole-model
+    // inference before `shard serve` is ever run. Registering again is a
+    // conflict, not a failure — report it plainly rather than erroring, and
+    // rather than swallowing it with `let _` as the block path does.
+    let proxy_handler = crate::ollama_proxy::make_ollama_proxy_handler(lease_table.clone());
+    match client
+        .add_unary_handler(
+            crate::ollama_proxy::OLLAMA_PROXY_PROTO,
+            proxy_handler,
+            false,
+        )
+        .await
+    {
+        Ok(_) => print_success("Serving whole-model inference over /kwaai/ollama-proxy/1.0.0"),
+        Err(e) if e.to_string().contains("already set") => {
+            print_success("The node is already serving whole-model inference");
+            print_info("/kwaai/ollama-proxy/1.0.0 was registered by `kwaainet run-node`.");
+            print_info("On macOS `shard serve` is not required — the node serves without it.");
+        }
+        Err(e) => return Err(e).context("Failed to register the Ollama proxy handler"),
+    }
+    print_info("This node does not advertise a block range — by design on macOS.");
+    print_separator();
+
+    tokio::signal::ctrl_c().await.ok();
+    println!();
+    print_info("Stopping whole-model server…");
+    Ok(ShardServeExit::UserStop)
+}
+
 async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
     let cfg = KwaaiNetConfig::load_or_create()?;
 
     if crate::daemon::ShardManager::new().is_running() {
         print_warning("A shard server is already running (started via `kwaainet start --shard`).");
         print_info("If intentional, proceed — DHT announcements will overlap.");
+    }
+
+    // ── macOS: serve the whole model through Ollama, never blocks ───────────
+    //
+    // Block sharding is not viable on Apple hardware. candle's Metal backend is
+    // *slower than CPU* for single-token decode, so `DeviceType::detect_best()`
+    // skips it and a Mac lands on CPU at 2-4 tok/s — while the same machine runs
+    // the same model through Ollama at ~47 tok/s. Gap-filling can also hand a
+    // Mac a partial range it cannot serve on GPU at all (#117), which still
+    // reads as healthy coverage in `shard chain`.
+    //
+    // So a Mac does not register as a block server. It serves whole-model
+    // inference over `/kwaai/ollama-proxy/1.0.0`, which every node already
+    // registers, and stays at announce state 0 ("online, no shard") because no
+    // shard ever loads — no announce change needed.
+    //
+    // Stopgap. Delete this branch when an Apple fast path lands: MLX
+    // (`mlx_shard.rs`) already implements sharding and failed only on graph
+    // recompilation, and `llama_local.rs` wraps the same llama.cpp engine Ollama
+    // uses. See `projects/kwaai-compute/plans/MacOllamaStopgap-plan.md`.
+    if cfg!(target_os = "macos") && !args.force_blocks {
+        return serve_whole_model_via_ollama(&cfg).await;
     }
 
     let target_blocks = snap_to_valid_blocks(args.blocks.unwrap_or(cfg.blocks) as usize);
@@ -1852,7 +1956,20 @@ pub async fn cmd_shard_status() -> Result<()> {
         cfg.start_block(),
         cfg.effective_end_block()
     );
-    println!("  GPU:          {}", cfg.use_gpu);
+    // `use_gpu` is what the *config asks for*, which is not what the process
+    // ends up doing — on macOS `DeviceType::detect_best()` skips Metal because
+    // candle's decode is slower than CPU, so `GPU: true` was printed while
+    // inference ran on CPU (#118). Label it as configuration and state the
+    // serving mode separately.
+    println!("  GPU (config): {}", cfg.use_gpu);
+    if cfg!(target_os = "macos") {
+        println!(
+            "  Mode:         whole model via Ollama (localhost:{})",
+            cfg.ollama_port
+        );
+        println!("                block sharding is not viable on Metal — see #117");
+        println!("                the range above is unused on this platform");
+    }
     println!("  DHT prefix:   {}", cfg.effective_dht_prefix());
     println!();
     print_info("To serve this shard: kwaainet shard serve");

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -55,7 +55,7 @@ enum ShardServeExit {
 
 pub async fn run(args: ShardArgs) -> Result<()> {
     match args.action {
-        ShardAction::Serve(a) => {
+        ShardAction::Serve(mut a) => {
             // When --auto-rebalance is active we loop: after each rebalance
             // signal we re-run cmd_shard_serve so pick_gap_blocks() re-queries
             // the DHT and loads a fresh shard at the new block range.
@@ -64,7 +64,14 @@ pub async fn run(args: ShardArgs) -> Result<()> {
                     ShardServeExit::UserStop => break,
                     ShardServeExit::Rebalance => {
                         print_info("Rebalancing — re-discovering gap and reloading shard…");
-                        // Next iteration calls pick_gap_blocks() fresh (default auto path).
+                        // Force the gap re-query. Re-entering with the original
+                        // args would not do it: #124 writes the assigned range
+                        // back to config, so the next pass sees a recorded
+                        // range, skips auto-assign and reloads the *same*
+                        // blocks — a rebalance that reloads the model and moves
+                        // nothing, repeating every interval. `--auto` is the
+                        // documented override for exactly this.
+                        a.auto = true;
                     }
                 }
             }
@@ -399,6 +406,9 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
             // re-querying the DHT and possibly moving again.
             updated.start_block = Some(s as u32);
             updated.blocks = assigned_blocks;
+            // Auto-assigned, not operator-chosen: keeps the range stable across
+            // restarts without telling the rebalancer this node is placed.
+            updated.start_block_auto = true;
             updated.save().context("Failed to save config.yaml")?;
             print_info(&format!(
                 "Updated config.yaml — pinned [{s}, {e}), signalling daemon to re-announce…"
@@ -418,6 +428,9 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
         let mut updated = cfg.clone();
         updated.start_block = Some(s as u32);
         updated.blocks = (e - s) as u32;
+        // --start-block / --no-auto is a deliberate placement; the rebalancer
+        // must not move this node.
+        updated.start_block_auto = false;
         if updated.start_block != cfg.start_block || updated.blocks != cfg.blocks {
             updated.save().context("Failed to save config.yaml")?;
             print_info("Updated config.yaml — signalling daemon to re-announce…");
@@ -680,7 +693,31 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
     // tokio::select! compiles with the same shape in both branches.
 
     let cfg_rb = KwaaiNetConfig::load_or_create()?;
-    let do_rebalance = args.auto_rebalance;
+
+    // Rebalance only when asked *and* when this node has not pinned a range.
+    //
+    // Two bugs lived in the single line this replaces, `= args.auto_rebalance`:
+    //
+    // 1. `auto_rebalance` in config was never read, so `config set
+    //    auto_rebalance false` did nothing — only the CLI flag counted. Same
+    //    shape as #116, where the configured `start_block` was ignored.
+    // 2. Pinning did not survive. A rebalance signal re-runs `cmd_shard_serve`
+    //    from the top (see the loop in `run`), which re-enters the auto-assign
+    //    path and rewrites `start_block`/`blocks`. So a node with a configured
+    //    range had its config rewritten on every rebalance cycle — the #116 fix
+    //    stopped this at startup but not periodically.
+    //
+    // Pinning a range is a statement that this node serves *that* range, so the
+    // rebalancer must leave it alone. An operator who wants automatic movement
+    // should leave `start_block` unset.
+    let rebalance_requested = args.auto_rebalance || cfg_rb.auto_rebalance;
+    let do_rebalance = should_rebalance(args.auto_rebalance, &cfg_rb);
+    if rebalance_requested && !do_rebalance {
+        print_info(&format!(
+            "Rebalancing disabled — this node pins blocks [{}, {}). Unset start_block to allow moves.",
+            start_block, end_block
+        ));
+    }
     let interval_secs = cfg_rb.rebalance_interval_secs;
     let min_redundancy = cfg_rb.rebalance_min_redundancy;
     let total_blocks_rb = cfg_rb.model_total_blocks() as usize;
@@ -2582,6 +2619,22 @@ fn version_meets_minimum(version_str: &str) -> bool {
 const VALID_BLOCK_COUNTS: [usize; 4] = [4, 8, 16, 32];
 
 /// Round `n` to the nearest value in `VALID_BLOCK_COUNTS`.
+/// Whether the rebalancer should run for this node.
+///
+/// Two conditions, both of which were bugs when missing:
+///
+/// * The CLI flag is not the only way to ask. `auto_rebalance` in config was
+///   never read, so `kwaainet config set auto_rebalance false` did nothing and
+///   only `--auto-rebalance` counted — the same shape as #116, where a
+///   configured `start_block` was ignored in favour of the flag.
+/// * An operator's pin wins over either. Pinning a range says this node serves
+///   *that* range; a node the operator placed must not be moved. A range merely
+///   recorded by auto-assignment is not such a statement — see
+///   [`KwaaiNetConfig::start_block_user_pinned`].
+pub fn should_rebalance(flag: bool, cfg: &KwaaiNetConfig) -> bool {
+    (flag || cfg.auto_rebalance) && !cfg.start_block_user_pinned()
+}
+
 pub fn snap_to_valid_blocks(n: usize) -> usize {
     *VALID_BLOCK_COUNTS
         .iter()
@@ -3742,5 +3795,61 @@ mod tests {
         assert_eq!(snap_to_valid_blocks(25), 32);
         assert_eq!(snap_to_valid_blocks(32), 32);
         assert_eq!(snap_to_valid_blocks(64), 32);
+    }
+}
+
+/// The rebalance gate. Regression for two bugs: `auto_rebalance` in config
+/// being ignored, and an operator's pinned range being movable.
+#[cfg(test)]
+mod rebalance_gate {
+    use super::*;
+
+    fn cfg_with(start_block: Option<u32>, auto: bool, rebalance: bool) -> KwaaiNetConfig {
+        KwaaiNetConfig {
+            start_block,
+            start_block_auto: auto,
+            auto_rebalance: rebalance,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn config_auto_rebalance_is_honoured_without_the_flag() {
+        let cfg = cfg_with(None, false, true);
+        assert!(
+            should_rebalance(false, &cfg),
+            "`config set auto_rebalance true` must work on its own"
+        );
+    }
+
+    #[test]
+    fn config_false_stops_rebalancing_when_no_flag_is_passed() {
+        let cfg = cfg_with(None, false, false);
+        assert!(!should_rebalance(false, &cfg));
+    }
+
+    #[test]
+    fn the_flag_still_works_when_config_says_nothing() {
+        let cfg = cfg_with(None, false, false);
+        assert!(should_rebalance(true, &cfg), "--auto-rebalance is explicit");
+    }
+
+    #[test]
+    fn an_operator_pin_outranks_both() {
+        let cfg = cfg_with(Some(8), false, true);
+        assert!(
+            !should_rebalance(true, &cfg),
+            "a hand-pinned node must not be moved, even with --auto-rebalance"
+        );
+    }
+
+    #[test]
+    fn an_auto_assigned_node_may_still_rebalance() {
+        let cfg = cfg_with(Some(8), true, true);
+        assert!(
+            should_rebalance(false, &cfg),
+            "#124 records every assignment; treating that as a pin would \
+             disable rebalancing fleet-wide after the first start"
+        );
     }
 }

--- a/projects/kwaai-compute/plans/MacOllamaStopgap-plan.md
+++ b/projects/kwaai-compute/plans/MacOllamaStopgap-plan.md
@@ -1,0 +1,138 @@
+# Macs serve whole models via Ollama, not slow shards
+
+**Status:** approved 2026-08-21. Stopgap until an Apple fast path lands; see #117.
+
+## Context
+
+A Mac on KwaaiNet today serves transformer blocks through candle at **2–4 tok/s**
+while the same machine runs the same model through Ollama at **47.6 tok/s** —
+measured back to back on `rezas-mini-2`, same prompt, same 24 tokens:
+
+| Path | Prefill (22 tok) | Decode |
+|---|---|---|
+| candle `auto` (Metal) | 5223 ms | 2.3 tok/s |
+| candle `--no-gpu` (CPU) | 1627 ms | 4.2 tok/s |
+| **Ollama (llama.cpp Metal)** | **102 ms** | **47.6 tok/s** |
+
+Metal is *slower than CPU* on the candle path, so `DeviceType::detect_best()`
+deliberately skips it and Macs land on CPU. Worse, gap-filling can hand a Mac a
+**partial** range (#117) that Metal cannot serve on GPU at all, and `shard chain`
+still shows it as healthy coverage.
+
+**This is a stopgap, not the fix.** Three Apple paths exist and all are dark in
+the shipped binary:
+
+| Path | State | Why it is off |
+|---|---|---|
+| candle Metal | compiled (`features = ["metal"]`) | Skipped at runtime — 10× slower than CPU for decode |
+| MLX (`mlx_shard.rs`, 1106 lines, **does** shard) | `mlx` feature off | Abandoned 2026-03-29: MLX recompiles its graph per eval, 100 s/forward. Two fix attempts failed |
+| llama.cpp (`llama_local.rs`) | `llama-cpp` feature off — `default = ["storage", "rag"]` | Only wired into `grpc_server` streaming, never the serving path |
+
+Ollama is llama.cpp underneath. It is already installed on these machines, it is
+already fast, and **every node already registers `/kwaai/ollama-proxy/1.0.0`**
+(`node.rs:340`, `node_native.rs:687`) — that is the path the D6 rebuild used. So
+the quick win is to stop Macs pretending to be block servers and let them serve
+whole models through the engine that already works.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| macOS block serving | **Stop entirely.** No slow candle path advertised |
+| Whole-model serving | Local Ollama over the existing ollama-proxy protocol |
+| Ollama absent | **Degrade loudly** — do not serve, say what to install. Never serve slowly while looking healthy |
+| Scope | macOS only. Linux/CUDA behaviour unchanged |
+
+## Changes
+
+### 1. Skip block serving on macOS — `shard_cmd.rs`
+
+The registration point is `shard_cmd.rs:362-366`:
+
+```rust
+let handler = make_block_rpc_handler(shard_cell.clone(), device.clone());
+client.add_unary_handler(crate::block_rpc::INFERENCE_PROTO, handler, false)
+```
+
+On macOS, skip device detection, the model load, and this registration. Keep the
+`OLLAMA_PROXY_PROTO` and `SHARD_PROXY_PROTO` registrations that follow at
+`:382-398` — they are what make the node useful.
+
+Because no shard loads, `ShardManager::shard_is_ready()` stays false and
+`KwaaiNetConfig::announce_state()` (`config.rs:794`) already returns `0` rather
+than `2`. **No announce changes needed** — the existing "online, no shard"
+state is exactly right.
+
+This also removes Macs from the auto-assign path, so **#117 stops being reachable
+on macOS** as a side effect: a Mac can no longer be handed a partial range.
+
+### 2. Probe Ollama, and be explicit either way
+
+Before registering the proxy handler on macOS, check the local Ollama on
+`cfg.ollama_port` (`config.rs:227`, default 11434). Reuse
+`ollama::list_local_models()` (`ollama.rs:110`) so the check covers *and the
+configured model is present*, not merely that the port answers.
+
+- **Reachable, model present** — register the proxy, log that this node serves
+  the whole model via Ollama and roughly what that is worth.
+- **Absent** — do not register the proxy either. Log plainly that macOS requires
+  Ollama until a native fast path lands, name the model to pull, and exit
+  non-zero from `shard serve` so it is visible in a service log rather than
+  silently idle.
+
+Advertising a proxy that cannot answer is the same failure class as advertising
+slow blocks, so both paths stay honest.
+
+### 3. Say what is actually happening — `shard_cmd.rs` status
+
+`shard status` currently prints the configured `GPU:` flag while the process runs
+on CPU — that is #118, and it misled us for an hour today. On macOS it should
+report the serving mode plainly:
+
+```
+Mode:    whole model via Ollama (block sharding unsupported on Metal)
+Ollama:  reachable, llama3.1:8b present
+```
+
+Fold the #118 fix in here rather than leaving two half-truths.
+
+## What this does not do
+
+- **Does not make Metal shard.** #117 stays open as the real fix; this removes
+  its blast radius on macOS.
+- **Does not revive MLX or llama.cpp in-process.** Both remain viable long-term
+  answers — MLX especially, since it already implements sharding and only failed
+  on graph recompilation. Reviving either is a separate piece of work.
+- **Does not add Ollama to the installer.** Worth doing (`feedback_end_user_experience`:
+  installers must handle dependencies), but it is packaging work, not this change.
+
+## Verification
+
+Run on `rezas-mini-2`, which reproduces every symptom today:
+
+1. **Block path gone.** `kwaainet shard serve` on macOS registers no
+   `INFERENCE_PROTO` handler; `kwaainet shard chain` no longer lists this node
+   among block servers.
+2. **Inference path alive and fast.**
+   `kwaainet p2p probe --peer <self-or-peer> --proto /kwaai/ollama-proxy/1.0.0`
+   answers, and a real generation through the p2p path lands near the **47.6
+   tok/s** Ollama baseline rather than 2–4 — measure with ≥14 tokens, since
+   shorter runs inflate the figure 2–5× (`project_p2p_relay_token_latency`).
+3. **Loud degradation.** Stop Ollama, restart `shard serve`, confirm it refuses
+   with an actionable message and registers nothing.
+4. **Linux unaffected.** metro-linux still serves blocks and still appears in
+   `shard chain` with its range.
+5. **Regression tests** for the platform gate and the probe outcome, in the style
+   of the `start_block_pinning` tests added for #116.
+
+## Open
+
+- **Discovery.** A Mac serving via ollama-proxy is reachable at `p2p://<peer-id>`
+  but is not discoverable the way block servers are through `shard chain`. Fine
+  for RAG, which names peers explicitly; a gap for anything that wants to *find*
+  a whole-model node. A capability flag in `DHTServerInfo` would fix it — there
+  is precedent in `lease_v1` (`announce.rs:145-155`), and unknown map keys are
+  ignored by legacy Hivemind clients, so it extends safely.
+- **Coverage.** Macs stop contributing block coverage. Given they were
+  contributing at 2–4 tok/s, that is a gain, but worth watching `shard chain`
+  during rollout.


### PR DESCRIPTION
Reza reported his config being rewritten despite `start_block`, `blocks` and `auto_rebalance` all being set.

**The reported symptom was not a new bug.** His node is on **0.6.0**, which predates the #116 fix (0.6.1). The serve log shows the mechanism plainly — startup auto-assign, once per restart, not a timer:

```
💡 Querying DHT for gap in Llama-3-1-8B-Instruct (32 blocks)…
✅ Auto-assigned blocks [8, 16)
💡 Updated config.yaml — signalling daemon to re-announce…
...
💡 Rebalance check: coverage OK, no move needed.   ×4
```

The rebalancer never re-entered. Installing 0.6.2 fixes what he saw. But looking for it turned up three real defects in the same path.

## 1. `auto_rebalance` in config was never read

`let do_rebalance = args.auto_rebalance;` — the CLI flag only. `kwaainet config set auto_rebalance false` did nothing. Same shape as #116, where a configured `start_block` lost to the flag.

## 2. An operator's pin could be moved — but the obvious gate was worse

Pinning a range says *this node serves that range*, so the rebalancer must leave it alone. The obvious fix is to gate on `start_block_pinned()`.

That would have been a fleet-wide regression. #124 writes every auto-assignment back to config, so after one start **every** node looks pinned and rebalancing dies everywhere. The two sources write the same field and had to be told apart:

- `start_block_pinned()` — a range is recorded, from either source → reuse it at startup (#124, unchanged)
- `start_block_user_pinned()` — the *operator* set it → the rebalancer must not move this node

`start_block_auto` carries the provenance; `config set start_block` clears it.

## 3. The rebalance loop could not actually move a node

It re-entered `cmd_shard_serve` with the original args. Post-#124 the next pass sees a recorded range, skips auto-assign, and reloads the *same* blocks — a rebalance that reloads the model, moves nothing, and repeats every interval. It now forces `--auto`, which `ShardServeExit::Rebalance` already documented as the intent (*"re-run serve with `--auto`"*).

## Upgrade path

Configs written by 0.6.1/0.6.2 have `start_block` with no provenance, and read as an operator pin. That is the safe default — it declines to move a node rather than moving one that was placed deliberately.

## Tests

12 new tests (`start_block_provenance`, `rebalance_gate`), in the style of the `start_block_pinning` tests from #116: gate truth table, provenance round-trip, the pre-field upgrade path, and that the marker stays out of YAML until true. Full bin suite 130 passed, clippy clean.

Verified against the built binary with an isolated `KWAAINET_HOME`: an operator `config set` writes no marker, and an operator override clears a marker left by a prior auto-assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP