### PR TITLE
feat(rpc): whole-network peer view and dial-a-known-peer over the Session stream

### DIFF
--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1314,8 +1314,11 @@ fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
             // Every field a client renders per row *except* rtt_ms — see the
             // type comment. Protocols are joined rather than nested so the
             // whole row stays one comparable string.
+            // `dcutr` is in here deliberately: an upgrade flips a connection
+            // from relayed to direct, which is exactly the kind of change the
+            // user is watching this page for.
             format!(
-                "{}|{}|{}|{}|{}|{}|{}|{}",
+                "{}|{}|{}|{}|{}|{}|{}|{}|{}",
                 p.peer_id,
                 p.addr,
                 p.kind,
@@ -1324,13 +1327,14 @@ fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
                 p.is_trusted_relay,
                 p.protocols.join(","),
                 p.agent_version,
+                p.dcutr,
             )
         })
         .collect();
     let routing = u
         .routing
         .iter()
-        .map(|r| format!("{}|{}", r.peer_id, r.connected))
+        .map(|r| format!("{}|{}|{}", r.peer_id, r.connected, r.is_bootstrap))
         .collect();
 
     (
@@ -1564,6 +1568,7 @@ fn build_network_update(
                     .map(|d| d.as_millis().min(u32::MAX as u128) as u32)
                     .unwrap_or(0),
                 agent_version: p.agent_version.clone().unwrap_or_default(),
+                dcutr: p.dcutr,
             };
             (
                 group_index(is_bootstrap, is_trusted_relay, kind),
@@ -1583,6 +1588,7 @@ fn build_network_update(
         .map(|p| RoutingPeer {
             peer_id: p.to_base58(),
             connected: connected_ids.contains(p),
+            is_bootstrap: bootstraps.contains(p),
         })
         .collect();
     routing.sort_by(|a, b| a.peer_id.cmp(&b.peer_id));
@@ -2425,6 +2431,7 @@ mod tests {
             protocols: vec!["/ipfs/kad/1.0.0".into()],
             rtt_ms: 10,
             agent_version: "kwaainet/0.5.4".into(),
+            dcutr: false,
         }
     }
 
@@ -2516,8 +2523,38 @@ mod tests {
         routed.routing = vec![RoutingPeer {
             peer_id: "A".into(),
             connected: true,
+            is_bootstrap: false,
         }];
         assert_ne!(network_identity(&a), network_identity(&routed));
+
+        // A DCUtR upgrade. The connection was already direct in `kind` terms
+        // by the time dcutr reports, so without this field in the identity the
+        // upgrade would be suppressed and never reach the client — despite
+        // being one of the most interesting things that can happen here.
+        let mut upgraded_peer = net_peer("A");
+        upgraded_peer.dcutr = true;
+        assert_ne!(
+            network_identity(&a),
+            network_identity(&net_update("2026-01-01T00:00:00Z", vec![upgraded_peer]))
+        );
+
+        // A routing peer being recognised as a bootstrap.
+        let mut bootstrap_routed = a.clone();
+        bootstrap_routed.routing = vec![RoutingPeer {
+            peer_id: "A".into(),
+            connected: false,
+            is_bootstrap: true,
+        }];
+        let mut plain_routed = a.clone();
+        plain_routed.routing = vec![RoutingPeer {
+            peer_id: "A".into(),
+            connected: false,
+            is_bootstrap: false,
+        }];
+        assert_ne!(
+            network_identity(&bootstrap_routed),
+            network_identity(&plain_routed)
+        );
     }
 
     /// Address churn is not a reachability change. `observed_addrs` moves as

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1346,7 +1346,20 @@ fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
     let routing = u
         .routing
         .iter()
-        .map(|r| format!("{}|{}|{}", r.peer_id, r.connected, r.is_bootstrap))
+        .map(|r| {
+            // Addresses are part of the identity: an entry losing its last
+            // dialable address is a real change of state, and omitting them
+            // here would suppress the update that reports it.
+            let mut addrs: Vec<&str> = r.addrs.iter().map(String::as_str).collect();
+            addrs.sort_unstable();
+            format!(
+                "{}|{}|{}|{}",
+                r.peer_id,
+                r.connected,
+                r.is_bootstrap,
+                addrs.join(",")
+            )
+        })
         .collect();
 
     (
@@ -1654,9 +1667,10 @@ fn build_network_update(
         .routing
         .iter()
         .map(|p| RoutingPeer {
-            peer_id: p.to_base58(),
-            connected: connected_ids.contains(p),
-            is_bootstrap: bootstraps.contains(p),
+            peer_id: p.peer_id.to_base58(),
+            connected: connected_ids.contains(&p.peer_id),
+            is_bootstrap: bootstraps.contains(&p.peer_id),
+            addrs: p.addrs.iter().map(|a| a.to_string()).collect(),
         })
         .collect();
     routing.sort_by(|a, b| a.peer_id.cmp(&b.peer_id));
@@ -2595,8 +2609,25 @@ mod tests {
             peer_id: "A".into(),
             connected: true,
             is_bootstrap: false,
+            addrs: vec![],
         }];
         assert_ne!(network_identity(&a), network_identity(&routed));
+
+        // An entry losing its last dialable address is a state change worth
+        // pushing: the peer goes from "reachable, just not connected" to
+        // "known but undialable", which is what the addrs field exists to
+        // distinguish. Suppressing it would leave the view claiming the
+        // former while the latter is true.
+        let mut addressed = a.clone();
+        addressed.routing = vec![RoutingPeer {
+            peer_id: "A".into(),
+            connected: false,
+            is_bootstrap: false,
+            addrs: vec!["/ip4/198.18.0.32/tcp/8080".into()],
+        }];
+        let mut stripped = addressed.clone();
+        stripped.routing[0].addrs.clear();
+        assert_ne!(network_identity(&addressed), network_identity(&stripped));
 
         // A DCUtR upgrade. The connection was already direct in `kind` terms
         // by the time dcutr reports, so without this field in the identity the
@@ -2636,12 +2667,14 @@ mod tests {
             peer_id: "A".into(),
             connected: false,
             is_bootstrap: true,
+            addrs: vec![],
         }];
         let mut plain_routed = a.clone();
         plain_routed.routing = vec![RoutingPeer {
             peer_id: "A".into(),
             connected: false,
             is_bootstrap: false,
+            addrs: vec![],
         }];
         assert_ne!(
             network_identity(&bootstrap_routed),

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1616,7 +1616,8 @@ fn build_network_update(
     trusted_relays: &std::collections::HashSet<libp2p::PeerId>,
     reason: UpdateReason,
 ) -> NetworkUpdate {
-    use crate::peers_view::{classify_addr, group_index, ConnKind};
+    use crate::peers_view::{classify_addr, dht_role, group_index, ConnKind, DhtRole};
+    use kwaai_rpc::v1::DhtRole as WireDhtRole;
 
     let connected_ids: std::collections::HashSet<libp2p::PeerId> =
         snapshot.peers.iter().map(|p| p.peer_id).collect();
@@ -1650,6 +1651,11 @@ fn build_network_update(
                 agent_version: p.agent_version.clone().unwrap_or_default(),
                 via: p.via.as_ref().map(|a| a.to_string()).unwrap_or_default(),
                 dcutr: p.dcutr,
+                dht_role: match dht_role(&p.protocols) {
+                    DhtRole::Server => WireDhtRole::Server as i32,
+                    DhtRole::Client => WireDhtRole::Client as i32,
+                    DhtRole::Unknown => WireDhtRole::Unknown as i32,
+                },
             };
             (
                 group_index(is_bootstrap, is_trusted_relay, kind),
@@ -2516,6 +2522,8 @@ mod tests {
             agent_version: "kwaainet/0.5.4".into(),
             via: String::new(),
             dcutr: false,
+            // Consistent with the kad entry in `protocols` above.
+            dht_role: kwaai_rpc::v1::DhtRole::Server as i32,
         }
     }
 

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -45,10 +45,10 @@ use kwaai_rpc::v1::{
     error::Code as ErrorCode,
     kwaai_net_server::{KwaaiNet, KwaaiNetServer},
     server_frame, BlockCoverageRequest, BlockCoverageUpdate, BlockPeer, Cancel, ChatMessage,
-    ChatToken, ClientFrame, ConnectedPeer, Done, Error as RpcError, GenerateRequest,
-    NetworkRequest, NetworkUpdate, PeerConnKind, PingReply, PingRequest, RoutingPeer, SelfStatus,
-    ServerFrame, ShardRunRequest, StatusReply, StorageDiscoveryRequest, StoragePeer,
-    StorageReachability, StorageUpdate, UpdateReason,
+    ChatToken, ClientFrame, ConnectReply, ConnectRequest, ConnectedPeer, Done, Error as RpcError,
+    GenerateRequest, NetworkRequest, NetworkUpdate, PeerConnKind, PingReply, PingRequest,
+    RoutingPeer, SelfStatus, ServerFrame, ShardRunRequest, StatusReply, StorageDiscoveryRequest,
+    StoragePeer, StorageReachability, StorageUpdate, UpdateReason,
 };
 use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -325,6 +325,10 @@ impl KwaaiNet for KwaaiNetService {
                             cancels.clone(),
                         )
                         .await;
+                    }
+
+                    client_frame::Body::Connect(req) => {
+                        spawn_session_connect(id, req, net_slot.clone(), out_tx.clone()).await;
                     }
 
                     client_frame::Body::Cancel(Cancel { target_id }) => {
@@ -1533,6 +1537,58 @@ async fn spawn_session_network(
         }
 
         cancels_for_cleanup.lock().await.remove(&id);
+    });
+}
+
+/// `ConnectRequest` — dial a peer we know of but are not connected to.
+///
+/// One-shot: a reply then Done, with no subscription to manage. The dial
+/// itself can take a while (a DHT lookup, then the dial), so it runs in its
+/// own task rather than blocking the session loop.
+async fn spawn_session_connect(
+    id: u64,
+    req: ConnectRequest,
+    net: Arc<RwLock<Option<NetworkHandle>>>,
+    out_tx: mpsc::Sender<Result<ServerFrame, Status>>,
+) {
+    tokio::spawn(async move {
+        let Some(handle) = net.read().await.clone() else {
+            let _ = out_tx
+                .send(Ok(error_frame(
+                    id,
+                    ErrorCode::Unimplemented,
+                    "connect requires the native p2p stack",
+                )))
+                .await;
+            return;
+        };
+
+        // A bare `/p2p/<id>` has no transport, which is precisely what makes
+        // the handle resolve it through the DHT rather than dial an address.
+        let reply = match handle.connect_peer(&format!("/p2p/{}", req.peer_id)).await {
+            Ok(_) => ConnectReply {
+                connected: true,
+                error: String::new(),
+            },
+            // Already connected is success: the caller wanted a connection to
+            // this peer and there is one.
+            Err(kwaai_p2p::P2PError::AlreadyConnected) => ConnectReply {
+                connected: true,
+                error: String::new(),
+            },
+            Err(e) => ConnectReply {
+                connected: false,
+                error: e.to_string(),
+            },
+        };
+
+        let _ = out_tx
+            .send(Ok(ServerFrame {
+                id,
+                body: Some(server_frame::Body::Connect(reply)),
+            }))
+            .await;
+        let _ = out_tx.send(Ok(done_frame(id))).await;
     });
 }
 

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1325,7 +1325,7 @@ fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
             // from relayed to direct, which is exactly the kind of change the
             // user is watching this page for.
             format!(
-                "{}|{}|{}|{}|{}|{}|{}|{}|{}",
+                "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
                 p.peer_id,
                 p.addr,
                 p.kind,
@@ -1334,6 +1334,7 @@ fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
                 p.is_trusted_relay,
                 p.protocols.join(","),
                 p.agent_version,
+                p.via,
                 p.dcutr,
             )
         })
@@ -1578,6 +1579,7 @@ fn build_network_update(
                     .map(|d| d.as_millis().min(u32::MAX as u128) as u32)
                     .unwrap_or(0),
                 agent_version: p.agent_version.clone().unwrap_or_default(),
+                via: p.via.as_ref().map(|a| a.to_string()).unwrap_or_default(),
                 dcutr: p.dcutr,
             };
             (
@@ -2442,6 +2444,7 @@ mod tests {
             protocols: vec!["/ipfs/kad/1.0.0".into()],
             rtt_ms: 10,
             agent_version: "kwaainet/0.5.4".into(),
+            via: String::new(),
             dcutr: false,
         }
     }
@@ -2548,6 +2551,16 @@ mod tests {
         assert_ne!(
             network_identity(&a),
             network_identity(&net_update("2026-01-01T00:00:00Z", vec![upgraded_peer]))
+        );
+
+        // The relay an inbound connection arrives through. A peer moving from
+        // one relay to another is a real change in how we reach it, and the
+        // view shows it, so it must not be suppressed.
+        let mut via_changed = net_peer("A");
+        via_changed.via = "/ip4/1.2.3.4/tcp/1/p2p/QmRelay/p2p-circuit".into();
+        assert_ne!(
+            network_identity(&a),
+            network_identity(&net_update("2026-01-01T00:00:00Z", vec![via_changed]))
         );
 
         // Registering a handler changes what this node serves, and the view

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -32,20 +32,25 @@
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
 use tonic::{transport::Server, Request, Response, Status, Streaming};
 use tracing::{error, info, warn};
 
+use kwaai_p2p::{
+    reachability::{Reachability, Source},
+    NetworkHandle,
+};
 use kwaai_rpc::v1::{
     client_frame,
     error::Code as ErrorCode,
     kwaai_net_server::{KwaaiNet, KwaaiNetServer},
     server_frame, BlockCoverageRequest, BlockCoverageUpdate, BlockPeer, Cancel, ChatMessage,
-    ChatToken, ClientFrame, Done, Error as RpcError, GenerateRequest, PingReply, PingRequest,
+    ChatToken, ClientFrame, ConnectedPeer, Done, Error as RpcError, GenerateRequest,
+    NetworkRequest, NetworkUpdate, PeerConnKind, PingReply, PingRequest, RoutingPeer, SelfStatus,
     ServerFrame, ShardRunRequest, StatusReply, StorageDiscoveryRequest, StoragePeer,
-    StorageReachability, StorageUpdate,
+    StorageReachability, StorageUpdate, UpdateReason,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -84,6 +89,14 @@ struct InferenceState {
 pub struct KwaaiNetService {
     config: Arc<KwaaiNetConfig>,
     inference: Arc<Mutex<Option<Arc<Mutex<InferenceState>>>>>,
+    /// The native swarm handle, filled in once the p2p node is up.
+    ///
+    /// Late-bound because `spawn` runs before the node starts — deliberately,
+    /// so ping/status/generate answer while p2p is still coming up. Empty
+    /// therefore means one of two things, and the Network op distinguishes
+    /// them: the node has not started yet (transient), or this daemon is
+    /// running the Go p2p path and never will (permanent).
+    net: Arc<RwLock<Option<NetworkHandle>>>,
     /// Captured at service construction so StatusReply.uptime_secs can
     /// report a process-level uptime without a separate clock.
     started_at: Instant,
@@ -94,6 +107,7 @@ impl KwaaiNetService {
         Self {
             config: Arc::new(config),
             inference: Arc::new(Mutex::new(None)),
+            net: Arc::new(RwLock::new(None)),
             started_at: Instant::now(),
         }
     }
@@ -184,6 +198,7 @@ impl KwaaiNet for KwaaiNetService {
         // Clone the bits each per-frame task captures.
         let cfg = self.config.clone();
         let inference_slot = self.inference.clone();
+        let net_slot = self.net.clone();
         let started_at = self.started_at;
 
         tokio::spawn(async move {
@@ -229,11 +244,24 @@ impl KwaaiNet for KwaaiNetService {
                     }
 
                     client_frame::Body::Status(_) => {
+                        // Routing-table size, matching the field's documented
+                        // meaning. 0 when the swarm is not up yet, or on the Go
+                        // p2p path where there is no handle to ask — the same
+                        // value this reported unconditionally before.
+                        let peer_count = match net_slot.read().await.clone() {
+                            Some(handle) => handle
+                                .routing_peers()
+                                .await
+                                .map(|p| p.len() as u32)
+                                .unwrap_or(0),
+                            None => 0,
+                        };
+
                         let reply = StatusReply {
                             server_time: now_rfc3339(),
                             model: cfg.model.clone(),
                             shard_ready: shard_ready_path_exists(),
-                            peer_count: 0, // TODO: thread through DHT routing-table size
+                            peer_count,
                             uptime_secs: started_at.elapsed().as_secs(),
                             // Same constant the updater compares against, so
                             // the version reported over the wire can never
@@ -280,6 +308,18 @@ impl KwaaiNet for KwaaiNetService {
                         spawn_session_storage_discovery(
                             id,
                             req,
+                            cfg.clone(),
+                            out_tx.clone(),
+                            cancels.clone(),
+                        )
+                        .await;
+                    }
+
+                    client_frame::Body::Network(req) => {
+                        spawn_session_network(
+                            id,
+                            req,
+                            net_slot.clone(),
                             cfg.clone(),
                             out_tx.clone(),
                             cancels.clone(),
@@ -1244,6 +1284,354 @@ async fn probe_storage_peers(client: &kwaai_p2p_daemon::P2PClient, peers: &mut [
     }
 }
 
+/// Default refresh cadence for a Network subscription, in seconds.
+///
+/// Faster than the two DHT-backed ops because a snapshot is a read of local
+/// swarm state — one trip through the event loop, no network. The cost of a
+/// tick is low enough that the interesting question is how quickly a
+/// connect/disconnect should surface, and 5s is about the limit of what feels
+/// live.
+const DEFAULT_NETWORK_INTERVAL_SECS: u64 = 5;
+
+/// The comparable content of a [`NetworkUpdate`].
+///
+/// Deliberately excludes `server_time` (moves every tick), `reason` (describes
+/// *why* we are sending, not what changed) and — critically — `rtt_ms`, which
+/// jitters on every ping and would defeat suppression entirely, turning a quiet
+/// node into a 5-second frame generator.
+///
+/// Connections are compared as a set: the swarm iterates a `HashMap`, so
+/// ordering is arbitrary and a pure reordering is not a change worth waking the
+/// UI for. The routing table is compared the same way.
+type NetworkIdentity = (String, bool, bool, BTreeSet<String>, BTreeSet<String>);
+
+fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
+    let self_status = u.self_status.clone().unwrap_or_default();
+    let connected = u
+        .connected
+        .iter()
+        .map(|p| {
+            // Every field a client renders per row *except* rtt_ms — see the
+            // type comment. Protocols are joined rather than nested so the
+            // whole row stays one comparable string.
+            format!(
+                "{}|{}|{}|{}|{}|{}|{}|{}",
+                p.peer_id,
+                p.addr,
+                p.kind,
+                p.direction,
+                p.is_bootstrap,
+                p.is_trusted_relay,
+                p.protocols.join(","),
+                p.agent_version,
+            )
+        })
+        .collect();
+    let routing = u
+        .routing
+        .iter()
+        .map(|r| format!("{}|{}", r.peer_id, r.connected))
+        .collect();
+
+    (
+        self_status.reachability,
+        self_status.using_relay,
+        self_status.announceable,
+        connected,
+        routing,
+    )
+}
+
+/// `NetworkRequest` — local swarm state, sampled and pushed.
+///
+/// Two things distinguish this from its DHT-backed siblings. First, it needs
+/// the native swarm: an empty handle slot is answered with a typed error rather
+/// than a blank view (see [`KwaaiNetService::net`]). Second, it is not purely
+/// polled — reachability is a real event source, so the loop waits on the
+/// announce watch channel alongside the interval timer and reports which one
+/// woke it in `NetworkUpdate.reason`.
+async fn spawn_session_network(
+    id: u64,
+    req: NetworkRequest,
+    net: Arc<RwLock<Option<NetworkHandle>>>,
+    cfg: Arc<KwaaiNetConfig>,
+    out_tx: mpsc::Sender<Result<ServerFrame, Status>>,
+    cancels: Arc<Mutex<HashMap<u64, oneshot::Sender<()>>>>,
+) {
+    // Register the cancel channel up-front so a Cancel arriving immediately
+    // after this frame still finds an entry to fire.
+    let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+    cancels.lock().await.insert(id, cancel_tx);
+
+    let cancels_for_cleanup = cancels.clone();
+    tokio::spawn(async move {
+        use std::time::Duration;
+
+        // Resolve the handle once. The slot is filled during node startup and
+        // never cleared, so a subscription that finds it empty would spin
+        // forever — better to say so immediately and let the client decide.
+        let handle = match net.read().await.clone() {
+            Some(h) => h,
+            None => {
+                // Two very different situations, and the client acts on them
+                // differently: on the Go p2p path the slot is never filled, so
+                // retrying is pointless; during native startup it is about to
+                // be, so retrying is exactly right.
+                let (code, msg) = if cfg.native_p2p() {
+                    (
+                        ErrorCode::Unavailable,
+                        "p2p node is still starting; retry shortly",
+                    )
+                } else {
+                    // UNIMPLEMENTED, not UNAVAILABLE: on the Go p2p path this
+                    // operation is not merely down, it is absent, and the slot
+                    // will never fill. A client that retries UNAVAILABLE would
+                    // do so forever.
+                    (
+                        ErrorCode::Unimplemented,
+                        "network view requires the native p2p stack \
+                         (`kwaainet config set native_p2p true`)",
+                    )
+                };
+                let _ = out_tx.send(Ok(error_frame(id, code, msg))).await;
+                cancels_for_cleanup.lock().await.remove(&id);
+                return;
+            }
+        };
+
+        let interval = if req.interval_secs > 0 {
+            req.interval_secs as u64
+        } else {
+            DEFAULT_NETWORK_INTERVAL_SECS
+        };
+
+        let bootstraps = crate::peers_view::bootstrap_peer_ids();
+        let trusted_relays = crate::peers_view::trusted_relay_peer_ids();
+
+        // The reachability event source. `changed()` fires only on a genuine
+        // change — address churn and repeated identifies do not move it — so
+        // this arm cannot become chatty.
+        let mut announce_rx = handle.announce_state();
+
+        let mut last_sent: Option<NetworkIdentity> = None;
+        let mut last_send_at: Option<std::time::Instant> = None;
+        // Why we are building this particular snapshot. The first one is a
+        // plain sample; later iterations set it from whichever select! arm won.
+        let mut reason = UpdateReason::Tick;
+
+        loop {
+            let snapshot = match handle.network_snapshot().await {
+                Ok(s) => s,
+                Err(e) => {
+                    // The swarm is gone (shutdown, or the service task died).
+                    // Nothing a retry can fix, so end the operation rather than
+                    // looping on a dead handle.
+                    let _ = out_tx
+                        .send(Ok(error_frame(
+                            id,
+                            ErrorCode::Unavailable,
+                            &format!("network snapshot failed: {e}"),
+                        )))
+                        .await;
+                    break;
+                }
+            };
+
+            let update = build_network_update(&snapshot, &bootstraps, &trusted_relays, reason);
+
+            // Same change/heartbeat contract as block coverage: suppress
+            // snapshots that would tell the client nothing, but never go
+            // silent for longer than HEARTBEAT, so silence stays readable as
+            // "nothing changed" rather than "the daemon wedged".
+            //
+            // A reachability wake-up bypasses the suppression check entirely.
+            // It is an event, and the whole reason for the watch arm is that
+            // the client should see it immediately.
+            let identity = network_identity(&update);
+            let changed = last_sent.as_ref() != Some(&identity);
+            let heartbeat_due = last_send_at
+                .map(|t: std::time::Instant| t.elapsed() >= HEARTBEAT)
+                .unwrap_or(true);
+            let is_event = reason == UpdateReason::Reachability;
+
+            if changed || heartbeat_due || is_event || !req.subscribe {
+                // A tick that changed nothing and is only going out to prove
+                // liveness says so, rather than masquerading as fresh news.
+                let update = if !changed && !is_event && req.subscribe {
+                    NetworkUpdate {
+                        reason: UpdateReason::Heartbeat as i32,
+                        ..update
+                    }
+                } else if changed && reason == UpdateReason::Tick && req.subscribe {
+                    // A sampled tick that *did* change is a peer-set change:
+                    // reachability changes arrive on the other arm.
+                    NetworkUpdate {
+                        reason: UpdateReason::Peers as i32,
+                        ..update
+                    }
+                } else {
+                    update
+                };
+
+                last_sent = Some(identity);
+                last_send_at = Some(std::time::Instant::now());
+
+                let frame = ServerFrame {
+                    id,
+                    body: Some(server_frame::Body::Network(update)),
+                };
+                if out_tx.send(Ok(frame)).await.is_err() {
+                    break; // client went away
+                }
+            }
+
+            if !req.subscribe {
+                let _ = out_tx.send(Ok(done_frame(id))).await;
+                break;
+            }
+
+            tokio::select! {
+                _ = &mut cancel_rx => {
+                    let _ = out_tx
+                        .send(Ok(error_frame(
+                            id,
+                            ErrorCode::Cancelled,
+                            "cancelled by client",
+                        )))
+                        .await;
+                    break;
+                }
+                // Reachability moved. Rebuild immediately rather than waiting
+                // out the remaining interval — a NAT transition is exactly the
+                // thing a user is watching this page for.
+                changed = announce_rx.changed() => {
+                    if changed.is_err() {
+                        // Sender dropped: the swarm is shutting down.
+                        break;
+                    }
+                    reason = UpdateReason::Reachability;
+                }
+                _ = tokio::time::sleep(Duration::from_secs(interval)) => {
+                    reason = UpdateReason::Tick;
+                }
+            }
+        }
+
+        cancels_for_cleanup.lock().await.remove(&id);
+    });
+}
+
+/// Project a [`kwaai_p2p::NetworkSnapshot`] onto the wire type.
+///
+/// Classification (relay-vs-direct, bootstrap, trusted-relay) and the sort
+/// order come from [`crate::peers_view`], shared with `kwaainet p2p peers
+/// list` so both surfaces describe the same network the same way.
+fn build_network_update(
+    snapshot: &kwaai_p2p::NetworkSnapshot,
+    bootstraps: &std::collections::HashSet<libp2p::PeerId>,
+    trusted_relays: &std::collections::HashSet<libp2p::PeerId>,
+    reason: UpdateReason,
+) -> NetworkUpdate {
+    use crate::peers_view::{classify_addr, group_index, ConnKind};
+
+    let connected_ids: std::collections::HashSet<libp2p::PeerId> =
+        snapshot.peers.iter().map(|p| p.peer_id).collect();
+
+    let mut connected: Vec<(u8, String, ConnectedPeer)> = snapshot
+        .peers
+        .iter()
+        .map(|p| {
+            let kind = classify_addr(&p.addr);
+            let is_bootstrap = bootstraps.contains(&p.peer_id);
+            let is_trusted_relay = trusted_relays.contains(&p.peer_id);
+            let peer_id = p.peer_id.to_base58();
+
+            let wire = ConnectedPeer {
+                peer_id: peer_id.clone(),
+                addr: p.addr.to_string(),
+                kind: match kind {
+                    ConnKind::Direct => PeerConnKind::Direct as i32,
+                    ConnKind::Relay => PeerConnKind::Relay as i32,
+                },
+                direction: p.direction.as_str().to_string(),
+                is_bootstrap,
+                is_trusted_relay,
+                protocols: p.protocols.clone(),
+                // Saturating rather than wrapping: an absurd RTT should show as
+                // "very large", never as a small number.
+                rtt_ms: p
+                    .rtt
+                    .map(|d| d.as_millis().min(u32::MAX as u128) as u32)
+                    .unwrap_or(0),
+                agent_version: p.agent_version.clone().unwrap_or_default(),
+            };
+            (
+                group_index(is_bootstrap, is_trusted_relay, kind),
+                peer_id,
+                wire,
+            )
+        })
+        .collect();
+
+    // Stable across polls: group, then peer id. An unstable order makes a live
+    // view flicker as rows swap under the user.
+    connected.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let mut routing: Vec<RoutingPeer> = snapshot
+        .routing
+        .iter()
+        .map(|p| RoutingPeer {
+            peer_id: p.to_base58(),
+            connected: connected_ids.contains(p),
+        })
+        .collect();
+    routing.sort_by(|a, b| a.peer_id.cmp(&b.peer_id));
+
+    // Spelled out rather than derived from Debug: these strings are wire
+    // contract (documented in kwaai.proto and matched by the GUI), so they must
+    // not follow a Rust variant rename.
+    let (reachability, reachability_source) = match &snapshot.reachability {
+        Reachability::Unknown => ("unknown", ""),
+        Reachability::Public { source, .. } => (
+            "public",
+            match source {
+                Source::IdentifyConsensus => "identify",
+                Source::Upnp => "upnp",
+                Source::AutoNat => "autonat",
+                Source::Declared => "declared",
+            },
+        ),
+        Reachability::Private => ("private", ""),
+    };
+
+    NetworkUpdate {
+        server_time: now_rfc3339(),
+        reason: reason as i32,
+        self_status: Some(SelfStatus {
+            peer_id: snapshot.local_peer_id.to_base58(),
+            reachability: reachability.to_string(),
+            reachability_source: reachability_source.to_string(),
+            using_relay: !snapshot.relay_addrs.is_empty(),
+            // Mirrors the announce loop's own gate: a node that does not know
+            // where it stands should not be telling the network it is direct.
+            announceable: !matches!(snapshot.reachability, Reachability::Unknown),
+            listen_addrs: snapshot
+                .listen_addrs
+                .iter()
+                .map(|a| a.to_string())
+                .collect(),
+            observed_addrs: snapshot
+                .observed_addrs
+                .iter()
+                .map(|(a, _)| a.to_string())
+                .collect(),
+            relay_addrs: snapshot.relay_addrs.iter().map(|a| a.to_string()).collect(),
+        }),
+        connected: connected.into_iter().map(|(_, _, w)| w).collect(),
+        routing,
+    }
+}
+
 /// Free-function variant of `KwaaiNetService::get_or_init_inference` so
 /// session worker tasks can call it without holding a `&self` borrow.
 async fn get_or_init_inference(
@@ -1445,6 +1833,7 @@ pub(crate) fn spawn_on_tcp_port(config: KwaaiNetConfig, tcp_port: u16) -> GrpcSe
     let (shutdown_unix_tx, shutdown_unix_rx) = oneshot::channel::<()>();
 
     let svc_state = KwaaiNetService::new(config);
+    let net_slot = svc_state.net.clone();
     let service = KwaaiNetServer::new(svc_state);
 
     // TCP: every platform.
@@ -1478,6 +1867,7 @@ pub(crate) fn spawn_on_tcp_port(config: KwaaiNetConfig, tcp_port: u16) -> GrpcSe
             shutdown_tcp: Some(shutdown_tcp_tx),
             #[cfg(unix)]
             shutdown_unix: Some(shutdown_unix_tx),
+            net: net_slot,
         }
     }
     #[cfg(not(unix))]
@@ -1537,9 +1927,22 @@ pub struct GrpcServerHandle {
     shutdown_tcp: Option<oneshot::Sender<()>>,
     #[cfg(unix)]
     shutdown_unix: Option<oneshot::Sender<()>>,
+    /// The service's swarm-handle slot, shared so the node can fill it once
+    /// p2p is up. See [`GrpcServerHandle::attach_network`].
+    net: Arc<RwLock<Option<NetworkHandle>>>,
 }
 
 impl GrpcServerHandle {
+    /// Hand the running swarm to the gRPC service.
+    ///
+    /// Until this is called the Network op reports that it has nothing to
+    /// serve. Only the native p2p path calls it; on the Go daemon path the
+    /// slot stays empty for the process's lifetime, which is what makes
+    /// "unsupported" distinguishable from "still starting".
+    pub async fn attach_network(&self, handle: NetworkHandle) {
+        *self.net.write().await = Some(handle);
+    }
+
     /// Trigger a graceful shutdown of both transports. Safe to call multiple
     /// times; subsequent calls are no-ops.
     pub fn shutdown(&mut self) {
@@ -2010,5 +2413,122 @@ mod tests {
         retiered_peer.trust_tier = "TRUSTED".into();
         let retiered = update("2026-01-01T00:00:05Z", vec![peer("A", 0, 4), retiered_peer]);
         assert_ne!(coverage_identity(&a), coverage_identity(&retiered));
+    }
+    fn net_peer(id: &str) -> ConnectedPeer {
+        ConnectedPeer {
+            peer_id: id.to_string(),
+            addr: "/ip4/198.18.0.10/tcp/8000".into(),
+            kind: PeerConnKind::Direct as i32,
+            direction: "outbound".into(),
+            is_bootstrap: false,
+            is_trusted_relay: false,
+            protocols: vec!["/ipfs/kad/1.0.0".into()],
+            rtt_ms: 10,
+            agent_version: "kwaainet/0.5.4".into(),
+        }
+    }
+
+    fn net_update(time: &str, peers: Vec<ConnectedPeer>) -> NetworkUpdate {
+        NetworkUpdate {
+            server_time: time.to_string(),
+            reason: UpdateReason::Tick as i32,
+            self_status: Some(SelfStatus {
+                peer_id: "12D3KooWSelf".into(),
+                reachability: "public".into(),
+                reachability_source: "autonat".into(),
+                using_relay: false,
+                announceable: true,
+                listen_addrs: vec!["/ip4/0.0.0.0/tcp/4001".into()],
+                observed_addrs: vec![],
+                relay_addrs: vec![],
+            }),
+            connected: peers,
+            routing: vec![],
+        }
+    }
+
+    /// The suppression contract. If any of these trip, a quiet node turns into
+    /// a frame generator (or, worse, a changing one goes silent).
+    #[test]
+    fn network_identity_ignores_time_reason_and_rtt() {
+        let a = net_update("2026-01-01T00:00:00Z", vec![net_peer("A"), net_peer("B")]);
+
+        // server_time advances every tick by construction.
+        let later = net_update("2026-01-01T00:00:05Z", vec![net_peer("A"), net_peer("B")]);
+        assert_eq!(network_identity(&a), network_identity(&later));
+
+        // `reason` says why we are sending, not what changed. If it counted,
+        // a heartbeat would look like news.
+        let mut different_reason = later.clone();
+        different_reason.reason = UpdateReason::Heartbeat as i32;
+        assert_eq!(network_identity(&a), network_identity(&different_reason));
+
+        // RTT is the important one: it moves on every ping, for every peer.
+        // Counting it would defeat suppression entirely.
+        let mut jittery = net_peer("A");
+        jittery.rtt_ms = 999;
+        let rtt_moved = net_update("2026-01-01T00:00:05Z", vec![jittery, net_peer("B")]);
+        assert_eq!(network_identity(&a), network_identity(&rtt_moved));
+
+        // The swarm iterates a HashMap, so connection order is arbitrary.
+        let reordered = net_update("2026-01-01T00:00:05Z", vec![net_peer("B"), net_peer("A")]);
+        assert_eq!(network_identity(&a), network_identity(&reordered));
+    }
+
+    /// The converse: everything a client actually renders must count.
+    #[test]
+    fn network_identity_tracks_rendered_fields() {
+        let a = net_update("2026-01-01T00:00:00Z", vec![net_peer("A")]);
+
+        // A peer joining or leaving.
+        let joined = net_update("2026-01-01T00:00:00Z", vec![net_peer("A"), net_peer("B")]);
+        assert_ne!(network_identity(&a), network_identity(&joined));
+
+        // A hole-punch upgrade: same peer, relayed path becomes direct.
+        let mut upgraded = net_peer("A");
+        upgraded.kind = PeerConnKind::Relay as i32;
+        assert_ne!(
+            network_identity(&a),
+            network_identity(&net_update("2026-01-01T00:00:00Z", vec![upgraded]))
+        );
+
+        // Identify landing after the connection established.
+        let mut identified = net_peer("A");
+        identified.protocols = vec!["/ipfs/kad/1.0.0".into(), "/libp2p/dcutr".into()];
+        assert_ne!(
+            network_identity(&a),
+            network_identity(&net_update("2026-01-01T00:00:00Z", vec![identified]))
+        );
+
+        // A NAT transition — the headline event this whole view exists for.
+        let mut gone_private = a.clone();
+        gone_private.self_status.as_mut().unwrap().reachability = "private".into();
+        assert_ne!(network_identity(&a), network_identity(&gone_private));
+
+        // Picking up a relay reservation.
+        let mut relaying = a.clone();
+        relaying.self_status.as_mut().unwrap().using_relay = true;
+        assert_ne!(network_identity(&a), network_identity(&relaying));
+
+        // A routing-table entry changing connected-state. The routing table
+        // and the connected set move independently, so this must register.
+        let mut routed = a.clone();
+        routed.routing = vec![RoutingPeer {
+            peer_id: "A".into(),
+            connected: true,
+        }];
+        assert_ne!(network_identity(&a), network_identity(&routed));
+    }
+
+    /// Address churn is not a reachability change. `observed_addrs` moves as
+    /// peers come and go without the verdict changing, and waking the UI for it
+    /// would make the page twitch for no reason.
+    #[test]
+    fn network_identity_ignores_observed_address_churn() {
+        let a = net_update("2026-01-01T00:00:00Z", vec![net_peer("A")]);
+        let mut churned = a.clone();
+        churned.self_status.as_mut().unwrap().observed_addrs =
+            vec!["/ip4/203.0.113.7/tcp/4001".into()];
+        assert_eq!(network_identity(&a), network_identity(&churned));
     }
 }

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1303,7 +1303,14 @@ const DEFAULT_NETWORK_INTERVAL_SECS: u64 = 5;
 /// Connections are compared as a set: the swarm iterates a `HashMap`, so
 /// ordering is arbitrary and a pure reordering is not a change worth waking the
 /// UI for. The routing table is compared the same way.
-type NetworkIdentity = (String, bool, bool, BTreeSet<String>, BTreeSet<String>);
+type NetworkIdentity = (
+    String,
+    bool,
+    bool,
+    String,
+    BTreeSet<String>,
+    BTreeSet<String>,
+);
 
 fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
     let self_status = u.self_status.clone().unwrap_or_default();
@@ -1341,6 +1348,9 @@ fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
         self_status.reachability,
         self_status.using_relay,
         self_status.announceable,
+        // Registering or removing a handler changes what this node serves, and
+        // the view shows it, so it has to wake the client.
+        self_status.local_protocols.join(","),
         connected,
         routing,
     )
@@ -1632,6 +1642,7 @@ fn build_network_update(
                 .map(|(a, _)| a.to_string())
                 .collect(),
             relay_addrs: snapshot.relay_addrs.iter().map(|a| a.to_string()).collect(),
+            local_protocols: snapshot.local_protocols.clone(),
         }),
         connected: connected.into_iter().map(|(_, _, w)| w).collect(),
         routing,
@@ -2448,6 +2459,7 @@ mod tests {
                 listen_addrs: vec!["/ip4/0.0.0.0/tcp/4001".into()],
                 observed_addrs: vec![],
                 relay_addrs: vec![],
+                local_protocols: vec!["/ipfs/kad/1.0.0".into()],
             }),
             connected: peers,
             routing: vec![],
@@ -2537,6 +2549,17 @@ mod tests {
             network_identity(&a),
             network_identity(&net_update("2026-01-01T00:00:00Z", vec![upgraded_peer]))
         );
+
+        // Registering a handler changes what this node serves, and the view
+        // shows it, so it has to reach the client.
+        let mut serving_more = a.clone();
+        serving_more
+            .self_status
+            .as_mut()
+            .unwrap()
+            .local_protocols
+            .push("/kwaai/inference/1.0.0".into());
+        assert_ne!(network_identity(&a), network_identity(&serving_more));
 
         // A routing peer being recognised as a bootstrap.
         let mut bootstrap_routed = a.clone();

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -23,6 +23,7 @@ mod node_native;
 mod ollama;
 mod ollama_proxy;
 mod p2p_cmd;
+mod peers_view;
 mod progress;
 #[cfg(feature = "rag")]
 mod rag_api;

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -66,7 +66,10 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // straight away. Failure here is non-fatal: the p2p node must
     // keep running even if the IPC surface didn't come up. The
     // handle's Drop signals graceful shutdown when run_node returns.
-    let _grpc_handle = crate::grpc_server::spawn(config.clone());
+    //
+    // The native path also hands it the swarm once that exists, which is what
+    // lets the Network op serve; see `attach_network`.
+    let grpc_handle = crate::grpc_server::spawn(config.clone());
 
     // -----------------------------------------------------------------------
     // Persistent identity — load or generate the keypair so the PeerId is
@@ -149,6 +152,7 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
             &public_name,
             trust_attestations,
             &mut sighup,
+            &grpc_handle,
         )
         .await?;
 

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -340,10 +340,16 @@ pub async fn run_native_node(
     public_name: &str,
     trust_attestations: Vec<String>,
     sighup: &mut SigHup,
+    grpc: &crate::grpc_server::GrpcServerHandle,
 ) -> Result<Option<String>> {
     info!("[1/4] Starting the native p2p stack...");
     let node = NativeNode::start(config, bootstrap_peers).await?;
     let peer_id = node.peer_id;
+
+    // Hand the swarm to the gRPC surface, which bound before the node existed
+    // so that ping/status/generate would answer during startup. Until now its
+    // Network op has been reporting "still starting"; from here it can serve.
+    grpc.attach_network(node.handle.clone()).await;
 
     // ── Announce inputs ────────────────────────────────────────────────────
     info!("[2/4] Preparing the DHT announcement...");

--- a/core/crates/kwaai-cli/src/p2p_cmd.rs
+++ b/core/crates/kwaai-cli/src/p2p_cmd.rs
@@ -4,16 +4,15 @@
 //! `peers list` return p2pd's in-memory view; `peers find` issues an active
 //! Kademlia lookup via p2pd.
 
-use std::collections::HashSet;
-
 use anyhow::{Context, Result};
-use kwaai_p2p::NetworkConfig;
 use kwaai_p2p_daemon::P2PClient;
 use libp2p::{Multiaddr, PeerId};
 
 use crate::cli::{P2pAction, P2pArgs, PeersAction, PeersArgs, ProbeArgs};
-use crate::config::KwaaiNetConfig;
 use crate::display::*;
+use crate::peers_view::{
+    bootstrap_peer_ids, classify_addr, group_index, trusted_relay_peer_ids, ConnKind,
+};
 use crate::shard_cmd::daemon_socket;
 
 pub async fn run(args: P2pArgs) -> Result<()> {
@@ -86,26 +85,6 @@ fn fmt_addr(bytes: &[u8]) -> String {
         .unwrap_or_else(|_| format!("0x{} (unparseable)", hex::encode(bytes)))
 }
 
-/// Connection classification. `LIST_PEERS` only gives us `(id, addrs)` so this
-/// is derived from the multiaddr alone.
-#[derive(Copy, Clone, PartialEq, Eq)]
-enum ConnKind {
-    /// Plain `/ip4/.../tcp/...` — directly dialable.
-    Direct,
-    /// Path includes `/p2p-circuit/` — going through a relay.
-    Relay,
-}
-
-fn classify_addr(m: &Multiaddr) -> ConnKind {
-    if m.iter()
-        .any(|p| matches!(p, libp2p::multiaddr::Protocol::P2pCircuit))
-    {
-        ConnKind::Relay
-    } else {
-        ConnKind::Direct
-    }
-}
-
 /// Backwards-compat shim retained so `info` keeps working unchanged.
 fn is_relayed(m: &Multiaddr) -> bool {
     classify_addr(m) == ConnKind::Relay
@@ -118,36 +97,6 @@ fn fmt_kind(k: ConnKind) -> &'static str {
         ConnKind::Direct => "\x1b[32m[direct]\x1b[0m",
         ConnKind::Relay => "\x1b[33m[ relay]\x1b[0m",
     }
-}
-
-/// Build the set of bootstrap peer IDs the local node was configured to use.
-/// Prefers the user's `initial_peers` override; falls back to the built-in
-/// KwaaiNet/Petals defaults. Same precedence as `vpk discover` and `node.rs`.
-fn bootstrap_peer_ids() -> HashSet<PeerId> {
-    let bootstraps: Vec<String> = match KwaaiNetConfig::load_or_create() {
-        Ok(cfg) if !cfg.initial_peers.is_empty() => cfg.initial_peers,
-        _ => NetworkConfig::with_petals_bootstrap().bootstrap_peers,
-    };
-
-    bootstraps
-        .iter()
-        .filter_map(|addr| addr.split("/p2p/").nth(1))
-        .filter_map(|id| id.parse::<PeerId>().ok())
-        .collect()
-}
-
-/// Build the set of trusted-relay peer IDs the local node was configured with.
-/// Empty when the user hasn't configured any (the production default).
-fn trusted_relay_peer_ids() -> HashSet<PeerId> {
-    let relays = KwaaiNetConfig::load_or_create()
-        .map(|cfg| cfg.trusted_relays)
-        .unwrap_or_default();
-
-    relays
-        .iter()
-        .filter_map(|addr| addr.split("/p2p/").nth(1))
-        .filter_map(|id| id.parse::<PeerId>().ok())
-        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -243,20 +192,8 @@ async fn peers_list() -> Result<()> {
     // Group ordering for the sort: bootstrap first (regardless of conn kind),
     // then trusted relay, then plain direct, then via-relay. Within each
     // group, sort by peer ID so output is stable across polls — useful when
-    // watching the list change as peers come and go.
-    fn group_index(is_bootstrap: bool, is_trusted_relay: bool, kind: ConnKind) -> u8 {
-        if is_bootstrap {
-            return 0;
-        }
-        if is_trusted_relay {
-            return 1;
-        }
-        match kind {
-            ConnKind::Direct => 2,
-            ConnKind::Relay => 3,
-        }
-    }
-
+    // watching the list change as peers come and go. Shared with the gRPC
+    // Network op so both surfaces order the same network identically.
     struct Row {
         group: u8,
         id_str: String,

--- a/core/crates/kwaai-cli/src/peers_view.rs
+++ b/core/crates/kwaai-cli/src/peers_view.rs
@@ -1,0 +1,165 @@
+//! Shared classification for peer listings.
+//!
+//! Two surfaces render the same connection table: `kwaainet p2p peers list`
+//! (via the p2pd control socket) and the gRPC Network op the GUI subscribes to
+//! (via `NetworkHandle`). They read the peer set from different places, but
+//! "is this connection relayed?" and "is this peer one of ours?" must mean the
+//! same thing in both — otherwise the CLI and the GUI quietly disagree about
+//! the same network, which is worse than either being wrong on its own.
+//!
+//! None of this is derivable from a connection alone. Relay-vs-direct comes
+//! from the multiaddr; bootstrap and trusted-relay membership come from local
+//! configuration. That is why it lives here rather than in `kwaai-p2p`: the
+//! swarm has no opinion about which peers the operator chose to trust.
+
+use std::collections::HashSet;
+
+use kwaai_p2p::{is_circuit, NetworkConfig};
+use libp2p::{Multiaddr, PeerId};
+
+use crate::config::KwaaiNetConfig;
+
+/// How a connection reaches the peer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ConnKind {
+    /// Plain transport address — directly dialable.
+    Direct,
+    /// Path runs through a circuit relay.
+    Relay,
+}
+
+/// Classify a connection from its multiaddr.
+///
+/// A `/p2p-circuit` component is the only signal available: neither the p2pd
+/// control protocol nor the swarm reports "relayed" as a fact of its own.
+pub fn classify_addr(m: &Multiaddr) -> ConnKind {
+    if is_circuit(m) {
+        ConnKind::Relay
+    } else {
+        ConnKind::Direct
+    }
+}
+
+/// Sort group for a connection, lowest first: bootstrap, trusted relay, plain
+/// direct, then via-relay.
+///
+/// Bootstrap and trusted-relay rank above the direct/relay split because they
+/// reflect configuration the operator explicitly chose — when scanning a peer
+/// list you are usually asking "did my bootstraps connect?" before anything
+/// else. Callers pair this with a peer-id tiebreak so the order is stable
+/// across polls; an unstable sort makes a live view flicker as peers reorder
+/// under it.
+pub fn group_index(is_bootstrap: bool, is_trusted_relay: bool, kind: ConnKind) -> u8 {
+    if is_bootstrap {
+        return 0;
+    }
+    if is_trusted_relay {
+        return 1;
+    }
+    match kind {
+        ConnKind::Direct => 2,
+        ConnKind::Relay => 3,
+    }
+}
+
+/// The bootstrap peer IDs this node was configured to use.
+///
+/// Prefers the user's `initial_peers` override and falls back to the built-in
+/// KwaaiNet/Petals defaults — the same precedence as `vpk discover` and
+/// `node.rs`, so all three agree on what counts as a bootstrap.
+pub fn bootstrap_peer_ids() -> HashSet<PeerId> {
+    let bootstraps: Vec<String> = match KwaaiNetConfig::load_or_create() {
+        Ok(cfg) if !cfg.initial_peers.is_empty() => cfg.initial_peers,
+        _ => NetworkConfig::with_petals_bootstrap().bootstrap_peers,
+    };
+
+    peer_ids_from_multiaddrs(&bootstraps)
+}
+
+/// The trusted-relay peer IDs this node was configured with. Empty when none
+/// are configured, which is the production default.
+pub fn trusted_relay_peer_ids() -> HashSet<PeerId> {
+    let relays = KwaaiNetConfig::load_or_create()
+        .map(|cfg| cfg.trusted_relays)
+        .unwrap_or_default();
+
+    peer_ids_from_multiaddrs(&relays)
+}
+
+/// Pull the `/p2p/<peer-id>` component out of each configured multiaddr.
+///
+/// Entries without one, or with an unparseable id, are skipped rather than
+/// failing the lot: a single malformed line in config should not blank out the
+/// bootstrap labels on an otherwise healthy peer list.
+fn peer_ids_from_multiaddrs(addrs: &[String]) -> HashSet<PeerId> {
+    addrs
+        .iter()
+        .filter_map(|addr| addr.split("/p2p/").nth(1))
+        .filter_map(|id| id.parse::<PeerId>().ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(s: &str) -> Multiaddr {
+        s.parse().expect("test multiaddr must parse")
+    }
+
+    #[test]
+    fn classifies_plain_transport_as_direct() {
+        assert_eq!(
+            classify_addr(&addr("/ip4/198.18.0.10/tcp/8000")),
+            ConnKind::Direct
+        );
+        assert_eq!(
+            classify_addr(&addr("/ip4/198.18.0.10/tcp/8000/p2p/12D3KooWA9DGWLoTPRZaZhBnjaGoQoDeGjKZKuadyeR6mUwXNBTa")),
+            ConnKind::Direct
+        );
+    }
+
+    #[test]
+    fn classifies_circuit_paths_as_relayed() {
+        // The relay component can sit at the end or be followed by the target
+        // peer; both are relayed.
+        assert_eq!(
+            classify_addr(&addr("/ip4/198.18.0.50/tcp/4001/p2p-circuit")),
+            ConnKind::Relay
+        );
+        assert_eq!(
+            classify_addr(&addr("/ip4/198.18.0.50/tcp/4001/p2p/12D3KooWA9DGWLoTPRZaZhBnjaGoQoDeGjKZKuadyeR6mUwXNBTa/p2p-circuit/p2p/12D3KooWH3uVF6wv47WnArKHk5p6cvgCJEb74UTmxztmQDc298L3")),
+            ConnKind::Relay
+        );
+    }
+
+    #[test]
+    fn bootstrap_outranks_every_other_group() {
+        // A bootstrap reached over a relay still sorts first: the question
+        // "did my bootstraps connect?" outranks how they connected.
+        assert_eq!(group_index(true, false, ConnKind::Relay), 0);
+        assert_eq!(group_index(true, true, ConnKind::Direct), 0);
+        assert_eq!(group_index(false, true, ConnKind::Relay), 1);
+        assert_eq!(group_index(false, false, ConnKind::Direct), 2);
+        assert_eq!(group_index(false, false, ConnKind::Relay), 3);
+    }
+
+    #[test]
+    fn extracts_peer_ids_and_skips_malformed_entries() {
+        let ids = peer_ids_from_multiaddrs(&[
+            "/ip4/198.18.0.10/tcp/8000/p2p/12D3KooWA9DGWLoTPRZaZhBnjaGoQoDeGjKZKuadyeR6mUwXNBTa"
+                .to_string(),
+            // No /p2p/ component — skipped, not fatal.
+            "/ip4/198.18.0.11/tcp/8000".to_string(),
+            // Present but not a valid peer id — also skipped.
+            "/ip4/198.18.0.12/tcp/8000/p2p/not-a-peer-id".to_string(),
+        ]);
+
+        assert_eq!(ids.len(), 1);
+        assert!(ids.contains(
+            &"12D3KooWA9DGWLoTPRZaZhBnjaGoQoDeGjKZKuadyeR6mUwXNBTa"
+                .parse::<PeerId>()
+                .unwrap()
+        ));
+    }
+}

--- a/core/crates/kwaai-cli/src/peers_view.rs
+++ b/core/crates/kwaai-cli/src/peers_view.rs
@@ -30,14 +30,32 @@ pub enum ConnKind {
 
 /// Classify a connection from its multiaddr.
 ///
-/// A `/p2p-circuit` component is the only signal available: neither the p2pd
-/// control protocol nor the swarm reports "relayed" as a fact of its own.
+/// Neither the p2pd control protocol nor the swarm reports "relayed" as a fact
+/// of its own, so this reads it off the address. Two shapes mean relayed:
+///
+/// * an explicit `/p2p-circuit` component;
+/// * an address with **no transport at all** — a bare `/p2p/<id>`. That is what
+///   an inbound connection's `send_back_addr` looks like when it arrived over a
+///   relay's already-open circuit: the relay strips the circuit components
+///   before handing us the stream, leaving only the peer id.
+///
+/// The second case is why `Direct` is not the fallback. Calling an unclassifi-
+/// able address direct claims the stronger and more surprising thing — that a
+/// stranger reached us unsolicited — on the least evidence, and on a NATed node
+/// with no port forward that claim is simply wrong.
 pub fn classify_addr(m: &Multiaddr) -> ConnKind {
-    if is_circuit(m) {
+    if is_circuit(m) || !has_transport(m) {
         ConnKind::Relay
     } else {
         ConnKind::Direct
     }
+}
+
+/// Whether the address names a way to actually reach the peer, rather than only
+/// naming the peer.
+fn has_transport(m: &Multiaddr) -> bool {
+    m.iter()
+        .any(|p| !matches!(p, libp2p::multiaddr::Protocol::P2p(_)))
 }
 
 /// Sort group for a connection, lowest first: bootstrap, trusted relay, plain
@@ -116,6 +134,20 @@ mod tests {
         assert_eq!(
             classify_addr(&addr("/ip4/198.18.0.10/tcp/8000/p2p/12D3KooWA9DGWLoTPRZaZhBnjaGoQoDeGjKZKuadyeR6mUwXNBTa")),
             ConnKind::Direct
+        );
+    }
+
+    #[test]
+    fn classifies_a_transportless_address_as_relayed() {
+        // What an inbound connection over an already-open circuit looks like:
+        // the relay strips the circuit components, leaving only the peer id.
+        // Calling this "direct" told a NATed node with no port forward that a
+        // stranger had reached it unsolicited, which cannot happen.
+        assert_eq!(
+            classify_addr(&addr(
+                "/p2p/12D3KooWA9DGWLoTPRZaZhBnjaGoQoDeGjKZKuadyeR6mUwXNBTa"
+            )),
+            ConnKind::Relay
         );
     }
 

--- a/core/crates/kwaai-cli/src/peers_view.rs
+++ b/core/crates/kwaai-cli/src/peers_view.rs
@@ -80,6 +80,53 @@ pub fn group_index(is_bootstrap: bool, is_trusted_relay: bool, kind: ConnKind) -
     }
 }
 
+/// Whether a peer serves the DHT, as far as identify has told us.
+///
+/// This is a *third* state deliberately: identify completes shortly after the
+/// connection establishes, so `protocols` is empty on a freshly-connected peer
+/// and stays empty for a beat. Collapsing that into a bool would make every
+/// peer briefly look like a non-server, and anything filtering on it would
+/// blink rows in and out as connections settle.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum DhtRole {
+    /// Advertises the kad protocol — a routing hop that can store records and
+    /// be returned as a lookup result.
+    Server,
+    /// Identify completed and kad was absent. A query-only participant: it
+    /// reads the DHT but never serves it, so it can be a peer's *target* but
+    /// never a step on the way to one.
+    Client,
+    /// Identify has not reported yet. Not a claim either way.
+    Unknown,
+}
+
+/// The kad protocol identifier, as advertised over identify.
+///
+/// Matched with a prefix rather than equality: libp2p appends a network
+/// suffix when one is configured (`/ipfs/kad/1.0.0` vs `/kwaai/kad/1.0.0`),
+/// and a peer on a named network still serves the DHT.
+const KAD_PROTOCOL_INFIX: &str = "/kad/";
+
+/// Classify a peer's DHT participation from its advertised protocols.
+///
+/// Keyed off the protocol list rather than `agent_version` on purpose:
+/// advertising a protocol is a commitment the peer's stack actually honours,
+/// whereas the version string is free text a peer can set to anything.
+///
+/// Client-mode is not a hivemind artifact and does not go away with the p2pd
+/// migration — rust-libp2p has the same mode, and our own nodes sit in it
+/// until reachability resolves. It is a permanent property of the network.
+pub fn dht_role(protocols: &[String]) -> DhtRole {
+    if protocols.is_empty() {
+        return DhtRole::Unknown;
+    }
+    if protocols.iter().any(|p| p.contains(KAD_PROTOCOL_INFIX)) {
+        DhtRole::Server
+    } else {
+        DhtRole::Client
+    }
+}
+
 /// The bootstrap peer IDs this node was configured to use.
 ///
 /// Prefers the user's `initial_peers` override and falls back to the built-in
@@ -193,5 +240,75 @@ mod tests {
                 .parse::<PeerId>()
                 .unwrap()
         ));
+    }
+
+    /// The protocol list a kwaainet node advertises once identify settles.
+    /// Captured from a live nat-test node.
+    fn server_protocols() -> Vec<String> {
+        [
+            "/ipfs/id/1.0.0",
+            "/ipfs/id/push/1.0.0",
+            "/ipfs/kad/1.0.0",
+            "/ipfs/ping/1.0.0",
+            "/libp2p/autonat/1.0.0",
+            "/libp2p/circuit/relay/0.2.0/hop",
+            "/libp2p/circuit/relay/0.2.0/stop",
+            "/libp2p/dcutr",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+
+    /// A hivemind `-dhtClient=1` sidecar, captured from the same network.
+    /// Note it still advertises circuit relay hop.
+    fn client_protocols() -> Vec<String> {
+        [
+            "/ipfs/id/1.0.0",
+            "/ipfs/id/push/1.0.0",
+            "/ipfs/ping/1.0.0",
+            "/libp2p/autonat/1.0.0",
+            "/libp2p/circuit/relay/0.2.0/hop",
+            "/libp2p/circuit/relay/0.2.0/stop",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+
+    #[test]
+    fn kad_speaker_is_a_server() {
+        assert_eq!(dht_role(&server_protocols()), DhtRole::Server);
+    }
+
+    #[test]
+    fn query_only_peer_is_a_client() {
+        assert_eq!(dht_role(&client_protocols()), DhtRole::Client);
+    }
+
+    /// The case that makes this an enum rather than a bool. identify lands
+    /// *after* the connection establishes, so a just-connected peer reports
+    /// nothing. Calling that "client" would misclassify every peer for the
+    /// first moments of its life, and blink rows in and out of a filtered view.
+    #[test]
+    fn no_protocols_yet_is_unknown() {
+        assert_eq!(dht_role(&[]), DhtRole::Unknown);
+    }
+
+    /// A named network suffixes the kad protocol id. Such a peer still serves
+    /// the DHT, so the match is on the infix rather than the full string.
+    #[test]
+    fn named_network_kad_still_serves() {
+        let protocols = vec!["/ipfs/id/1.0.0".to_string(), "/kwaai/kad/1.0.0".to_string()];
+        assert_eq!(dht_role(&protocols), DhtRole::Server);
+    }
+
+    /// Relay hop must not be read as DHT participation: the hivemind clients
+    /// advertise it, and conflating the two would classify every one of them
+    /// as a server.
+    #[test]
+    fn relay_hop_alone_is_not_a_server() {
+        let protocols = vec!["/libp2p/circuit/relay/0.2.0/hop".to_string()];
+        assert_eq!(dht_role(&protocols), DhtRole::Client);
     }
 }

--- a/core/crates/kwaai-p2p/src/error.rs
+++ b/core/crates/kwaai-p2p/src/error.rs
@@ -19,6 +19,16 @@ pub enum P2PError {
     #[error("Dial failed: {0}")]
     DialFailed(String),
 
+    /// A dial was skipped because a connection to the peer already exists (or
+    /// one is already being established).
+    ///
+    /// Not a failure — the caller's goal is already met. Distinct from
+    /// [`P2PError::DialFailed`] so a caller that only wants *a* connection can
+    /// treat it as success, while one that wanted a *new* connection can see
+    /// that it did not get one.
+    #[error("Already connected")]
+    AlreadyConnected,
+
     /// DHT operation failed
     #[error("DHT operation failed: {0}")]
     DhtError(String),

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -17,6 +17,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 
 use libp2p::{Multiaddr, PeerId};
 use tokio::sync::{mpsc, oneshot, watch};
@@ -62,6 +63,15 @@ pub type UnaryHandler = Box<
 >;
 
 /// A connected peer, as reported by [`NetworkHandle::list_peers`].
+///
+/// One entry per **connection**, not per peer: a peer reachable both directly
+/// and over a relay appears twice, which is what makes a hole-punch upgrade
+/// visible as it happens.
+///
+/// The three descriptive fields below are populated from identify and ping, so
+/// they fill in shortly *after* a connection establishes rather than with it.
+/// A freshly connected peer legitimately reports `None`/empty for all three —
+/// treat that as "not yet known", never as "the peer lacks this".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PeerInfo {
     /// The remote peer's ID.
@@ -71,6 +81,40 @@ pub struct PeerInfo {
     pub addr: Multiaddr,
     /// Which side opened the connection.
     pub direction: Direction,
+    /// Most recent ping round-trip time. `None` until the first ping completes.
+    pub rtt: Option<Duration>,
+    /// The peer's advertised software version, from identify.
+    pub agent_version: Option<String>,
+    /// The protocols the peer advertised over identify. Empty until identify
+    /// completes.
+    pub protocols: Vec<String>,
+}
+
+/// Everything the Network view needs, captured in one pass over the service's
+/// state.
+///
+/// Exists as a single command rather than five accessor calls because the
+/// parts are read *together* and rendered as one picture: composing it from
+/// separate `await`s would let the peer table, the routing table and the
+/// reachability verdict come from three different moments and disagree with
+/// each other on screen.
+#[derive(Debug, Clone)]
+pub struct NetworkSnapshot {
+    /// One entry per live connection.
+    pub peers: Vec<PeerInfo>,
+    /// Every peer in the Kademlia routing table. Overlaps `peers` but neither
+    /// set contains the other — see [`NetworkHandle::routing_peers`].
+    pub routing: Vec<PeerId>,
+    /// What we currently believe about our own reachability.
+    pub reachability: crate::reachability::Reachability,
+    /// Addresses of confirmed circuit-relay reservations. Empty when not
+    /// relaying.
+    pub relay_addrs: Vec<Multiaddr>,
+    /// Addresses peers have reported observing us at, with the number of
+    /// distinct peers that said so.
+    pub observed_addrs: Vec<(Multiaddr, usize)>,
+    /// The swarm's listen addresses.
+    pub listen_addrs: Vec<Multiaddr>,
 }
 
 /// Which end dialed.
@@ -113,6 +157,11 @@ pub enum Command {
     /// Snapshot of currently connected peers.
     ListPeers {
         reply: oneshot::Sender<Vec<PeerInfo>>,
+    },
+    /// Connected peers, routing table, reachability and address state, read in
+    /// one pass so the parts cannot disagree with each other.
+    NetworkSnapshot {
+        reply: oneshot::Sender<crate::handle::NetworkSnapshot>,
     },
     /// Addresses other peers reported observing us at, with a count of how many
     /// distinct peers reported each.
@@ -306,6 +355,17 @@ impl NetworkHandle {
     /// Currently connected peers.
     pub async fn list_peers(&self) -> P2PResult<Vec<PeerInfo>> {
         self.call(|reply| Command::ListPeers { reply }).await
+    }
+
+    /// The whole network picture in one consistent read — connections, routing
+    /// table, reachability and addresses.
+    ///
+    /// Prefer this over calling [`Self::list_peers`], [`Self::routing_peers`],
+    /// [`Self::reachability`] and the address accessors in sequence: this is
+    /// one trip through the event loop, so every part describes the same
+    /// instant.
+    pub async fn network_snapshot(&self) -> P2PResult<NetworkSnapshot> {
+        self.call(|reply| Command::NetworkSnapshot { reply }).await
     }
 
     /// Addresses peers have observed us at, paired with the number of distinct

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -123,6 +123,14 @@ pub struct NetworkSnapshot {
     pub observed_addrs: Vec<(Multiaddr, usize)>,
     /// The swarm's listen addresses.
     pub listen_addrs: Vec<Multiaddr>,
+    /// Protocols this node serves to peers, sorted.
+    ///
+    /// The handlers actually registered — the unary and raw-stream namespaces
+    /// plus kad's own names — rather than everything the swarm might negotiate.
+    /// libp2p keeps its full advertised set private to `Swarm`, and this is the
+    /// more useful answer anyway: it is what this node will *do* for a peer,
+    /// which is what a reader comparing it against a peer's list wants.
+    pub local_protocols: Vec<String>,
 }
 
 /// Which end dialed.

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -81,6 +81,12 @@ pub struct PeerInfo {
     pub addr: Multiaddr,
     /// Which side opened the connection.
     pub direction: Direction,
+    /// Whether DCUtR upgraded this connection from relayed to direct.
+    ///
+    /// Distinct from simply being direct: it means the path was established
+    /// *through* a NAT by coordinated simultaneous dial, rather than there
+    /// being no NAT to traverse.
+    pub dcutr: bool,
     /// Most recent ping round-trip time. `None` until the first ping completes.
     pub rtt: Option<Duration>,
     /// The peer's advertised software version, from identify.

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -104,6 +104,21 @@ pub struct PeerInfo {
     pub protocols: Vec<String>,
 }
 
+/// One Kademlia routing-table entry: a peer, and how we would reach it.
+///
+/// The addresses matter on their own. A routing entry with none is a peer we
+/// know of but cannot dial, which is a different state from one we simply are
+/// not connected to — and only the addresses distinguish them. Surfacing them
+/// is also what makes a bad entry visible: a peer whose only address is its own
+/// loopback looks identical to a healthy one until you can see the address.
+#[derive(Debug, Clone)]
+pub struct RoutingEntry {
+    pub peer_id: PeerId,
+    /// What kad holds for this peer, already filtered to addresses a third
+    /// party could dial. Empty when kad knows the peer but no usable address.
+    pub addrs: Vec<Multiaddr>,
+}
+
 /// Everything the Network view needs, captured in one pass over the service's
 /// state.
 ///
@@ -120,7 +135,7 @@ pub struct NetworkSnapshot {
     pub peers: Vec<PeerInfo>,
     /// Every peer in the Kademlia routing table. Overlaps `peers` but neither
     /// set contains the other — see [`NetworkHandle::routing_peers`].
-    pub routing: Vec<PeerId>,
+    pub routing: Vec<RoutingEntry>,
     /// What we currently believe about our own reachability.
     pub reachability: crate::reachability::Reachability,
     /// Addresses of confirmed circuit-relay reservations. Empty when not

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -100,6 +100,8 @@ pub struct PeerInfo {
 /// each other on screen.
 #[derive(Debug, Clone)]
 pub struct NetworkSnapshot {
+    /// This node's own peer ID.
+    pub local_peer_id: PeerId,
     /// One entry per live connection.
     pub peers: Vec<PeerInfo>,
     /// Every peer in the Kademlia routing table. Overlaps `peers` but neither

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -81,6 +81,14 @@ pub struct PeerInfo {
     pub addr: Multiaddr,
     /// Which side opened the connection.
     pub direction: Direction,
+    /// The relay an inbound connection arrived through, when it was relayed.
+    ///
+    /// An inbound relayed connection's `addr` is a bare `/p2p/<peer>` — it says
+    /// who reached us and nothing about how. This is the local end of that
+    /// connection (our circuit listener), which is the only place the relay's
+    /// address and identity appear. `None` for outbound, where `addr` already
+    /// carries the relay, and for plain inbound.
+    pub via: Option<Multiaddr>,
     /// Whether DCUtR upgraded this connection from relayed to direct.
     ///
     /// Distinct from simply being direct: it means the path was established

--- a/core/crates/kwaai-p2p/src/lib.rs
+++ b/core/crates/kwaai-p2p/src/lib.rs
@@ -56,7 +56,9 @@ pub use config::{
 };
 pub use dht_service::{remove_dht_service, spawn_dht_service};
 pub use error::{P2PError, P2PResult};
-pub use handle::{Direction, InboundUnaryCall, NetworkHandle, PeerInfo, UnaryHandler};
+pub use handle::{
+    Direction, InboundUnaryCall, NetworkHandle, NetworkSnapshot, PeerInfo, UnaryHandler,
+};
 pub use raw_stream::{InboundStream, RawStream, RawStreamError};
 pub use reachability::{
     AnnounceState, Reachability, ReachabilityKind, Source as ReachabilitySource,

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -90,6 +90,13 @@ const MAX_ADDRESSES_PER_PEER: usize = 6;
 struct Connection {
     addr: Multiaddr,
     direction: Direction,
+    /// Whether DCUtR upgraded this connection from a relayed path to a direct
+    /// one. Set when `dcutr::Event` reports success for this connection id.
+    ///
+    /// Worth distinguishing from a plain direct connection: it is direct
+    /// *despite* both ends being behind NAT, which is the difference between
+    /// "no NAT in the way" and "the NAT was traversed".
+    dcutr: bool,
 }
 
 /// Owns the swarm and drives it. Construct with [`NetworkService::spawn`].
@@ -666,6 +673,7 @@ impl NetworkService {
                     peer_id: *peer_id,
                     addr: c.addr.clone(),
                     direction: c.direction,
+                    dcutr: c.dcutr,
                     rtt,
                     agent_version: agent_version.clone(),
                     protocols: protocols.clone(),
@@ -1212,10 +1220,16 @@ impl NetworkService {
                 };
                 debug!(peer = %peer_id, %addr, direction = direction.as_str(), "connection established");
 
-                self.connections
-                    .entry(peer_id)
-                    .or_default()
-                    .insert(connection_id, Connection { addr, direction });
+                self.connections.entry(peer_id).or_default().insert(
+                    connection_id,
+                    Connection {
+                        addr,
+                        direction,
+                        // Set later if dcutr reports success for this id;
+                        // the upgrade always follows establishment.
+                        dcutr: false,
+                    },
+                );
 
                 if let Some(reply) = self.pending_dials.remove(&connection_id) {
                     let _ = reply.send(Ok(peer_id));
@@ -1389,7 +1403,15 @@ impl NetworkService {
                 // A success here means the relayed connection was replaced by a
                 // direct one — the whole point of holding the circuit.
                 Ok(connection_id) => {
-                    info!(peer = %remote_peer_id, ?connection_id, "dcutr hole punch succeeded")
+                    info!(peer = %remote_peer_id, ?connection_id, "dcutr hole punch succeeded");
+                    // Mark the specific connection, not the peer: a peer can
+                    // hold both an upgraded connection and a plain one, and
+                    // only the former was earned by DCUtR.
+                    if let Some(conns) = self.connections.get_mut(&remote_peer_id) {
+                        if let Some(conn) = conns.get_mut(&connection_id) {
+                            conn.dcutr = true;
+                        }
+                    }
                 }
                 Err(e) => debug!(peer = %remote_peer_id, error = %e, "dcutr hole punch failed"),
             },

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -91,6 +91,10 @@ const MAX_ADDRESSES_PER_PEER: usize = 6;
 struct Connection {
     addr: Multiaddr,
     direction: Direction,
+    /// For an inbound relayed connection, our circuit listener — which names
+    /// the relay. `None` for outbound (the dialled address already carries the
+    /// relay) and for plain inbound (our own bind address says nothing).
+    via: Option<Multiaddr>,
     /// Whether DCUtR upgraded this connection from a relayed path to a direct
     /// one. Set when `dcutr::Event` reports success for this connection id.
     ///
@@ -684,6 +688,7 @@ impl NetworkService {
                     peer_id: *peer_id,
                     addr: c.addr.clone(),
                     direction: c.direction,
+                    via: c.via.clone(),
                     dcutr: c.dcutr,
                     rtt,
                     agent_version: agent_version.clone(),
@@ -1293,13 +1298,25 @@ impl NetworkService {
                 endpoint,
                 ..
             } => {
-                let (addr, direction) = match &endpoint {
+                // `via` is the local end of an inbound connection. For a
+                // relayed one that is our circuit listener, which names the
+                // relay's address and peer id — the only place that appears.
+                // `send_back_addr` alone is a bare `/p2p/<peer>`: it says who
+                // reached us and nothing at all about how.
+                let (addr, direction, via) = match &endpoint {
                     ConnectedPoint::Dialer { address, .. } => {
-                        (address.clone(), Direction::Outbound)
+                        (address.clone(), Direction::Outbound, None)
                     }
-                    ConnectedPoint::Listener { send_back_addr, .. } => {
-                        (send_back_addr.clone(), Direction::Inbound)
-                    }
+                    ConnectedPoint::Listener {
+                        send_back_addr,
+                        local_addr,
+                    } => (
+                        send_back_addr.clone(),
+                        Direction::Inbound,
+                        // Only when it tells us something the address does not:
+                        // a plain TCP listener is just our own bind address.
+                        is_circuit(local_addr).then(|| local_addr.clone()),
+                    ),
                 };
                 debug!(peer = %peer_id, %addr, direction = direction.as_str(), "connection established");
 
@@ -1308,6 +1325,7 @@ impl NetworkService {
                     Connection {
                         addr,
                         direction,
+                        via,
                         // Set later if dcutr reports success for this id;
                         // the upgrade always follows establishment.
                         dcutr: false,

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -483,6 +483,7 @@ impl NetworkService {
                 observed.sort_by(|a, b| b.1.cmp(&a.1));
 
                 let _ = reply.send(NetworkSnapshot {
+                    local_peer_id: *self.swarm.local_peer_id(),
                     peers: self.collect_peers(),
                     routing,
                     reachability: self.reachability.current().clone(),

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -40,7 +40,7 @@ use crate::config::NetworkConfig;
 use crate::error::{P2PError, P2PResult};
 use crate::handle::{
     parse_protocols, Command, Direction, InboundStreamSender, InboundUnaryCall, InboundUnarySender,
-    NetworkHandle, PeerInfo,
+    NetworkHandle, NetworkSnapshot, PeerInfo,
 };
 use crate::raw_stream;
 use crate::reachability::{AnnounceState, Effect, Reachability, ReachabilityState, IDENTIFY_GRACE};
@@ -120,6 +120,15 @@ pub struct NetworkService {
     /// here. Dropped when the last connection to a peer closes, so an entry
     /// always describes a peer we can act on.
     peer_protocols: HashMap<PeerId, Vec<String>>,
+    /// Most recent ping round-trip time per peer. Sampled: overwritten on every
+    /// ping event rather than accumulated, so this is "latency now", not an
+    /// average. Same lifetime as `peer_protocols` — dropped with the last
+    /// connection, so an entry always describes a peer we can act on.
+    peer_rtt: HashMap<PeerId, Duration>,
+    /// The agent version each connected peer advertised over identify (the
+    /// remote's software build, e.g. `kwaainet/0.5.4`). Same lifetime as
+    /// `peer_protocols`.
+    peer_agent: HashMap<PeerId, String>,
     /// Registered unary handlers: negotiated protocol → the handler task's
     /// channel. Kept in lockstep with the behaviour's inbound protocol set, so
     /// an entry here means the protocol is advertised and vice versa.
@@ -339,6 +348,8 @@ impl NetworkService {
             observed_addrs: HashMap::new(),
             require_global_ips: config.require_global_ips,
             peer_protocols: HashMap::new(),
+            peer_rtt: HashMap::new(),
+            peer_agent: HashMap::new(),
             unary_handlers: HashMap::new(),
             stream_handlers: HashMap::new(),
             reachability,
@@ -459,18 +470,26 @@ impl NetworkService {
             }
 
             Command::ListPeers { reply } => {
-                let peers = self
-                    .connections
+                let _ = reply.send(self.collect_peers());
+            }
+
+            Command::NetworkSnapshot { reply } => {
+                let routing = self.collect_routing_peers();
+                let mut observed: Vec<(Multiaddr, usize)> = self
+                    .observed_addrs
                     .iter()
-                    .flat_map(|(peer_id, conns)| {
-                        conns.values().map(move |c| PeerInfo {
-                            peer_id: *peer_id,
-                            addr: c.addr.clone(),
-                            direction: c.direction,
-                        })
-                    })
+                    .map(|(addr, observers)| (addr.clone(), observers.len()))
                     .collect();
-                let _ = reply.send(peers);
+                observed.sort_by(|a, b| b.1.cmp(&a.1));
+
+                let _ = reply.send(NetworkSnapshot {
+                    peers: self.collect_peers(),
+                    routing,
+                    reachability: self.reachability.current().clone(),
+                    relay_addrs: self.relays.confirmed_addrs(),
+                    observed_addrs: observed,
+                    listen_addrs: self.swarm.listeners().cloned().collect(),
+                });
             }
 
             Command::ObservedAddrs { reply } => {
@@ -502,19 +521,7 @@ impl NetworkService {
             // size (k=20 per bucket, 256 buckets) and never touching the
             // network, so it is safe in the event loop.
             Command::RoutingPeers { reply } => {
-                let peers = self
-                    .swarm
-                    .behaviour_mut()
-                    .kad
-                    .kbuckets()
-                    .flat_map(|bucket| {
-                        bucket
-                            .iter()
-                            .map(|entry| *entry.node.key.preimage())
-                            .collect::<Vec<_>>()
-                    })
-                    .collect();
-                let _ = reply.send(peers);
+                let _ = reply.send(self.collect_routing_peers());
             }
 
             Command::DhtFindPeer { peer, reply } => {
@@ -634,6 +641,55 @@ impl NetworkService {
                 let _ = reply.send(());
             }
         }
+    }
+
+    /// One [`PeerInfo`] per live connection, enriched with whatever identify
+    /// and ping have learned so far.
+    ///
+    /// Per-connection, not per-peer: a peer with both a relay path and a direct
+    /// path appears twice, deliberately — that duplication is how a hole-punch
+    /// upgrade becomes visible. The enrichment fields are keyed by peer, so the
+    /// two rows share them.
+    fn collect_peers(&self) -> Vec<PeerInfo> {
+        self.connections
+            .iter()
+            .flat_map(|(peer_id, conns)| {
+                let rtt = self.peer_rtt.get(peer_id).copied();
+                let agent_version = self.peer_agent.get(peer_id).cloned();
+                let protocols = self
+                    .peer_protocols
+                    .get(peer_id)
+                    .cloned()
+                    .unwrap_or_default();
+                conns.values().map(move |c| PeerInfo {
+                    peer_id: *peer_id,
+                    addr: c.addr.clone(),
+                    direction: c.direction,
+                    rtt,
+                    agent_version: agent_version.clone(),
+                    protocols: protocols.clone(),
+                })
+            })
+            .collect()
+    }
+
+    /// Every peer in the Kademlia routing table.
+    ///
+    /// A walk over in-memory k-buckets — bounded by the routing table size
+    /// (k=20 per bucket, 256 buckets) and never touching the network, so it is
+    /// safe in the event loop.
+    fn collect_routing_peers(&mut self) -> Vec<PeerId> {
+        self.swarm
+            .behaviour_mut()
+            .kad
+            .kbuckets()
+            .flat_map(|bucket| {
+                bucket
+                    .iter()
+                    .map(|entry| *entry.node.key.preimage())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
     }
 
     /// Dial `addr`, seeding the routing table with it when it carries a
@@ -1196,6 +1252,11 @@ impl NetworkService {
                     // The capability list describes a peer we can act on; a
                     // disconnected peer's is stale by definition.
                     self.peer_protocols.remove(&peer_id);
+                    // Latency and build version are properties of a live
+                    // connection too. Keeping them would let a reconnected peer
+                    // briefly report the *previous* session's RTT.
+                    self.peer_rtt.remove(&peer_id);
+                    self.peer_agent.remove(&peer_id);
                     // Same for its opinion about where it saw us. Without this
                     // the map only ever grows, and the identify-consensus
                     // fallback would keep counting observers that left —
@@ -1281,7 +1342,15 @@ impl NetworkService {
             KwaaiBehaviourEvent::Identify(event) => self.handle_identify_event(event),
             KwaaiBehaviourEvent::Kad(event) => self.handle_kad_event(event),
             KwaaiBehaviourEvent::Ping(ping::Event { peer, result, .. }) => match result {
-                Ok(rtt) => trace!(peer = %peer, ?rtt, "ping"),
+                Ok(rtt) => {
+                    trace!(peer = %peer, ?rtt, "ping");
+                    // Last-write-wins: the peer table reports current latency,
+                    // not a smoothed average. A failed ping deliberately leaves
+                    // the previous value rather than clearing it — one lost
+                    // probe is not evidence the peer is gone, and libp2p will
+                    // close the connection (clearing this) if it really is.
+                    self.peer_rtt.insert(peer, rtt);
+                }
                 Err(e) => debug!(peer = %peer, error = %e, "ping failed"),
             },
             KwaaiBehaviourEvent::Unary(unary::Event::InboundRequest { peer, request }) => {
@@ -1575,7 +1644,11 @@ impl NetworkService {
                     .insert(peer_id);
 
                 // (c) Remember what the peer can do. Relay-hop, AutoNAT and
-                // dcutr capability are all read off this list.
+                // dcutr capability are all read off this list. The agent
+                // version rides along: purely descriptive (nothing branches on
+                // it), but it is what makes a peer table diagnosable when one
+                // build in the mesh misbehaves.
+                self.peer_agent.insert(peer_id, info.agent_version.clone());
                 let protocols: Vec<String> = info.protocols.iter().map(|p| p.to_string()).collect();
                 // Recorded *before* the relay manager runs: `apply_relay_actions`
                 // reads this map to decide whether a reservation can be

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -33,7 +33,8 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{debug, info, trace, warn};
 
 use crate::addresses::{
-    dest_peer_id, is_announceable_with, peer_id_from_multiaddr, strip_dest_p2p, strip_p2p,
+    dest_peer_id, is_announceable_with, is_circuit, peer_id_from_multiaddr, strip_dest_p2p,
+    strip_p2p,
 };
 use crate::behaviour::{KwaaiBehaviour, KwaaiBehaviourEvent};
 use crate::config::NetworkConfig;
@@ -456,9 +457,18 @@ impl NetworkService {
                     Some(peer) if strip_p2p(&addr).is_empty() => {
                         self.dispatch_routed(peer, RoutedRequest::Connect { reply });
                     }
-                    _ => match self.dial(addr) {
+                    _ => match self.dial(addr.clone()) {
                         Ok(connection_id) => {
                             self.pending_dials.insert(connection_id, reply);
+                        }
+                        // Already connected: the caller asked to be connected
+                        // and is, so answer success rather than surfacing an
+                        // error for a no-op.
+                        Err(P2PError::AlreadyConnected) => {
+                            let resolved = peer_id_from_multiaddr(&addr);
+                            let _ = reply.send(
+                                resolved.ok_or_else(|| P2PError::DialFailed(addr.to_string())),
+                            );
                         }
                         Err(e) => {
                             let _ = reply.send(Err(e));
@@ -703,8 +713,20 @@ impl NetworkService {
 
     /// Dial `addr`, seeding the routing table with it when it carries a
     /// `/p2p/<peer-id>` component.
+    ///
+    /// Redundant when we are already connected to the named peer, so those
+    /// dials are suppressed. `DialOpts::from(Multiaddr)` cannot express that:
+    /// it builds the *unknown-peer-id* variant, which hardcodes
+    /// `PeerCondition::Always` and offers no `condition()` at all. The result
+    /// was a second connection to every bootstrap on each re-dial — same peer,
+    /// byte-identical address, indistinguishable in `list_peers` — held until
+    /// libp2p reaped it on keepalive ~45 s later.
+    ///
+    /// When the address names a peer we can use the peer-id builder instead,
+    /// which does take a condition. A bare address (no `/p2p/`) has no peer to
+    /// compare against and keeps the old unconditional behaviour.
     fn dial(&mut self, addr: Multiaddr) -> P2PResult<ConnectionId> {
-        use libp2p::swarm::dial_opts::DialOpts;
+        use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
 
         // `dest_peer_id`, not `peer_id_from_multiaddr`: the latter returns the
         // *first* `/p2p`, which on a circuit address is the relay. Filing the
@@ -729,8 +751,17 @@ impl NetworkService {
             }
         }
 
-        // `allocate_new_port()`, overriding the `DialOpts` default of
-        // best-effort port reuse.
+        // Only for a plain address naming one peer. A circuit address carries
+        // *two* `/p2p/` components — the relay's and the target's — and
+        // `peer_id_from_multiaddr` returns the first, which is the relay.
+        // Conditioning on that would skip a dial to the target whenever we
+        // happened to be connected to the relay, which is always: holding a
+        // connection to the relay is what makes the circuit dialable at all.
+        let peer = peer_id_from_multiaddr(&addr);
+        let condition_safe = peer.is_some() && !is_circuit(&addr);
+
+        // Both arms call `allocate_new_port()`, overriding the `DialOpts`
+        // default of best-effort port reuse.
         //
         // Reuse asks the transport to bind our listen port as the dial's source
         // port. That is right for a DCUtR hole punch — `libp2p-dcutr` requests
@@ -744,19 +775,40 @@ impl NetworkService {
         // `AddrNotAvailable` raised by `connect`. Our failure is `EADDRINUSE`
         // from `bind`, one step earlier, where the `?` propagates before the
         // fallback can run — so the dial simply fails.
-        // Built through `unknown_peer_id().address(..)` rather than
-        // `DialOpts::from(addr)`, because only the builder exposes
-        // `allocate_new_port()`; the two are otherwise the same dial.
-        let opts = DialOpts::unknown_peer_id()
-            .address(addr.clone())
-            .allocate_new_port()
-            .build();
+        let opts = match peer {
+            // DisconnectedAndNotDialing rather than Disconnected: the latter
+            // still permits a second dial while the first is in flight, which
+            // is exactly the window a periodic re-dial lands in.
+            Some(peer) if condition_safe => DialOpts::peer_id(peer)
+                .addresses(vec![addr.clone()])
+                .condition(PeerCondition::DisconnectedAndNotDialing)
+                .allocate_new_port()
+                .build(),
+            // `unknown_peer_id().address(..)` rather than
+            // `DialOpts::from(addr)`, because only the builder exposes
+            // `allocate_new_port()`; the two are otherwise the same dial.
+            _ => DialOpts::unknown_peer_id()
+                .address(addr.clone())
+                .allocate_new_port()
+                .build(),
+        };
         let connection_id = opts.connection_id();
-        self.swarm
-            .dial(opts)
-            .map_err(|e| P2PError::DialFailed(format!("{addr}: {e}")))?;
-        debug!(%addr, ?connection_id, "dialing");
-        Ok(connection_id)
+        match self.swarm.dial(opts) {
+            Ok(()) => {
+                debug!(%addr, ?connection_id, "dialing");
+                Ok(connection_id)
+            }
+            // Not a failure: the condition held, meaning we are already
+            // connected or already dialing. Reported as its own error so
+            // callers can tell "no dial was needed" from "the dial failed" —
+            // `ConnectPeer` in particular must answer success here, since the
+            // caller's goal (be connected to this peer) is already met.
+            Err(DialError::DialPeerConditionFalse(_)) => {
+                debug!(%addr, "already connected or dialing — skipping redundant dial");
+                Err(P2PError::AlreadyConnected)
+            }
+            Err(e) => Err(P2PError::DialFailed(format!("{addr}: {e}"))),
+        }
     }
 
     /// Dial every bootstrap address and kick off a Kademlia bootstrap.
@@ -769,7 +821,11 @@ impl NetworkService {
         let mut last_error = None;
         for addr in peers {
             match self.dial(addr.clone()) {
-                Ok(_) => dialed += 1,
+                // A skipped dial counts as reached: we are already connected
+                // to that bootstrap, which is what the dial was for. Counting
+                // it as a failure would make a re-bootstrap on a healthy node
+                // look like a total failure.
+                Ok(_) | Err(P2PError::AlreadyConnected) => dialed += 1,
                 Err(e) => {
                     warn!(%addr, error = %e, "bootstrap dial failed to start");
                     last_error = Some(e);
@@ -1513,7 +1569,15 @@ impl NetworkService {
                         continue;
                     }
                     let dialable = relay_addr.with(libp2p::multiaddr::Protocol::P2p(relay));
+                    // AlreadyConnected is not a dial failure and must not back
+                    // the candidate off: the connection this dial wanted
+                    // exists. The guard above usually catches that first, but
+                    // it also requires identify to have landed, so this arm is
+                    // reachable in the window between the two.
                     if let Err(e) = self.dial(dialable) {
+                        if matches!(e, P2PError::AlreadyConnected) {
+                            continue;
+                        }
                         debug!(%relay, error = %e, "dialing a relay candidate");
                         let next = self.relays.on_relay_dial_failed(relay, Instant::now());
                         self.apply_relay_actions(next);

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -41,7 +41,7 @@ use crate::config::NetworkConfig;
 use crate::error::{P2PError, P2PResult};
 use crate::handle::{
     parse_protocols, Command, Direction, InboundStreamSender, InboundUnaryCall, InboundUnarySender,
-    NetworkHandle, NetworkSnapshot, PeerInfo,
+    NetworkHandle, NetworkSnapshot, PeerInfo, RoutingEntry,
 };
 use crate::raw_stream;
 use crate::reachability::{AnnounceState, Effect, Reachability, ReachabilityState, IDENTIFY_GRACE};
@@ -544,7 +544,12 @@ impl NetworkService {
             // size (k=20 per bucket, 256 buckets) and never touching the
             // network, so it is safe in the event loop.
             Command::RoutingPeers { reply } => {
-                let _ = reply.send(self.collect_routing_peers());
+                let _ = reply.send(
+                    self.collect_routing_peers()
+                        .into_iter()
+                        .map(|e| e.peer_id)
+                        .collect(),
+                );
             }
 
             Command::DhtFindPeer { peer, reply } => {
@@ -729,7 +734,7 @@ impl NetworkService {
     /// A walk over in-memory k-buckets — bounded by the routing table size
     /// (k=20 per bucket, 256 buckets) and never touching the network, so it is
     /// safe in the event loop.
-    fn collect_routing_peers(&mut self) -> Vec<PeerId> {
+    fn collect_routing_peers(&mut self) -> Vec<RoutingEntry> {
         self.swarm
             .behaviour_mut()
             .kad
@@ -737,7 +742,21 @@ impl NetworkService {
             .flat_map(|bucket| {
                 bucket
                     .iter()
-                    .map(|entry| *entry.node.key.preimage())
+                    .map(|entry| RoutingEntry {
+                        peer_id: *entry.node.key.preimage(),
+                        // Reported alongside the peer rather than dropped: an
+                        // entry with no usable address is a peer we know of but
+                        // cannot dial, and without the addresses that is
+                        // indistinguishable on screen from one we simply have
+                        // not connected to yet.
+                        addrs: entry
+                            .node
+                            .value
+                            .iter()
+                            .filter(|a| !a.is_empty())
+                            .cloned()
+                            .collect(),
+                    })
                     .collect::<Vec<_>>()
             })
             .collect()

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -507,6 +507,7 @@ impl NetworkService {
                     relay_addrs: self.relays.confirmed_addrs(),
                     observed_addrs: observed,
                     listen_addrs: self.swarm.listeners().cloned().collect(),
+                    local_protocols: self.collect_local_protocols(),
                 });
             }
 
@@ -690,6 +691,32 @@ impl NetworkService {
                 })
             })
             .collect()
+    }
+
+    /// Protocols this node serves, sorted and deduplicated.
+    ///
+    /// Read off the registered handlers rather than from the swarm: libp2p
+    /// keeps its advertised protocol set private to `Swarm`, and the handlers
+    /// are the more honest answer anyway — they are what this node will
+    /// actually do for a peer that asks.
+    fn collect_local_protocols(&mut self) -> Vec<String> {
+        let mut protos: Vec<String> = self
+            .unary_handlers
+            .keys()
+            .chain(self.stream_handlers.keys())
+            .cloned()
+            .collect();
+        protos.extend(
+            self.swarm
+                .behaviour_mut()
+                .kad
+                .protocol_names()
+                .iter()
+                .map(|p| p.to_string()),
+        );
+        protos.sort();
+        protos.dedup();
+        protos
     }
 
     /// Every peer in the Kademlia routing table.

--- a/core/crates/kwaai-p2p/tests/swarm.rs
+++ b/core/crates/kwaai-p2p/tests/swarm.rs
@@ -490,3 +490,56 @@ async fn an_address_that_answers_with_the_wrong_peer_id_is_evicted() {
     })
     .await;
 }
+
+// ---------------------------------------------------------------------------
+// Redundant dials
+// ---------------------------------------------------------------------------
+
+/// Re-dialing a peer we are already connected to must not open a second
+/// connection.
+///
+/// `DialOpts::from(Multiaddr)` builds the unknown-peer-id variant, which
+/// hardcodes `PeerCondition::Always`. Against a live network that produced a
+/// duplicate connection to every bootstrap on each re-dial — same peer,
+/// byte-identical `/dns/` address, indistinguishable in `list_peers` — held
+/// until libp2p reaped it on keepalive ~45s later.
+#[tokio::test]
+async fn re_dialing_a_connected_peer_does_not_open_a_second_connection() {
+    let (alice, _alice_task, _alice_id) = spawn_test_swarm();
+    let (bob, _bob_task, bob_id) = spawn_test_swarm();
+
+    let bob_addr = dialable_addr(&bob, bob_id).await;
+    alice
+        .connect_peer(&bob_addr.to_string())
+        .await
+        .expect("first dial");
+
+    let count = || async {
+        alice
+            .list_peers()
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|p| p.peer_id == bob_id)
+            .count()
+    };
+    assert_eq!(count().await, 1, "one connection after the first dial");
+
+    // Dial the same address again, several times. Each is a no-op.
+    for _ in 0..3 {
+        let again = alice.connect_peer(&bob_addr.to_string()).await;
+        assert_eq!(
+            again.expect("a redundant dial reports the peer, not an error"),
+            bob_id,
+            "the caller asked to be connected and is — that is success",
+        );
+    }
+
+    // Give any dial that did slip through time to establish before counting.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        count().await,
+        1,
+        "re-dialing an already-connected peer must not add connections",
+    );
+}

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -481,6 +481,16 @@ message RoutingPeer {
     // connection: the DHT does not label bootstraps, and which nodes
     // hold that role is the operator's choice.
     bool is_bootstrap = 3;
+
+    // The addresses the routing table holds for this peer, as multiaddr
+    // strings.
+    //
+    // Empty means kad knows the peer but has no address a third party
+    // could dial — a materially different state from "known and not
+    // currently connected", and one a peer id alone cannot express. It is
+    // also what makes a poisoned entry legible: a peer whose only address
+    // is its own loopback reads as healthy until the address is visible.
+    repeated string addrs = 4;
 }
 
 // This node's own position in the network.

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -429,6 +429,17 @@ message ConnectedPeer {
 
     // The peer's advertised software version. May be empty.
     string agent_version = 9;
+
+    // Whether DCUtR upgraded this connection from a relayed path to a
+    // direct one.
+    //
+    // Only ever true alongside PEER_CONN_KIND_DIRECT, and it means
+    // something stronger: the path was established *through* a NAT by
+    // coordinated simultaneous dial, rather than there being no NAT in
+    // the way. A node reporting "private" reachability can still hold
+    // upgraded connections — that is DCUtR working, not a
+    // contradiction.
+    bool dcutr = 10;
 }
 
 // One entry in the Kademlia routing table.
@@ -445,6 +456,13 @@ message RoutingPeer {
 
     // Whether this peer also appears in NetworkUpdate.connected.
     bool connected = 2;
+
+    // Whether this peer is one of our configured bootstrap nodes.
+    //
+    // Derived from local configuration, the same way it is for a
+    // connection: the DHT does not label bootstraps, and which nodes
+    // hold that role is the operator's choice.
+    bool is_bootstrap = 3;
 }
 
 // This node's own position in the network.

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -458,6 +458,37 @@ message ConnectedPeer {
     // upgraded connections — that is DCUtR working, not a
     // contradiction.
     bool dcutr = 10;
+
+    // Whether this peer serves the DHT, from its advertised protocols.
+    //
+    // Separate from is_bootstrap/is_trusted_relay rather than a variant
+    // of them: those are operator configuration, this is observed peer
+    // behaviour, and they are independent. A client-mode peer still
+    // advertises circuit relay hop, and a relayed node of ours runs kad
+    // in client mode while remaining a full peer — so "client" is a
+    // marker on a row, not a role that replaces the others.
+    DhtRole dht_role = 12;
+}
+
+// A peer's DHT participation, as reported by identify.
+//
+// Three states, not a bool: identify completes shortly *after* the
+// connection establishes, so a freshly-connected peer has no protocol
+// list yet. UNKNOWN keeps that gap honest — a client filtering on this
+// would otherwise blink rows in and out as connections settle.
+enum DhtRole {
+    // Identify has not reported this peer's protocols yet.
+    DHT_ROLE_UNKNOWN = 0;
+
+    // Advertises kad: a routing hop that can store records and be
+    // returned as a lookup result.
+    DHT_ROLE_SERVER = 1;
+
+    // Identify completed and kad was absent. Queries the DHT without
+    // serving it. Common and permanent — every hivemind/Python process
+    // proxies through such a peer, and rust-libp2p nodes sit in this
+    // mode until reachability resolves.
+    DHT_ROLE_CLIENT = 2;
 }
 
 // One entry in the Kademlia routing table.

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -344,8 +344,10 @@ message BlockCoverageUpdate {
 // Requires the native p2p stack. The Go p2p daemon's control protocol
 // reports only (peer id, addresses) per connection, so direction,
 // protocols, latency and the routing table have nowhere to come from;
-// the daemon answers FAILED_PRECONDITION rather than serving a view
-// that is mostly blank.
+// rather than serve a mostly-blank view the daemon answers
+// UNIMPLEMENTED, which a client should treat as permanent for the
+// daemon's lifetime. UNAVAILABLE means something different here — the
+// native node is still starting and a retry will succeed.
 message NetworkRequest {
     // When true the operation stays open and the server pushes updates
     // until the client sends a Cancel body for this op id. When false a
@@ -454,9 +456,12 @@ message SelfStatus {
     // Announcing is deferred while unknown.
     string reachability = 2;
 
-    // What produced the verdict: "identify" (peer consensus), "autonat"
-    // (a dial-back probe) or "declared" (operator configuration — an
-    // instruction, not evidence). Empty while reachability is unknown.
+    // What produced the verdict, weakest evidence first: "identify"
+    // (enough distinct peers reported the same address), "upnp" (the
+    // local gateway says it mapped us), "autonat" (a peer dialed us back
+    // and got through) or "declared" (operator configuration — an
+    // instruction, not evidence at all). Empty unless reachability is
+    // "public": a private or undecided verdict has no source.
     string reachability_source = 3;
 
     // Whether at least one *confirmed* circuit reservation is live. A

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -85,6 +85,13 @@ message ClientFrame {
         // Done); a live feed when true (a BlockCoverageUpdate every
         // refresh interval until cancelled with a `Cancel` body).
         BlockCoverageRequest block_coverage = 15;
+        // Local p2p state: connections, DHT routing table and this
+        // node's own reachability. Unlike the two above it queries no
+        // DHT — it reads the swarm — so it is cheap enough to poll at a
+        // few seconds. Reachability changes push out of band rather than
+        // waiting for the next tick; see NetworkUpdate.reason.
+        NetworkRequest network = 17;
+
 
         // VPK storage-node discovery. Like block_coverage, but for the
         // `_kwaai.vpk.nodes` DHT registry. Note that a one-shot request
@@ -122,6 +129,11 @@ message ServerFrame {
         // one-shot BlockCoverageRequest; a subscription delivers one
         // per refresh interval until the op is cancelled.
         BlockCoverageUpdate block_coverage = 15;
+        // Snapshot of local p2p state. One arrives for a one-shot
+        // NetworkRequest; a subscription delivers one per refresh
+        // interval, plus one immediately whenever reachability changes.
+        NetworkUpdate network = 17;
+
 
         // Snapshot of discovered VPK storage nodes. Arrives in pairs
         // per discovery round: one with probes_pending set, then one
@@ -325,6 +337,170 @@ message BlockCoverageUpdate {
 
     // All discovered block servers, sorted by start_block.
     repeated BlockPeer peers = 7;
+}
+
+// `kwaainet p2p peers list`, and more — local swarm state.
+//
+// Requires the native p2p stack. The Go p2p daemon's control protocol
+// reports only (peer id, addresses) per connection, so direction,
+// protocols, latency and the routing table have nowhere to come from;
+// the daemon answers FAILED_PRECONDITION rather than serving a view
+// that is mostly blank.
+message NetworkRequest {
+    // When true the operation stays open and the server pushes updates
+    // until the client sends a Cancel body for this op id. When false a
+    // single update is sent followed by Done.
+    bool subscribe = 1;
+
+    // Refresh cadence for subscriptions, in seconds. 0 means the server
+    // default (5s). Ignored when `subscribe` is false.
+    //
+    // This is the *sampling* floor, not the whole story: connections and
+    // the routing table have no event source and so are polled, but
+    // reachability changes are pushed the moment they happen. See
+    // NetworkUpdate.reason.
+    uint32 interval_secs = 2;
+}
+
+// Why a NetworkUpdate was sent.
+//
+// Without this a client cannot tell a routine sample from a genuine
+// event, and would have to infer it by diffing successive snapshots.
+enum UpdateReason {
+    // The refresh timer fired and something changed, or this is the
+    // single update of a one-shot request.
+    UPDATE_REASON_TICK = 0;
+
+    // Reachability, relay use, or announceability moved. Sent
+    // immediately rather than on the next tick boundary.
+    UPDATE_REASON_REACHABILITY = 1;
+
+    // The connected-peer or routing set changed since the last update.
+    UPDATE_REASON_PEERS = 2;
+
+    // Nothing changed. Sent periodically so a client can distinguish a
+    // quiet network from a stalled feed.
+    UPDATE_REASON_HEARTBEAT = 3;
+}
+
+// How a connection reaches the peer.
+enum PeerConnKind {
+    // A plain transport address — directly dialable.
+    PEER_CONN_KIND_DIRECT = 0;
+
+    // The path runs through a circuit relay.
+    PEER_CONN_KIND_RELAY = 1;
+}
+
+// One live connection.
+//
+// Per connection, not per peer: a peer reachable both directly and over
+// a relay appears twice, which is what makes a hole-punch upgrade
+// visible while it happens.
+message ConnectedPeer {
+    // libp2p peer id, base58.
+    string peer_id = 1;
+
+    // The connection's multiaddr — the remote address for outbound
+    // connections, the observed send-back address for inbound ones.
+    string addr = 2;
+
+    PeerConnKind kind = 3;
+
+    // "inbound" if the peer dialed us, "outbound" if we dialed them.
+    string direction = 4;
+
+    // Set when this peer is one of our configured bootstrap nodes.
+    bool is_bootstrap = 5;
+
+    // Set when this peer is one of our configured trusted relays.
+    bool is_trusted_relay = 6;
+
+    // Protocols the peer advertised over identify. Empty until identify
+    // completes, which is shortly *after* the connection establishes —
+    // empty means "not yet known", not "speaks nothing".
+    repeated string protocols = 7;
+
+    // Most recent ping round-trip time. 0 means no ping has completed
+    // yet, not zero latency.
+    uint32 rtt_ms = 8;
+
+    // The peer's advertised software version. May be empty.
+    string agent_version = 9;
+}
+
+// One entry in the Kademlia routing table.
+//
+// The routing table and the connected set overlap but neither contains
+// the other: k-buckets hold a bounded number of entries per distance
+// range, the table deliberately retains peers we are not currently
+// connected to, and kad stays in client mode (adding nothing) until
+// reachability resolves. A young node can have live connections and an
+// empty table.
+message RoutingPeer {
+    // libp2p peer id, base58.
+    string peer_id = 1;
+
+    // Whether this peer also appears in NetworkUpdate.connected.
+    bool connected = 2;
+}
+
+// This node's own position in the network.
+message SelfStatus {
+    // Our libp2p peer id, base58.
+    string peer_id = 1;
+
+    // "unknown" until a verdict is reached, then "public" or "private".
+    // Announcing is deferred while unknown.
+    string reachability = 2;
+
+    // What produced the verdict: "identify" (peer consensus), "autonat"
+    // (a dial-back probe) or "declared" (operator configuration — an
+    // instruction, not evidence). Empty while reachability is unknown.
+    string reachability_source = 3;
+
+    // Whether at least one *confirmed* circuit reservation is live. A
+    // requested-but-unanswered reservation does not count.
+    bool using_relay = 4;
+
+    // Whether there is any point announcing to the DHT yet. False only
+    // while reachability is unknown.
+    bool announceable = 5;
+
+    // The swarm's listen addresses.
+    repeated string listen_addrs = 6;
+
+    // Addresses peers reported observing us at — our external-address
+    // candidates. Ordered by the number of distinct peers that agreed,
+    // most-confirmed first.
+    repeated string observed_addrs = 7;
+
+    // Addresses of confirmed circuit-relay reservations. Empty when not
+    // relaying.
+    repeated string relay_addrs = 8;
+}
+
+// Snapshot of local p2p state.
+//
+// A subscription suppresses unchanged snapshots, so a client should read
+// silence as "nothing changed" rather than as a stalled feed — an
+// unchanged snapshot is still sent periodically as a heartbeat, so a
+// feed quiet for much longer than the heartbeat is genuinely wedged.
+message NetworkUpdate {
+    // Daemon wall-clock time of this snapshot, RFC 3339.
+    string server_time = 1;
+
+    UpdateReason reason = 2;
+
+    SelfStatus self_status = 3;
+
+    // One entry per live connection, ordered bootstrap → trusted relay →
+    // direct → relayed, then by peer id, so the ordering is stable
+    // across updates.
+    repeated ConnectedPeer connected = 4;
+
+    // The Kademlia routing table, sorted by peer id.
+    repeated RoutingPeer routing = 5;
 }
 
 // `kwaainet vpk discover` — VPK storage nodes from the DHT.

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -430,6 +430,16 @@ message ConnectedPeer {
     // The peer's advertised software version. May be empty.
     string agent_version = 9;
 
+    // The relay an inbound connection arrived through, when it was
+    // relayed. Empty otherwise.
+    //
+    // An inbound relayed connection's `addr` is a bare `/p2p/<peer>`: it
+    // names who reached us and says nothing about how. This is the local
+    // end of that connection — our circuit listener — and is the only
+    // place the relay's address and identity appear. Outbound needs no
+    // equivalent, since the dialled address already carries the relay.
+    string via = 11;
+
     // Whether DCUtR upgraded this connection from a relayed path to a
     // direct one.
     //

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -501,6 +501,15 @@ message SelfStatus {
     // Addresses of confirmed circuit-relay reservations. Empty when not
     // relaying.
     repeated string relay_addrs = 8;
+
+    // Protocols this node serves to peers, sorted.
+    //
+    // The handlers actually registered rather than everything the swarm
+    // might negotiate: libp2p keeps its full advertised set private, and
+    // this is the more useful answer anyway — it is what this node will
+    // *do* for a peer, which is what a reader comparing it against a
+    // peer's protocol list wants to know.
+    repeated string local_protocols = 9;
 }
 
 // Snapshot of local p2p state.

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -92,6 +92,10 @@ message ClientFrame {
         // waiting for the next tick; see NetworkUpdate.reason.
         NetworkRequest network = 17;
 
+        // Dial a peer by id. One ConnectReply, then Done.
+        ConnectRequest connect = 18;
+
+
 
         // VPK storage-node discovery. Like block_coverage, but for the
         // `_kwaai.vpk.nodes` DHT registry. Note that a one-shot request
@@ -133,6 +137,10 @@ message ServerFrame {
         // NetworkRequest; a subscription delivers one per refresh
         // interval, plus one immediately whenever reachability changes.
         NetworkUpdate network = 17;
+
+        // Reply to a ConnectRequest.
+        ConnectReply connect = 18;
+
 
 
         // Snapshot of discovered VPK storage nodes. Arrives in pairs
@@ -654,6 +662,29 @@ message StorageUpdate {
     // All discovered nodes, sorted by public_name then peer_id so the
     // ordering is stable across rounds.
     repeated StoragePeer peers = 3;
+}
+
+// Dial a peer we know of but hold no connection to.
+//
+// A bare peer id is resolved through the DHT first, the way Go's routed
+// host does it, so the caller does not need an address — which is the
+// point: the routing table knows peers it has no connection to, and this
+// is how you reach one.
+//
+// Note this makes *us* the dialer, so it will not trigger a DCUtR
+// upgrade: libp2p has the inbound side initiate hole punching.
+message ConnectRequest {
+    // libp2p peer id, base58. An address is resolved via the DHT.
+    string peer_id = 1;
+}
+
+message ConnectReply {
+    // True when a connection exists after the attempt — including when
+    // one already existed, since the caller's goal is met either way.
+    bool connected = 1;
+
+    // Failure detail, empty on success.
+    string error = 2;
 }
 
 // =====================================================================

--- a/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
+++ b/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
@@ -234,6 +234,10 @@ fn network_update_roundtrip_all_sections() {
             listen_addrs: vec!["/ip4/0.0.0.0/tcp/4001".to_string()],
             observed_addrs: vec!["/ip4/203.0.113.7/tcp/4001".to_string()],
             relay_addrs: vec!["/ip4/198.18.0.50/tcp/4001/p2p-circuit".to_string()],
+            local_protocols: vec![
+                "/ipfs/kad/1.0.0".to_string(),
+                "/kwaai/inference/1.0.0".to_string(),
+            ],
         }),
         connected: vec![ConnectedPeer {
             peer_id: "12D3KooWExamplePeerA".to_string(),

--- a/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
+++ b/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
@@ -14,7 +14,10 @@
 //!   * a `None` produces a body that omits the tag entirely and decodes back
 //!     to `None` (we are NOT silently widening absent-vs-empty).
 
-use kwaai_rpc::v1::{ChatMessage, ChatToken};
+use kwaai_rpc::v1::{
+    client_frame, server_frame, ChatMessage, ChatToken, ClientFrame, ConnectedPeer, NetworkRequest,
+    NetworkUpdate, PeerConnKind, RoutingPeer, SelfStatus, ServerFrame, UpdateReason,
+};
 use prost::Message;
 
 /// `ChatMessage` with every field set, including `conversation_id`.
@@ -153,5 +156,221 @@ fn chat_token_finish_reason_wire_tag_is_stable() {
         bytes.as_slice(),
         &[0x1a, 0x01, b'y'],
         "finish_reason must serialise at proto tag 3 (key byte 0x1a)"
+    );
+}
+
+/// `ConnectedPeer` round-trip with every field populated.
+///
+/// The three enrichment fields (`protocols`, `rtt_ms`, `agent_version`) fill
+/// in from identify and ping *after* a connection establishes, so the empty
+/// state is meaningful and is covered separately below.
+#[test]
+fn connected_peer_roundtrip_all_fields_set() {
+    let original = ConnectedPeer {
+        peer_id: "12D3KooWExampleBootstrapPeerIdBase58".to_string(),
+        addr: "/ip4/198.18.0.10/tcp/8000".to_string(),
+        kind: PeerConnKind::Direct as i32,
+        direction: "outbound".to_string(),
+        is_bootstrap: true,
+        is_trusted_relay: false,
+        protocols: vec![
+            "/ipfs/kad/1.0.0".to_string(),
+            "/libp2p/circuit/relay/0.2.0/hop".to_string(),
+        ],
+        rtt_ms: 42,
+        agent_version: "kwaainet/0.5.4".to_string(),
+    };
+
+    let decoded = ConnectedPeer::decode(original.encode_to_vec().as_slice())
+        .expect("ConnectedPeer must decode from its own encoding");
+    assert_eq!(decoded, original);
+}
+
+/// A freshly established connection: identify and ping have not completed, so
+/// the enrichment fields are empty/zero.
+///
+/// This pins the "not yet known" encoding. `rtt_ms == 0` must mean "no ping has
+/// completed", never "zero latency", and an empty `protocols` must not be
+/// confused with "speaks nothing" — a client rendering these needs the
+/// distinction to survive the wire.
+#[test]
+fn connected_peer_roundtrip_before_identify() {
+    let original = ConnectedPeer {
+        peer_id: "12D3KooWExampleFreshlyConnectedPeer".to_string(),
+        addr: "/ip4/192.168.1.10/tcp/4001".to_string(),
+        kind: PeerConnKind::Relay as i32,
+        direction: "inbound".to_string(),
+        is_bootstrap: false,
+        is_trusted_relay: false,
+        protocols: vec![],
+        rtt_ms: 0,
+        agent_version: String::new(),
+    };
+
+    let decoded = ConnectedPeer::decode(original.encode_to_vec().as_slice())
+        .expect("ConnectedPeer must decode from its own encoding");
+    assert_eq!(decoded, original);
+    assert!(decoded.protocols.is_empty());
+    assert_eq!(decoded.rtt_ms, 0);
+}
+
+/// `NetworkUpdate` carrying all three sections.
+///
+/// Guards the section tags against renumbering: `self_status` (3),
+/// `connected` (4) and `routing` (5) are what the GUI's Network page binds to.
+#[test]
+fn network_update_roundtrip_all_sections() {
+    let original = NetworkUpdate {
+        server_time: "2026-08-01T12:00:00Z".to_string(),
+        reason: UpdateReason::Reachability as i32,
+        self_status: Some(SelfStatus {
+            peer_id: "12D3KooWExampleSelfPeerId".to_string(),
+            reachability: "private".to_string(),
+            reachability_source: "autonat".to_string(),
+            using_relay: true,
+            announceable: true,
+            listen_addrs: vec!["/ip4/0.0.0.0/tcp/4001".to_string()],
+            observed_addrs: vec!["/ip4/203.0.113.7/tcp/4001".to_string()],
+            relay_addrs: vec!["/ip4/198.18.0.50/tcp/4001/p2p-circuit".to_string()],
+        }),
+        connected: vec![ConnectedPeer {
+            peer_id: "12D3KooWExamplePeerA".to_string(),
+            addr: "/ip4/198.18.0.10/tcp/8000".to_string(),
+            kind: PeerConnKind::Direct as i32,
+            direction: "outbound".to_string(),
+            is_bootstrap: true,
+            is_trusted_relay: false,
+            protocols: vec!["/ipfs/kad/1.0.0".to_string()],
+            rtt_ms: 7,
+            agent_version: "kwaainet/0.5.4".to_string(),
+        }],
+        routing: vec![
+            RoutingPeer {
+                peer_id: "12D3KooWExamplePeerA".to_string(),
+                connected: true,
+            },
+            RoutingPeer {
+                peer_id: "12D3KooWExampleKnownButOffline".to_string(),
+                connected: false,
+            },
+        ],
+    };
+
+    let decoded = NetworkUpdate::decode(original.encode_to_vec().as_slice())
+        .expect("NetworkUpdate must decode from its own encoding");
+    assert_eq!(decoded, original);
+}
+
+/// The routing table legitimately holds peers we are not connected to, and a
+/// young node has connections but an empty table. Neither set contains the
+/// other, so both edges must survive the wire.
+#[test]
+fn network_update_roundtrip_disjoint_peer_sets() {
+    // Connections established, kad still in client mode: empty routing table.
+    let young = NetworkUpdate {
+        server_time: "2026-08-01T12:00:00Z".to_string(),
+        reason: UpdateReason::Tick as i32,
+        self_status: Some(SelfStatus {
+            reachability: "unknown".to_string(),
+            announceable: false,
+            ..Default::default()
+        }),
+        connected: vec![ConnectedPeer {
+            peer_id: "12D3KooWExamplePeerA".to_string(),
+            ..Default::default()
+        }],
+        routing: vec![],
+    };
+    let decoded = NetworkUpdate::decode(young.encode_to_vec().as_slice()).expect("must decode");
+    assert_eq!(decoded, young);
+    assert!(decoded.routing.is_empty());
+    assert_eq!(decoded.connected.len(), 1);
+
+    // The converse: a routing entry for a peer we hold no connection to.
+    let known_not_connected = NetworkUpdate {
+        server_time: "2026-08-01T12:00:00Z".to_string(),
+        reason: UpdateReason::Peers as i32,
+        self_status: None,
+        connected: vec![],
+        routing: vec![RoutingPeer {
+            peer_id: "12D3KooWExampleKnownButOffline".to_string(),
+            connected: false,
+        }],
+    };
+    let decoded =
+        NetworkUpdate::decode(known_not_connected.encode_to_vec().as_slice()).expect("must decode");
+    assert_eq!(decoded, known_not_connected);
+}
+
+/// `UpdateReason::Tick` is the proto3 zero value, so it occupies no bytes on
+/// the wire. That is deliberate — but it means a client cannot distinguish
+/// "reason was TICK" from "sender predates the field". Pin the two facts that
+/// matter: TICK is the default, and every other reason survives the round trip.
+#[test]
+fn update_reason_tick_is_the_zero_value() {
+    let tick = NetworkUpdate {
+        reason: UpdateReason::Tick as i32,
+        ..Default::default()
+    };
+    assert!(
+        tick.encode_to_vec().is_empty(),
+        "an otherwise-empty NetworkUpdate with reason=TICK must encode to zero bytes"
+    );
+
+    for reason in [
+        UpdateReason::Reachability,
+        UpdateReason::Peers,
+        UpdateReason::Heartbeat,
+    ] {
+        let msg = NetworkUpdate {
+            reason: reason as i32,
+            ..Default::default()
+        };
+        let decoded = NetworkUpdate::decode(msg.encode_to_vec().as_slice()).expect("must decode");
+        assert_eq!(
+            decoded.reason, reason as i32,
+            "{reason:?} must survive the round trip"
+        );
+    }
+}
+
+/// The Session envelope slot. `NetworkRequest` rides at oneof tag 17 on
+/// ClientFrame and `NetworkUpdate` at tag 17 on ServerFrame; the GUI dispatches
+/// on exactly those, and tags 10-16 are already spoken for by other operations.
+#[test]
+fn network_frames_occupy_oneof_tag_17() {
+    let req = ClientFrame {
+        id: 1,
+        body: Some(client_frame::Body::Network(NetworkRequest {
+            subscribe: true,
+            interval_secs: 5,
+        })),
+    };
+    let decoded =
+        ClientFrame::decode(req.encode_to_vec().as_slice()).expect("ClientFrame must decode");
+    assert!(
+        matches!(decoded.body, Some(client_frame::Body::Network(_))),
+        "NetworkRequest must ride in the ClientFrame.network oneof arm"
+    );
+
+    // Tag 17, wire type 2 (LEN) => (17 << 3) | 2 = 138 => varint [0x8a, 0x01].
+    let body_only = ClientFrame {
+        id: 0,
+        body: Some(client_frame::Body::Network(NetworkRequest::default())),
+    };
+    assert_eq!(
+        body_only.encode_to_vec().as_slice(),
+        &[0x8a, 0x01, 0x00],
+        "ClientFrame.network must serialise at proto tag 17"
+    );
+
+    let update = ServerFrame {
+        id: 1,
+        body: Some(server_frame::Body::Network(NetworkUpdate::default())),
+    };
+    assert_eq!(
+        update.encode_to_vec().as_slice(),
+        &[0x08, 0x01, 0x8a, 0x01, 0x00],
+        "ServerFrame.network must serialise at proto tag 17"
     );
 }

--- a/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
+++ b/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
@@ -15,8 +15,9 @@
 //!     to `None` (we are NOT silently widening absent-vs-empty).
 
 use kwaai_rpc::v1::{
-    client_frame, server_frame, ChatMessage, ChatToken, ClientFrame, ConnectedPeer, NetworkRequest,
-    NetworkUpdate, PeerConnKind, RoutingPeer, SelfStatus, ServerFrame, UpdateReason,
+    client_frame, server_frame, ChatMessage, ChatToken, ClientFrame, ConnectedPeer, DhtRole,
+    NetworkRequest, NetworkUpdate, PeerConnKind, RoutingPeer, SelfStatus, ServerFrame,
+    UpdateReason,
 };
 use prost::Message;
 
@@ -181,6 +182,9 @@ fn connected_peer_roundtrip_all_fields_set() {
         agent_version: "kwaainet/0.5.4".to_string(),
         via: String::new(),
         dcutr: false,
+        // Consistent with the kad protocol advertised above: a peer that
+        // speaks kad is a DHT server.
+        dht_role: DhtRole::Server as i32,
     };
 
     let decoded = ConnectedPeer::decode(original.encode_to_vec().as_slice())
@@ -209,6 +213,9 @@ fn connected_peer_roundtrip_before_identify() {
         agent_version: String::new(),
         via: String::new(),
         dcutr: false,
+        // Identify has not run, so the role is genuinely not known yet —
+        // the same "not yet known" state this test exists to pin.
+        dht_role: DhtRole::Unknown as i32,
     };
 
     let decoded = ConnectedPeer::decode(original.encode_to_vec().as_slice())
@@ -253,17 +260,22 @@ fn network_update_roundtrip_all_sections() {
             agent_version: "kwaainet/0.5.4".to_string(),
             via: String::new(),
             dcutr: false,
+            dht_role: DhtRole::Server as i32,
         }],
         routing: vec![
             RoutingPeer {
                 peer_id: "12D3KooWExamplePeerA".to_string(),
                 connected: true,
                 is_bootstrap: false,
+                addrs: vec!["/ip4/198.18.0.10/tcp/8000".to_string()],
             },
             RoutingPeer {
                 peer_id: "12D3KooWExampleKnownButOffline".to_string(),
                 connected: false,
                 is_bootstrap: false,
+                // A routing entry keeps its addresses after the connection
+                // drops — that is what makes it dialable again later.
+                addrs: vec!["/ip4/198.18.0.99/tcp/8000".to_string()],
             },
         ],
     };
@@ -308,6 +320,10 @@ fn network_update_roundtrip_disjoint_peer_sets() {
             peer_id: "12D3KooWExampleKnownButOffline".to_string(),
             connected: false,
             is_bootstrap: false,
+            // Deliberately empty: a routing entry carrying no address is
+            // the degenerate case a client has to be able to distinguish,
+            // and an empty list must survive the wire as one.
+            addrs: vec![],
         }],
     };
     let decoded =

--- a/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
+++ b/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
@@ -179,6 +179,7 @@ fn connected_peer_roundtrip_all_fields_set() {
         ],
         rtt_ms: 42,
         agent_version: "kwaainet/0.5.4".to_string(),
+        via: String::new(),
         dcutr: false,
     };
 
@@ -206,6 +207,7 @@ fn connected_peer_roundtrip_before_identify() {
         protocols: vec![],
         rtt_ms: 0,
         agent_version: String::new(),
+        via: String::new(),
         dcutr: false,
     };
 
@@ -249,6 +251,7 @@ fn network_update_roundtrip_all_sections() {
             protocols: vec!["/ipfs/kad/1.0.0".to_string()],
             rtt_ms: 7,
             agent_version: "kwaainet/0.5.4".to_string(),
+            via: String::new(),
             dcutr: false,
         }],
         routing: vec![

--- a/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
+++ b/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
@@ -179,6 +179,7 @@ fn connected_peer_roundtrip_all_fields_set() {
         ],
         rtt_ms: 42,
         agent_version: "kwaainet/0.5.4".to_string(),
+        dcutr: false,
     };
 
     let decoded = ConnectedPeer::decode(original.encode_to_vec().as_slice())
@@ -205,6 +206,7 @@ fn connected_peer_roundtrip_before_identify() {
         protocols: vec![],
         rtt_ms: 0,
         agent_version: String::new(),
+        dcutr: false,
     };
 
     let decoded = ConnectedPeer::decode(original.encode_to_vec().as_slice())
@@ -243,15 +245,18 @@ fn network_update_roundtrip_all_sections() {
             protocols: vec!["/ipfs/kad/1.0.0".to_string()],
             rtt_ms: 7,
             agent_version: "kwaainet/0.5.4".to_string(),
+            dcutr: false,
         }],
         routing: vec![
             RoutingPeer {
                 peer_id: "12D3KooWExamplePeerA".to_string(),
                 connected: true,
+                is_bootstrap: false,
             },
             RoutingPeer {
                 peer_id: "12D3KooWExampleKnownButOffline".to_string(),
                 connected: false,
+                is_bootstrap: false,
             },
         ],
     };
@@ -295,6 +300,7 @@ fn network_update_roundtrip_disjoint_peer_sets() {
         routing: vec![RoutingPeer {
             peer_id: "12D3KooWExampleKnownButOffline".to_string(),
             connected: false,
+            is_bootstrap: false,
         }],
     };
     let decoded =


### PR DESCRIPTION
Adds the `Network` session op at **frame tag 17** and a `Connect` op at **tag 18**, giving a client a whole-network view of a node's p2p state and a way to dial a peer the node knows about but is not connected to.

### Why now

`Kwaai-AI-Lab/KwaaiNetGUI` `main` already ships the Peers tab (`lib/src/ui/pages/peers_tab.dart`), and its generated bindings reference tags 17 and 18. Released KwaaiNet **v0.6.2** stops at tag 16 (`storage`), so the GUI's Peers tab currently has no daemon that understands its frames. This PR closes that gap — it is the remaining blocker for shipping the GUI against an upstream KwaaiNet release.

The GUI's bindings and this proto were verified to match field-for-field and tag-for-tag across all seven new messages (`NetworkRequest`, `NetworkUpdate`, `ConnectRequest`, `ConnectReply`, `ConnectedPeer`, `RoutingPeer`, `SelfStatus`).

### What it adds

**`kwaai-p2p`** — the swarm exposes RTT, agent version, served protocols, DCUtR upgrades, the relay an inbound connection arrived through, routing-table addresses, and DHT client/server role, as one whole-network snapshot.

**`kwaai-rpc`** — `NetworkRequest`/`NetworkUpdate` at tag 17 (one-shot or subscribe with an interval), `ConnectRequest`/`ConnectReply` at tag 18.

**`kwaai-cli`** — serves both ops from the native swarm; a new `peers_view` module holds the classification logic (bootstrap/relay identification, connection kind, DHT role) shared with `kwaainet p2p peers`.

Two fixes fell out of the work: the swarm no longer re-dials peers it is already connected to, and a transportless connection is no longer reported as direct.

### Tag allocation

17 and 18 are unused on `main` (which allocates through 16). No existing tag changes meaning.

### Non-native path

`Network` returns `UNIMPLEMENTED` rather than `UNAVAILABLE` when the node is on the Go p2p path — the handle slot will never fill there, so a client retrying `UNAVAILABLE` would retry forever. During native startup, when the slot is about to fill, it returns `UNAVAILABLE` so retrying is correct. Read through `KwaaiNetConfig::native_p2p()` so the three-state flag from #114 resolves properly.

### Testing

Rebased onto `main` at `b359162f`. `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` passes with 0 failures. Proto round-trip coverage extended for the new frames; `kwaai-p2p/tests/swarm.rs` covers the snapshot.
