### PR TITLE
fix(config): stop cargo test from destroying the developer's real config

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -17,7 +17,40 @@ pub fn kwaainet_dir() -> PathBuf {
     if let Ok(home) = std::env::var("KWAAINET_HOME") {
         return PathBuf::from(home);
     }
-    dirs_home().join(".kwaainet")
+    // Unit tests must never resolve to the developer's real ~/.kwaainet.
+    //
+    // `set_key` ends in `save()`, and several tests call it. With the real path
+    // that serialises a `Default`-derived config straight over the live one,
+    // silently deleting every key a default does not carry. On this machine
+    // `cargo test` destroyed 23 registered knowledge bases, `inference_url`,
+    // the storage block and the vpk settings — the KB data survived on disk,
+    // but nothing referenced it any more.
+    //
+    // The sandbox is deliberately here rather than in the tests: a guard each
+    // test has to remember is a guard that eventually gets forgotten, and the
+    // failure is silent and off-target. `KWAAINET_HOME` still wins, so
+    // integration tests that want a specific directory keep working.
+    #[cfg(test)]
+    {
+        test_sandbox_dir()
+    }
+    #[cfg(not(test))]
+    {
+        dirs_home().join(".kwaainet")
+    }
+}
+
+/// Per-process temp directory standing in for `~/.kwaainet` under `cargo test`.
+#[cfg(test)]
+fn test_sandbox_dir() -> PathBuf {
+    use std::sync::OnceLock;
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = std::env::temp_dir().join(format!("kwaainet-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    })
+    .clone()
 }
 
 pub fn config_file() -> PathBuf {
@@ -1367,5 +1400,46 @@ mod start_block_provenance {
             serde_yaml::from_str("start_block: 8\nblocks: 8\n").expect("deserialize");
         assert!(!cfg.start_block_auto);
         assert!(cfg.start_block_user_pinned());
+    }
+}
+
+/// `cargo test` must not be able to touch the developer's real config.
+#[cfg(test)]
+mod test_isolation {
+    use super::*;
+
+    #[test]
+    fn config_path_is_sandboxed_under_test() {
+        // No KWAAINET_HOME is set in this process, so this is the path a test
+        // that calls save() would write to.
+        if std::env::var("KWAAINET_HOME").is_ok() {
+            return; // explicitly directed elsewhere; nothing to prove
+        }
+        let real = dirs_home().join(".kwaainet");
+        assert_ne!(
+            kwaainet_dir(),
+            real,
+            "a test that calls save() would overwrite the real config"
+        );
+    }
+
+    #[test]
+    fn set_key_saves_into_the_sandbox_only() {
+        // set_key() ends in save(). Prove the write lands in the sandbox.
+        if std::env::var("KWAAINET_HOME").is_ok() {
+            return;
+        }
+        let mut cfg = KwaaiNetConfig::default();
+        cfg.set_key("start_block", "16").expect("set");
+        let written = config_file();
+        assert!(
+            written.starts_with(std::env::temp_dir()),
+            "config write escaped the sandbox: {}",
+            written.display()
+        );
+        assert!(
+            written.exists(),
+            "save() should have written the sandbox copy"
+        );
     }
 }


### PR DESCRIPTION
## What happened

`kwaainet rag list` on rezas-mini-2 reported **"No knowledge bases initialised"**. All 23 registrations — `D6`, `Legal`, `Astrophysics`, the lot — were gone from `config.yaml`, along with `inference_url`, `storage`, `vpk_local_port` and `vpk_mode`. The config had shrunk from 7253 to 1144 bytes. The 2.4 GB of KB data was intact on disk; nothing referenced it.

The culprit is `cargo test`.

`set_key` ends in `self.save()` (`config.rs:1030`), and several unit tests call it — two from #116, one added in #127. With no `KWAAINET_HOME` set, `kwaainet_dir()` resolved to the real `~/.kwaainet`, so those tests wrote a `Default`-derived config straight over the live one.

Demonstrated by checksumming the real config around a full suite run:

```
before: 634adb0a…  blocks: 32
test result: ok. 130 passed
after:  a38a5e38…
*** TEST SUITE REWROTE THE REAL CONFIG ***
< blocks: 32          > blocks: 8
< start_block: 0      > start_block: 8
< native_p2p: true    (deleted)
< inference_url: …    (deleted)
< rag_kbs: (23 KBs)   (deleted)
```

## Why it matters beyond the data loss

This is also what made the config look like it was being **rewritten periodically** — the symptom that sent #127 hunting through the rebalancer. Every `cargo test` run silently reset `blocks` and `start_block`. #127's three findings are real and worth keeping, but this was the reported symptom's actual cause.

## The fix

`kwaainet_dir()` resolves to a per-process temp sandbox under `cfg(test)`. `KWAAINET_HOME` still takes precedence, so integration tests are unaffected; non-test builds are unchanged.

The guard is in `kwaainet_dir()` rather than in each test deliberately — a guard every test author must remember is one that eventually gets forgotten, and this failure is silent and lands somewhere other than the test that caused it.

## Verification

```
test result: ok. 132 passed
config before=634adb0afa6e6d5e5d4438cf11186f4b
config after =634adb0afa6e6d5e5d4438cf11186f4b
KBs: 23 -> 23
✅ real config untouched by the full suite
```

Plus two regression tests: the resolved path is never the real home under test, and a `set_key` write demonstrably lands in the sandbox.

## Follow-up worth considering

`set_key` performing IO is surprising for a setter and is what made this reachable. Splitting the mutation from the persistence would remove the hazard at its source, but that is a wider refactor than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP