### PR TITLE
refactor(config): set_key mutates, callers persist

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -1057,6 +1057,18 @@ impl KwaaiNetConfig {
     }
 
     /// Set a top-level key by name (string value coerced to the right type).
+    ///
+    /// **Mutates only — the caller persists.** This used to end in `save()`,
+    /// which made a setter perform disk I/O: every caller wrote the whole
+    /// config to `~/.kwaainet/config.yaml` as a side effect of assigning one
+    /// field. Unit tests calling `set_key` on a `KwaaiNetConfig::default()`
+    /// therefore serialised an empty config over the developer's real one,
+    /// destroying every key a default does not carry — on one machine, 23
+    /// registered knowledge bases, `inference_url`, the storage block and the
+    /// vpk settings.
+    ///
+    /// Separating the two also lets a caller validate several keys before
+    /// committing any of them, which the implicit save made impossible.
     pub fn set_key(&mut self, key: &str, value: &str) -> Result<()> {
         match key {
             "model" => self.model = value.to_string(),
@@ -1113,7 +1125,7 @@ impl KwaaiNetConfig {
                 key
             ),
         }
-        self.save()
+        Ok(())
     }
 }
 
@@ -1477,24 +1489,33 @@ mod test_isolation {
     }
 
     #[test]
-    fn set_key_saves_into_the_sandbox_only() {
-        // set_key() ends in save(). Prove the write lands in the sandbox.
+    fn set_key_does_not_touch_the_disk() {
+        // The hazard at its source: a setter must not perform I/O.
         if std::env::var("KWAAINET_HOME").is_ok() {
             return;
         }
+        let path = config_file();
+        let before = std::fs::read(&path).ok();
         let mut cfg = KwaaiNetConfig::default();
         cfg.set_key("start_block", "16").expect("set");
-        let written = config_file();
-        assert!(
-            written.starts_with(std::env::temp_dir()),
-            "config write escaped the sandbox: {}",
-            written.display()
+        assert_eq!(
+            std::fs::read(&path).ok(),
+            before,
+            "set_key wrote to disk; it must only mutate the struct"
         );
-        assert!(
-            written.exists(),
-            "save() should have written the sandbox copy"
-        );
+        assert_eq!(cfg.start_block, Some(16), "but it must still mutate");
     }
+
+    // There is deliberately no test here that calls `save()` and then asserts
+    // the file landed in the sandbox. `grpc_server`'s tests set `KWAAINET_HOME`
+    // process-wide (guarded by a mutex private to that module, so it does not
+    // serialise against this one), which means a concurrent `save()` can be
+    // redirected into their temp dir between the write and the assertion. Such
+    // a test passes alone and fails in the suite.
+    //
+    // `config_path_is_sandboxed_under_test` covers the guard without touching
+    // the filesystem, and `set_key_does_not_touch_the_disk` above covers the
+    // behaviour this module actually protects.
 }
 
 /// Block-shard serving is opt-in. Regression for the default flip.

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -629,7 +629,9 @@ async fn main() -> Result<()> {
                     }
                 }
                 Some(ConfigAction::Set { key, value }) => {
+                    // set_key mutates; persisting is the caller's job.
                     cfg.set_key(&key, &value)?;
+                    cfg.save()?;
                     print_box_header("⚙️  Configuration Updated");
                     print_success(&format!("Set {} = {}", key, value));
                     print_separator();


### PR DESCRIPTION
> **Stacked on #131** (which is stacked on #128). Base is `feat/shard-serving-opt-in` so this diff shows only the refactor. GitHub retargets as the stack merges.

## The hazard

`set_key` ended in `self.save()` — assigning one field wrote the whole config to disk as a side effect:

```rust
_ => anyhow::bail!("Unknown config key '{}'…", key),
}
self.save()      // ← a setter performing I/O
```

That is precisely what let unit tests destroy the real config. A test doing:

```rust
let mut cfg = KwaaiNetConfig::default();   // empty of everything you configured
cfg.set_key("start_block", "0")            // …saves it over ~/.kwaainet/config.yaml
```

serialises a *default* config over the live one, so it does not edit one key — it replaces the file. On my machine that deleted 23 KB registrations, `inference_url`, the storage block and the vpk settings, twice. Nine test call sites do this.

## Guard vs. cause

#128 sandboxes `kwaainet_dir()` under `cfg(test)`, so no test can reach the real path whatever it calls. **Keep that** — it cannot be forgotten by the next test author.

This PR removes the hazard itself. A setter should not do I/O.

## Blast radius: one caller

Exactly one production call site, `config set`, which now persists explicitly. Verified end to end against an isolated `KWAAINET_HOME`:

```
✅ Set blocks = 16
blocks: 16                    # persisted
🧱 blocks:         16         # reads back
Error: Unknown config key 'bogus_key'…
unchanged after error: YES
```

Separating mutation from persistence also makes it possible to validate several keys before committing any — impossible while every assignment wrote immediately.

## A pre-existing race this surfaced

I first added a companion test asserting `save()` lands in the sandbox. It passed alone and failed in the suite.

Cause: `grpc_server`'s tests set `KWAAINET_HOME` **process-wide** (`grpc_server.rs:1602`), serialised by a mutex private to that module — so it does not serialise against anything else. A concurrent `save()` gets redirected into their temp dir between the write and the assertion.

I removed the racy test rather than paper over it, and recorded why in a comment where it would have gone. **This is a live hazard beyond my test**: any test in this crate that touches `HOME` or `KWAAINET_HOME`-derived paths can be perturbed by the grpc module. Worth a crate-wide test lock, but that is a separate change.

## Verification

140 tests pass across **three consecutive full runs**, with the real config verified byte-identical after each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP