### PR TITLE
docs(readme): recommend Ollama whole-model serving on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ From an app's point of view, KwaaiNet looks like a familiar chat-completion styl
 
 ## Current status
 
-**Latest release: v0.6.2** (August 2026). Two things are worth knowing before you set up a node.
+**As of v0.6.2.** Two things are worth knowing before you set up a node.
 
 **The networking stack is now native.** As of **v0.6.0** every node runs the in-process
 rust-libp2p stack by default; the Go `p2pd` child process is no longer required. Existing
@@ -198,7 +198,7 @@ curl -s http://localhost:11434/api/chat -d '{
   "model": "llama3.1:8b", "stream": false,
   "options": {"num_ctx": 8192, "num_predict": 80},
   "messages": [{"role": "user", "content": "Explain knowledge graphs in one paragraph."}]
-}' | python3 -c 'import json,sys; d=json.load(sys.stdin); print(f"{d["eval_count"]/(d["eval_duration"]/1e9):.1f} tok/s")'
+}' | python3 -c 'import json,sys; d=json.load(sys.stdin); print("%.1f tok/s" % (d["eval_count"]/(d["eval_duration"]/1e9)))'
 ```
 
 > Pin `num_ctx` explicitly. Ollama defaults to a very large context, which pushes part of the
@@ -235,15 +235,18 @@ The node will connect to bootstrap peers, announce itself on the DHT, auto-detec
 
 > **Pre-release note (< v1.0):** `kwaainet start --daemon` automatically starts shard serving (if a local model is present) and storage serving (if storage has been initialised). This opt-out default keeps the network dense during the insider phase. Run with `--no-contribute` to start the node without contributing, or permanently disable with `kwaainet config set contribute.shards false`.
 >
-> On macOS this contributes **whole-model inference via Ollama** rather than block shards — see [Current status](#current-status).
+> From the next release, on macOS this contributes **whole-model inference via Ollama** rather than block shards — on v0.6.2 see [Current status](#current-status) for the manual equivalent.
 >
-> Note that block sharding is **experimental** but currently opt-out. On Linux/CUDA, if you would
-> rather contribute only whole models through Ollama, turn shard serving off — the node keeps
-> serving over `/kwaai/ollama-proxy/1.0.0` either way:
+> Block sharding is **experimental**. On v0.6.2 it is opt-out — a node with a local model serves
+> blocks unless told otherwise — and it becomes opt-in from the next release. Whole-model serving
+> over `/kwaai/ollama-proxy/1.0.0` is unaffected either way. To be sure a node contributes only
+> whole models, whichever release it is on:
 >
 > ```bash
 > kwaainet config set contribute.shards false
 > ```
+>
+> To serve blocks once it is opt-in, set that to `true` or pass `--shard`.
 
 ### 3. Call the OpenAI-compatible API
 
@@ -353,7 +356,7 @@ KwaaiNet is under active development. The Rust CLI and node implementation alrea
 - **Whole-model serving over Ollama** — the recommended way to contribute today. Every node registers `/kwaai/ollama-proxy/1.0.0` on every platform, serves every model held locally (the target comes from the request), and needs no special mode.
 - **Block-sharded LLM inference** (CandleEngine, **experimental**) exposed through an OpenAI-compatible HTTP API — SafeTensors, RoPE, GQA, SwiGLU, per-session KV-cache, full sampling controls. Linux/CUDA only in practice; not yet dependable enough to recommend over whole-model serving.
 - **Distributed inference across multiple machines** (experimental) with session-pinned peer paths, automatic gap-filling, and graceful failover when peers go offline.
-- **Per-platform backends**: candle + CUDA with Flash Attention on Linux (30–36 tok/s FP16 on an RTX A5000) serves block shards; Apple Silicon serves whole models through Ollama (47.3 tok/s measured on a Mac mini). Candle's Metal backend is compiled but skipped at runtime — its decode is ~10× slower than CPU — so Metal block sharding is not offered. See [Current status](#current-status).
+- **Per-platform backends**: candle + CUDA with Flash Attention on Linux (30–36 tok/s FP16 on an RTX A5000) serves block shards; Apple Silicon contributes whole models through Ollama instead (47.3 tok/s measured on a Mac mini; automatic from the next release, manual on v0.6.2). Candle's Metal backend is compiled but skipped at runtime — its decode is ~10× slower than CPU — so Metal block sharding is not offered. See [Current status](#current-status).
 - Selective block download (`shard download --start-block N --blocks M`), reusable inference circuits (`shard circuit create`), and `shard run --local` model reuse for near-zero cold start.
 - Auto-detects local models and network state, and appears on the public map when configured at [map.kwaai.ai](https://map.kwaai.ai).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ KwaaiNet is a decentralized AI node architecture for **Layer 8** — the trust a
 Each KwaaiNet node combines:
 
 - A **decentralized trust graph** (cryptographic identity, verifiable credentials, local trust scores).
-- **Shared, sharded LLM compute** over heterogeneous CPUs/GPUs using Petals-style distributed inference. Linux/CUDA nodes serve transformer blocks; Apple Silicon Macs serve **whole models through Ollama** — block sharding on Metal is not yet viable (see [Current status](#current-status)).
+- **Shared LLM compute** over heterogeneous CPUs/GPUs. Nodes contribute **whole models through Ollama** — the recommended default on every platform — and Linux/CUDA machines can additionally pool a single oversized model across several boxes with Petals-style block sharding (see [Current status](#current-status)).
 - **Secure multi-tenant knowledge storage** via Virtual Private Knowledge (VPK) with encrypted vector search.
 - **Local-first RAG and knowledge graphs** — retrieval-augmented generation over your own documents, with an optional link to VPK for network-outsourced storage.
 - **Intent-based, peer-to-peer networking** that routes based on "what I need" (model, trust tier, latency), not just IP addresses.
@@ -23,9 +23,13 @@ From an app's point of view, KwaaiNet looks like a familiar chat-completion styl
 rust-libp2p stack by default; the Go `p2pd` child process is no longer required. Existing
 nodes keep working — set `native_p2p: false` in `~/.kwaainet/config.yaml` to opt out.
 
-**On Apple Silicon, serve whole models through Ollama — not block shards.** Block-sharded
-inference on Metal is not viable today, so a Mac contributing block shards makes the network
-*slower*, not faster. Measured on an Apple Silicon Mac mini, same model, same prompt:
+**Prefer Ollama whole-model serving over block sharding.** Block sharding remains the more
+ambitious mechanism — pooling a model too large for one GPU across several machines — but today
+it is only worth running on Linux/CUDA hardware. Everywhere else, whole-model serving through
+Ollama contributes more, and needs no special mode: every node registers the
+`/kwaai/ollama-proxy/1.0.0` protocol, so installing Ollama and pulling a model is enough.
+
+On Apple Silicon the difference is stark. Measured on a Mac mini, same model, same prompt:
 
 | Path | Decode |
 |---|---|
@@ -246,21 +250,58 @@ This sends a chat-completion request to your local node, which may route it thro
 
 For a full walkthrough including platform specifics, model discovery, and Python/JS examples see **[docs/getting-started-node.md](docs/getting-started-node.md)** and **[docs/api-quickstart.md](docs/api-quickstart.md)**.
 
-### 4. Distributed inference across the network
+### 4. Contribute inference to the network
 
-Download the model (or just the blocks you need):
+There are two ways a node can contribute compute. **Whole-model serving through Ollama is the
+recommended default on every platform today.** Block sharding is the more ambitious mechanism —
+it pools a model too large for any single GPU across several machines — but it is only worth
+running on Linux/CUDA hardware right now.
+
+| Your machine | Recommended | Why |
+|---|---|---|
+| Apple Silicon Mac | **Ollama, whole model** | Metal block sharding is ~20× slower than Ollama on the same box ([#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117)) |
+| Linux + CUDA | Either | Blocks pool VRAM across machines; Ollama is simpler and faster per node |
+| CPU-only or small GPU | **Ollama, small model** | A slow block server stalls every chain it joins |
+
+#### Serving whole models through Ollama (recommended)
+
+Every node registers the `/kwaai/ollama-proxy/1.0.0` protocol on every platform, so this needs
+no special mode — install Ollama, pull a model, and your running node already serves it:
+
+```bash
+ollama pull llama3.1:8b
+kwaainet start --daemon
+```
+
+Two things worth knowing:
+
+- **A node serves every model Ollama has locally, not just one.** The target model comes from
+  each request, so pulling `llama3.2:3b` alongside `llama3.1:8b` makes both available.
+- **The node is discoverable under a single model prefix.** Peers that know your PeerId can
+  request any local model; peers relying on DHT discovery find you under the one model in your
+  config. Advertising the full served list is planned.
+
+On macOS, `kwaainet shard serve` also refuses to serve blocks and takes this path automatically
+from the next release — see [Current status](#current-status) for the measurements and the
+manual equivalent on v0.6.2 and earlier.
+
+#### Block sharding across machines (Linux + CUDA)
+
+Download the model, or just the blocks you intend to serve:
 
 ```bash
 kwaainet shard download
+kwaainet shard serve            # advertises your block range on the DHT
 ```
 
-Run inference across the live KwaaiNet peer network:
+Then run inference across the live peer network:
 
 ```bash
 kwaainet shard run "What is the capital of France?"
 ```
 
-The coordinator discovers block servers via DHT, pins a stable peer path for the session, and forwards activations through the chain:
+The coordinator discovers block servers via DHT, pins a stable peer path for the session, and
+forwards activations through the chain:
 
 ```
 Pinned path:
@@ -270,31 +311,11 @@ Pinned path:
   Assistant: The capital of France is Paris.
 ```
 
-Add `--stats` to see per-token timing breakdown (prefill, decode, throughput). For local-only inference without networking: `kwaainet shard run "prompt" --local`.
+Add `--stats` for a per-token timing breakdown (prefill, decode, throughput). For local-only
+inference without networking: `kwaainet shard run "prompt" --local`.
 
-**On Apple Silicon, contribute whole models rather than blocks.** From the next release,
-`kwaainet shard serve` detects macOS and serves the whole model over Ollama automatically,
-rather than advertising a block range it would fill slowly (on v0.6.2 and earlier see
-[Current status](#current-status) for the manual equivalent):
-
-```bash
-# Prerequisite: Ollama installed with at least one model pulled
-ollama pull llama3.1:8b
-
-kwaainet shard serve
-# 🍎 KwaaiNet Whole-Model Server (macOS)
-#   Backend: Ollama on localhost:11434
-#   ✅ Serving whole-model inference over /kwaai/ollama-proxy/1.0.0
-#   💡 This node does not advertise a block range — by design on macOS.
-```
-
-The node serves every model Ollama has locally, not just one — the target model is taken from
-each request. If Ollama is not running the command refuses to start rather than serving
-slowly, so a node is never silently useless. To force the old block-serving path anyway, pass
-`--force-blocks`.
-
-See [Current status](#current-status) for the measurements behind this, and
-[#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117) for the real fix.
+On Apple Silicon, pass `--force-blocks` if you want the block path anyway for testing or
+benchmarking — it is not a useful way to contribute.
 
 See **[docs/sharded-llm-processing.md](docs/sharded-llm-processing.md)** for the full architecture of block-sharded inference, KV-cache management, and data flow diagrams.
 
@@ -313,7 +334,8 @@ KwaaiNet is under active development. The Rust CLI and node implementation alrea
 
 ### Compute & inference
 
-- **Block-sharded LLM inference** (CandleEngine) exposed through an OpenAI-compatible HTTP API — SafeTensors, RoPE, GQA, SwiGLU, per-session KV-cache, full sampling controls.
+- **Whole-model serving over Ollama** — the recommended way to contribute today. Every node registers `/kwaai/ollama-proxy/1.0.0` on every platform, serves every model held locally (the target comes from the request), and needs no special mode.
+- **Block-sharded LLM inference** (CandleEngine) exposed through an OpenAI-compatible HTTP API — SafeTensors, RoPE, GQA, SwiGLU, per-session KV-cache, full sampling controls. Best suited to Linux/CUDA today.
 - **Distributed inference across multiple machines** with session-pinned peer paths, automatic gap-filling, and graceful failover when peers go offline.
 - **Per-platform backends**: candle + CUDA with Flash Attention on Linux (30–36 tok/s FP16 on an RTX A5000) serves block shards; Apple Silicon serves whole models through Ollama (47.3 tok/s measured on a Mac mini). Candle's Metal backend is compiled but skipped at runtime — its decode is ~10× slower than CPU — so Metal block sharding is not offered. See [Current status](#current-status).
 - Selective block download (`shard download --start-block N --blocks M`), reusable inference circuits (`shard circuit create`), and `shard run --local` model reuse for near-zero cold start.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ KwaaiNet is a decentralized AI node architecture for **Layer 8** — the trust a
 Each KwaaiNet node combines:
 
 - A **decentralized trust graph** (cryptographic identity, verifiable credentials, local trust scores).
-- **Shared LLM compute** over heterogeneous CPUs/GPUs. Nodes contribute **whole models through Ollama** — the recommended default on every platform — and Linux/CUDA machines can additionally pool a single oversized model across several boxes with Petals-style block sharding (see [Current status](#current-status)).
+- **Shared LLM compute** over heterogeneous CPUs/GPUs. Nodes contribute **whole models through Ollama** — the supported path on every platform. Petals-style **block sharding**, which pools a single oversized model across several machines, is **experimental** and currently limited to Linux/CUDA (see [Current status](#current-status)).
 - **Secure multi-tenant knowledge storage** via Virtual Private Knowledge (VPK) with encrypted vector search.
 - **Local-first RAG and knowledge graphs** — retrieval-augmented generation over your own documents, with an optional link to VPK for network-outsourced storage.
 - **Intent-based, peer-to-peer networking** that routes based on "what I need" (model, trust tier, latency), not just IP addresses.
@@ -23,11 +23,15 @@ From an app's point of view, KwaaiNet looks like a familiar chat-completion styl
 rust-libp2p stack by default; the Go `p2pd` child process is no longer required. Existing
 nodes keep working — set `native_p2p: false` in `~/.kwaainet/config.yaml` to opt out.
 
-**Prefer Ollama whole-model serving over block sharding.** Block sharding remains the more
-ambitious mechanism — pooling a model too large for one GPU across several machines — but today
-it is only worth running on Linux/CUDA hardware. Everywhere else, whole-model serving through
-Ollama contributes more, and needs no special mode: every node registers the
-`/kwaai/ollama-proxy/1.0.0` protocol, so installing Ollama and pulling a model is enough.
+**Serve whole models through Ollama. Block sharding is experimental.** Sharding is the more
+ambitious mechanism — pooling a model too large for any single GPU across several machines — and
+it remains a core goal, but it is not yet dependable enough to recommend: it does not work on
+Apple Silicon at all ([#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117)), and elsewhere
+it should be treated as something to experiment with rather than rely on.
+
+Whole-model serving is the supported path, and needs no special mode: every node registers the
+`/kwaai/ollama-proxy/1.0.0` protocol on every platform, so installing Ollama and pulling a model
+is enough to contribute.
 
 On Apple Silicon the difference is stark. Measured on a Mac mini, same model, same prompt:
 
@@ -232,6 +236,14 @@ The node will connect to bootstrap peers, announce itself on the DHT, auto-detec
 > **Pre-release note (< v1.0):** `kwaainet start --daemon` automatically starts shard serving (if a local model is present) and storage serving (if storage has been initialised). This opt-out default keeps the network dense during the insider phase. Run with `--no-contribute` to start the node without contributing, or permanently disable with `kwaainet config set contribute.shards false`.
 >
 > On macOS this contributes **whole-model inference via Ollama** rather than block shards — see [Current status](#current-status).
+>
+> Note that block sharding is **experimental** but currently opt-out. On Linux/CUDA, if you would
+> rather contribute only whole models through Ollama, turn shard serving off — the node keeps
+> serving over `/kwaai/ollama-proxy/1.0.0` either way:
+>
+> ```bash
+> kwaainet config set contribute.shards false
+> ```
 
 ### 3. Call the OpenAI-compatible API
 
@@ -253,14 +265,14 @@ For a full walkthrough including platform specifics, model discovery, and Python
 ### 4. Contribute inference to the network
 
 There are two ways a node can contribute compute. **Whole-model serving through Ollama is the
-recommended default on every platform today.** Block sharding is the more ambitious mechanism —
-it pools a model too large for any single GPU across several machines — but it is only worth
-running on Linux/CUDA hardware right now.
+supported path on every platform.** **Block sharding is experimental** — it pools a model too
+large for any single GPU across several machines, which remains a core goal, but it is not yet
+dependable enough to run unattended.
 
-| Your machine | Recommended | Why |
+| Your machine | Contribute with | Why |
 |---|---|---|
-| Apple Silicon Mac | **Ollama, whole model** | Metal block sharding is ~20× slower than Ollama on the same box ([#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117)) |
-| Linux + CUDA | Either | Blocks pool VRAM across machines; Ollama is simpler and faster per node |
+| Apple Silicon Mac | **Ollama, whole model** | Block sharding does not work on Metal — ~20× slower than Ollama on the same box ([#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117)) |
+| Linux + CUDA | **Ollama, whole model** — sharding if you are experimenting | Sharding works here, but expect rough edges |
 | CPU-only or small GPU | **Ollama, small model** | A slow block server stalls every chain it joins |
 
 #### Serving whole models through Ollama (recommended)
@@ -285,7 +297,11 @@ On macOS, `kwaainet shard serve` also refuses to serve blocks and takes this pat
 from the next release — see [Current status](#current-status) for the measurements and the
 manual equivalent on v0.6.2 and earlier.
 
-#### Block sharding across machines (Linux + CUDA)
+#### Block sharding across machines (experimental, Linux + CUDA)
+
+> **Experimental.** Sharding is under active development and its behaviour changes between
+> releases. Run it if you want to help find the rough edges; do not depend on it for anything
+> that matters.
 
 Download the model, or just the blocks you intend to serve:
 
@@ -335,8 +351,8 @@ KwaaiNet is under active development. The Rust CLI and node implementation alrea
 ### Compute & inference
 
 - **Whole-model serving over Ollama** — the recommended way to contribute today. Every node registers `/kwaai/ollama-proxy/1.0.0` on every platform, serves every model held locally (the target comes from the request), and needs no special mode.
-- **Block-sharded LLM inference** (CandleEngine) exposed through an OpenAI-compatible HTTP API — SafeTensors, RoPE, GQA, SwiGLU, per-session KV-cache, full sampling controls. Best suited to Linux/CUDA today.
-- **Distributed inference across multiple machines** with session-pinned peer paths, automatic gap-filling, and graceful failover when peers go offline.
+- **Block-sharded LLM inference** (CandleEngine, **experimental**) exposed through an OpenAI-compatible HTTP API — SafeTensors, RoPE, GQA, SwiGLU, per-session KV-cache, full sampling controls. Linux/CUDA only in practice; not yet dependable enough to recommend over whole-model serving.
+- **Distributed inference across multiple machines** (experimental) with session-pinned peer paths, automatic gap-filling, and graceful failover when peers go offline.
 - **Per-platform backends**: candle + CUDA with Flash Attention on Linux (30–36 tok/s FP16 on an RTX A5000) serves block shards; Apple Silicon serves whole models through Ollama (47.3 tok/s measured on a Mac mini). Candle's Metal backend is compiled but skipped at runtime — its decode is ~10× slower than CPU — so Metal block sharding is not offered. See [Current status](#current-status).
 - Selective block download (`shard download --start-block N --blocks M`), reusable inference circuits (`shard circuit create`), and `shard run --local` model reuse for near-zero cold start.
 - Auto-detects local models and network state, and appears on the public map when configured at [map.kwaai.ai](https://map.kwaai.ai).
@@ -746,7 +762,7 @@ KwaaiNet's roadmap is defined as the **gap** between the aspirational Layer 8 ar
 | Area    | Aspirational (whitepapers)                                                                 | Current implementation (Rust node)                                       |
 |---------|--------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
 | Trust   | 5-layer trust pipeline including Testable Credentials (PVP-1) and EigenTrust propagation. | Identity + VC wallet + local time-decayed trust scores shipped; ToIP work in progress. |
-| Compute | Sharded inference, decentralized training, safe tool-calling with trust-gated policies.   | Block sharding shipped on Linux/CUDA with auto-detected GPU and a bundled CUDA runtime (no toolkit install needed); inference circuits, session-pinned paths, selective download and an OpenAI-compatible API all shipped. **Apple Silicon serves whole models via Ollama as a stopgap** — Metal block sharding is not yet viable ([#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117)). |
+| Compute | Sharded inference, decentralized training, safe tool-calling with trust-gated policies.   | **Whole-model serving over Ollama is the supported path** on every platform. **Block sharding is experimental**: it runs on Linux/CUDA with auto-detected GPU and a bundled CUDA runtime, with inference circuits, session-pinned paths, selective download and an OpenAI-compatible API — but it does not work on Apple Silicon ([#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117)) and is not yet dependable enough to rely on. |
 | Storage | Fully distributed personal AI memory via cross-node VPK sharding and DHT-backed resolution. | **VPK Phase 1 complete**: Eve nodes serve multi-tenant vector storage over `/kwaai/storage/1.0.0` libp2p RPC; Bob nodes discover Eves by PeerId via DHT; `kwaainet vpk bench` benchmarks sharded vs local vs Qdrant performance. **RAG Phase 2 complete**: local-first embedded knowledge base, hybrid BM25 (tantivy) + dense retrieval, brute-force exact search for small corpora (< 2K vectors), lost-in-the-middle context reordering, `rag destroy`, configurable chunking. HNSW tuned to m=16, ef_construction=200 (benchmarked: 97–99% recall on text embeddings at all corpus sizes up to 50K). PHE encryption (Phase 3) is next. See [VPK Shard Benchmark](docs/vpk-shard-bench/README.md) and [HNSW Parameter Study](docs/hnsw_vs_brute_force.md). |
 | Network | Intent-casting as a Layer 8 business protocol with economic settlement and neutrality guarantees. | libp2p + Kademlia DHT, trust-gated routing by model/trust/latency shipped. |
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ KwaaiNet is a decentralized AI node architecture for **Layer 8** — the trust a
 Each KwaaiNet node combines:
 
 - A **decentralized trust graph** (cryptographic identity, verifiable credentials, local trust scores).
-- **Shared, sharded LLM compute** over heterogeneous CPUs/GPUs using Petals-style distributed inference. Apple Silicon Macs use llama.cpp with Metal for 30+ tok/s local inference; Linux nodes use CUDA-accelerated block sharding.
+- **Shared, sharded LLM compute** over heterogeneous CPUs/GPUs using Petals-style distributed inference. Linux/CUDA nodes serve transformer blocks; Apple Silicon Macs serve **whole models through Ollama** — block sharding on Metal is not yet viable (see [Current status](#current-status)).
 - **Secure multi-tenant knowledge storage** via Virtual Private Knowledge (VPK) with encrypted vector search.
 - **Local-first RAG and knowledge graphs** — retrieval-augmented generation over your own documents, with an optional link to VPK for network-outsourced storage.
 - **Intent-based, peer-to-peer networking** that routes based on "what I need" (model, trust tier, latency), not just IP addresses.
@@ -15,8 +15,45 @@ From an app's point of view, KwaaiNet looks like a familiar chat-completion styl
 
 ---
 
+## Current status
+
+**Latest release: v0.6.2** (August 2026). Two things are worth knowing before you set up a node.
+
+**The networking stack is now native.** As of **v0.6.0** every node runs the in-process
+rust-libp2p stack by default; the Go `p2pd` child process is no longer required. Existing
+nodes keep working — set `native_p2p: false` in `~/.kwaainet/config.yaml` to opt out.
+
+**On Apple Silicon, serve whole models through Ollama — not block shards.** Block-sharded
+inference on Metal is not viable today, so a Mac contributing block shards makes the network
+*slower*, not faster. Measured on an Apple Silicon Mac mini, same model, same prompt:
+
+| Path | Decode |
+|---|---|
+| candle, Metal GPU | 2.3 tok/s |
+| candle, CPU (`--no-gpu`) | 4.2 tok/s |
+| **Ollama (llama.cpp + Metal)** | **47.3 tok/s** |
+
+Metal is *slower than CPU* on the candle path, so the runtime deliberately skips it — which is
+why a Mac serving blocks lands at single-digit tok/s.
+
+**From the next release**, `kwaainet shard serve` detects macOS automatically and serves whole
+models over Ollama instead of advertising a block range — nothing to pass, but Ollama must be
+installed with a model pulled. **On v0.6.2 and earlier**, a Mac still serves blocks, so stop it
+contributing shards and let Ollama do the work:
+
+```bash
+kwaainet config set contribute.shards false
+ollama pull llama3.1:8b
+```
+
+This is a **stopgap, not the fix** — see [#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117)
+for native Metal shard support. Linux/CUDA nodes are unaffected and continue to serve blocks.
+
+---
+
 ## Table of Contents
 
+- [Current status](#current-status)
 - [Why KwaaiNet?](#why-kwaainet)
 - [Quickstart: run a node and make a request](#quickstart-run-a-node-and-make-a-request)
 - [Project status: where we are now](#project-status-where-we-are-now)
@@ -138,12 +175,27 @@ kwaainet benchmark --gpu
 
 **Apple Silicon (Metal):**
 
-On macOS with a GGUF model available (via Ollama or `~/.kwaainet/models/`), the benchmark and API server automatically use llama.cpp with Metal GPU acceleration:
+`kwaainet benchmark` measures the built-in candle engine. Published binaries are compiled
+without the `llama-cpp` feature, so the benchmark falls back to candle — and candle's Metal
+backend is skipped at runtime because its decode is ~10× slower than CPU. Expect single-digit
+tok/s from this number on a Mac; it is not what your node contributes.
+
+For the throughput a Mac actually serves, measure Ollama directly — that is the path
+`kwaainet shard serve` uses on macOS:
 
 ```bash
-ollama pull llama3.1:8b    # download a GGUF model
-kwaainet benchmark         # auto-detects GGUF → 36+ tok/s via Metal
+ollama pull llama3.1:8b
+
+curl -s http://localhost:11434/api/chat -d '{
+  "model": "llama3.1:8b", "stream": false,
+  "options": {"num_ctx": 8192, "num_predict": 80},
+  "messages": [{"role": "user", "content": "Explain knowledge graphs in one paragraph."}]
+}' | python3 -c 'import json,sys; d=json.load(sys.stdin); print(f"{d["eval_count"]/(d["eval_duration"]/1e9):.1f} tok/s")'
 ```
+
+> Pin `num_ctx` explicitly. Ollama defaults to a very large context, which pushes part of the
+> model onto CPU and depresses throughput; `/v1/chat/completions` ignores `options`, so use
+> `/api/chat` when you want the setting to take effect.
 
 To check how many model blocks your hardware can serve:
 
@@ -174,6 +226,8 @@ kwaainet start --daemon
 The node will connect to bootstrap peers, announce itself on the DHT, auto-detect available hardware, and appear on [map.kwaai.ai](https://map.kwaai.ai). No Python, no build tools, no manual configuration required.
 
 > **Pre-release note (< v1.0):** `kwaainet start --daemon` automatically starts shard serving (if a local model is present) and storage serving (if storage has been initialised). This opt-out default keeps the network dense during the insider phase. Run with `--no-contribute` to start the node without contributing, or permanently disable with `kwaainet config set contribute.shards false`.
+>
+> On macOS this contributes **whole-model inference via Ollama** rather than block shards — see [Current status](#current-status).
 
 ### 3. Call the OpenAI-compatible API
 
@@ -218,11 +272,29 @@ Pinned path:
 
 Add `--stats` to see per-token timing breakdown (prefill, decode, throughput). For local-only inference without networking: `kwaainet shard run "prompt" --local`.
 
-On Apple Silicon Macs with a GGUF model (Ollama or `~/.kwaainet/models/`), inference automatically uses llama.cpp with Metal GPU acceleration (36+ tok/s). The shard API also supports this fast path:
+**On Apple Silicon, contribute whole models rather than blocks.** From the next release,
+`kwaainet shard serve` detects macOS and serves the whole model over Ollama automatically,
+rather than advertising a block range it would fill slowly (on v0.6.2 and earlier see
+[Current status](#current-status) for the manual equivalent):
 
 ```bash
-kwaainet shard api --port 8080 --ollama-model llama3.1:8b
+# Prerequisite: Ollama installed with at least one model pulled
+ollama pull llama3.1:8b
+
+kwaainet shard serve
+# 🍎 KwaaiNet Whole-Model Server (macOS)
+#   Backend: Ollama on localhost:11434
+#   ✅ Serving whole-model inference over /kwaai/ollama-proxy/1.0.0
+#   💡 This node does not advertise a block range — by design on macOS.
 ```
+
+The node serves every model Ollama has locally, not just one — the target model is taken from
+each request. If Ollama is not running the command refuses to start rather than serving
+slowly, so a node is never silently useless. To force the old block-serving path anyway, pass
+`--force-blocks`.
+
+See [Current status](#current-status) for the measurements behind this, and
+[#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117) for the real fix.
 
 See **[docs/sharded-llm-processing.md](docs/sharded-llm-processing.md)** for the full architecture of block-sharded inference, KV-cache management, and data flow diagrams.
 
@@ -243,7 +315,7 @@ KwaaiNet is under active development. The Rust CLI and node implementation alrea
 
 - **Block-sharded LLM inference** (CandleEngine) exposed through an OpenAI-compatible HTTP API — SafeTensors, RoPE, GQA, SwiGLU, per-session KV-cache, full sampling controls.
 - **Distributed inference across multiple machines** with session-pinned peer paths, automatic gap-filling, and graceful failover when peers go offline.
-- **Dual backends**: llama.cpp + Metal on Apple Silicon (36+ tok/s auto fast-path for GGUF models); candle + CUDA with Flash Attention on Linux (30–36 tok/s FP16 on an RTX A5000).
+- **Per-platform backends**: candle + CUDA with Flash Attention on Linux (30–36 tok/s FP16 on an RTX A5000) serves block shards; Apple Silicon serves whole models through Ollama (47.3 tok/s measured on a Mac mini). Candle's Metal backend is compiled but skipped at runtime — its decode is ~10× slower than CPU — so Metal block sharding is not offered. See [Current status](#current-status).
 - Selective block download (`shard download --start-block N --blocks M`), reusable inference circuits (`shard circuit create`), and `shard run --local` model reuse for near-zero cold start.
 - Auto-detects local models and network state, and appears on the public map when configured at [map.kwaai.ai](https://map.kwaai.ai).
 
@@ -262,6 +334,7 @@ KwaaiNet is under active development. The Rust CLI and node implementation alrea
 
 ### Networking
 
+- **Native rust-libp2p stack, default since v0.6.0** — the Go `p2pd` child process is no longer required. Same PeerId, same control socket, same NAT traversal (AutoNAT, circuit relay, DCUtR, UPnP) in-process. Opt out with `native_p2p: false`.
 - libp2p + Kademlia DHT swarm, Petals/Hivemind-compatible, with live diagnostics (`p2p info`, `p2p peers list/find`) and direct peer messaging (`p2p peers send`).
 - **IDENTIFY-based public-IP detection** — auto-confirms and announces a node's public address with no manual config.
 - **Trusted relays** and **stable bootstrap identities** (`start --identity-key`) so NATed and bootstrap nodes keep consistent routing and `PeerId` across restarts.
@@ -651,7 +724,7 @@ KwaaiNet's roadmap is defined as the **gap** between the aspirational Layer 8 ar
 | Area    | Aspirational (whitepapers)                                                                 | Current implementation (Rust node)                                       |
 |---------|--------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
 | Trust   | 5-layer trust pipeline including Testable Credentials (PVP-1) and EigenTrust propagation. | Identity + VC wallet + local time-decayed trust scores shipped; ToIP work in progress. |
-| Compute | Sharded inference, decentralized training, safe tool-calling with trust-gated policies.   | Dual backend: llama.cpp for 30+ tok/s local on Apple Silicon, candle for distributed block sharding on Linux/CUDA. Auto-detected GPU with bundled CUDA runtime (no toolkit install needed). Inference circuits, session-pinned paths, selective download, OpenAI-compatible API shipped. |
+| Compute | Sharded inference, decentralized training, safe tool-calling with trust-gated policies.   | Block sharding shipped on Linux/CUDA with auto-detected GPU and a bundled CUDA runtime (no toolkit install needed); inference circuits, session-pinned paths, selective download and an OpenAI-compatible API all shipped. **Apple Silicon serves whole models via Ollama as a stopgap** — Metal block sharding is not yet viable ([#117](https://github.com/Kwaai-AI-Lab/KwaaiNet/issues/117)). |
 | Storage | Fully distributed personal AI memory via cross-node VPK sharding and DHT-backed resolution. | **VPK Phase 1 complete**: Eve nodes serve multi-tenant vector storage over `/kwaai/storage/1.0.0` libp2p RPC; Bob nodes discover Eves by PeerId via DHT; `kwaainet vpk bench` benchmarks sharded vs local vs Qdrant performance. **RAG Phase 2 complete**: local-first embedded knowledge base, hybrid BM25 (tantivy) + dense retrieval, brute-force exact search for small corpora (< 2K vectors), lost-in-the-middle context reordering, `rag destroy`, configurable chunking. HNSW tuned to m=16, ef_construction=200 (benchmarked: 97–99% recall on text embeddings at all corpus sizes up to 50K). PHE encryption (Phase 3) is next. See [VPK Shard Benchmark](docs/vpk-shard-bench/README.md) and [HNSW Parameter Study](docs/hnsw_vs_brute_force.md). |
 | Network | Intent-casting as a Layer 8 business protocol with economic settlement and neutrality guarantees. | libp2p + Kademlia DHT, trust-gated routing by model/trust/latency shipped. |
 


### PR DESCRIPTION
The README told Apple Silicon users they get **30–36 tok/s from llama.cpp + Metal** in three separate places. No published binary can do that.

## Why the claim was wrong

- `llama-cpp` is not in `default = ["storage", "rag"]` (`kwaai-cli/Cargo.toml:122`)
- nothing in `.github/workflows/release.yml` enables it, so no release archive has it
- `kwaainet benchmark` therefore hits `#[cfg(not(feature = "llama-cpp"))] let ran_llama = false;` (`main.rs:1486`) and falls through to candle
- candle's Metal backend is then skipped at runtime — *"Metal GPU available but skipped (decode is 10x slower than CPU)"* (`kwaai-inference/src/lib.rs:175`)

So a stock Mac runs on CPU at single-digit tok/s, while the README promised 36+.

## What the hardware actually does

Measured on an Apple Silicon Mac mini, same model, same prompt:

| Path | Decode |
|---|---|
| candle, Metal GPU | 2.3 tok/s |
| candle, CPU | 4.2 tok/s |
| **Ollama (llama.cpp + Metal)** | **47.3 tok/s** |

A Mac contributing block shards makes the network **slower**, not faster.

## Changes

- New **Current status** section: the v0.6.0 native-libp2p cutover, and the Apple Silicon guidance with the measurements above
- Header bullet, Quickstart §4, benchmark instructions, project status and roadmap row all corrected to match what the code does
- Benchmark guidance now measures Ollama directly, since that is the path a Mac actually serves on

## Accuracy about what has shipped

The macOS auto-detection is #126 — **merged but not released**. Rather than claim v0.6.2 does something it doesn't, the guidance reads "from the next release" and gives the manual equivalent for current users:

```bash
kwaainet config set contribute.shards false
ollama pull llama3.1:8b
```

`contribute.shards` verified as a real key (`config.rs:1046`); `--force-blocks` verified against `shard serve --help`.

## Verification

The documented benchmark snippet was run against a live Ollama and returns **46.8 tok/s**, consistent with the table. It pins `num_ctx` on `/api/chat` deliberately — `/v1/chat/completions` ignores `options`, and leaving the context at Ollama's default pushes part of the model onto CPU and depresses throughput.

Code fences balanced; no stale `36+ tok/s` / `30+ tok/s` / `Dual backend` claims remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP