### PR TITLE
feat(shard): make experimental block-shard serving opt-in

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -342,27 +342,64 @@ pub struct ContributeConfig {
     #[serde(default = "default_true")]
     pub storage: bool,
 
-    /// Automatically start shard serving on daemon start (when a model is available).
-    #[serde(default = "default_true")]
-    pub shards: bool,
+    /// Automatically start **experimental** block-shard serving on daemon start.
+    ///
+    /// **Opt-in, and deliberately three-state.** `Some(true)` serves blocks,
+    /// `Some(false)` is an explicit refusal, and `None` means the operator has
+    /// never chosen — which now resolves to [`DEFAULT_CONTRIBUTE_SHARDS`],
+    /// i.e. off.
+    ///
+    /// This used to default to on. Block sharding is experimental: it does not
+    /// work on Apple Silicon at all (#117), where a node serving blocks runs
+    /// ~20x slower than the same machine serving whole models through Ollama —
+    /// so the opt-out default enrolled every Mac into the one path that makes
+    /// the network worse. Turning contribution *off* by default would be the
+    /// wrong reading of this change: whole-model serving over
+    /// `/kwaai/ollama-proxy/1.0.0` is registered by the node itself and is
+    /// unaffected, so a node with `shards: None` still contributes inference.
+    ///
+    /// It is an `Option` for the same reason `native_p2p` is: flipping a plain
+    /// `bool` default cannot distinguish "never chosen" from "explicitly set",
+    /// so it would silently override operators who deliberately asked for
+    /// sharding. Read it through [`ContributeConfig::shards`], never directly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shards: Option<bool>,
 
     /// Automatically install updates when a new version is available (pre-v1.0 default: true).
     #[serde(default = "default_true")]
     pub auto_update: bool,
 }
 
+/// Block-shard serving is opt-in: experimental, and actively harmful on Metal.
+pub const DEFAULT_CONTRIBUTE_SHARDS: bool = false;
+
+impl ContributeConfig {
+    /// Whether to serve block shards — the explicit choice if there is one,
+    /// otherwise [`DEFAULT_CONTRIBUTE_SHARDS`].
+    pub fn shards(&self) -> bool {
+        self.shards.unwrap_or(DEFAULT_CONTRIBUTE_SHARDS)
+    }
+
+    /// True when the operator has said nothing about shard serving, so the
+    /// opt-in default applies. Used to explain the change once at startup
+    /// rather than silently dropping a node's block contribution.
+    pub fn shards_unset(&self) -> bool {
+        self.shards.is_none()
+    }
+}
+
 impl Default for ContributeConfig {
     fn default() -> Self {
         Self {
             storage: true,
-            shards: true,
+            shards: None,
             auto_update: true,
         }
     }
 }
 
 fn contribute_config_is_default(c: &ContributeConfig) -> bool {
-    c.storage && c.shards && c.auto_update
+    c.storage && c.shards.is_none() && c.auto_update
 }
 
 /// Resolved contribution policy after applying CLI overrides.
@@ -998,7 +1035,7 @@ impl KwaaiNetConfig {
     pub fn contribute_policy(&self, cli_no_contribute: bool) -> ContributePolicy {
         ContributePolicy {
             storage: self.contribute.storage && !cli_no_contribute,
-            shards: self.contribute.shards && !cli_no_contribute,
+            shards: self.contribute.shards() && !cli_no_contribute,
             auto_update: self.contribute.auto_update && is_pre_release(),
         }
     }
@@ -1043,7 +1080,7 @@ impl KwaaiNetConfig {
             }
             "inference_url" => self.inference_url = value.to_string(),
             "contribute.storage" => self.contribute.storage = parse_bool(value)?,
-            "contribute.shards" => self.contribute.shards = parse_bool(value)?,
+            "contribute.shards" => self.contribute.shards = Some(parse_bool(value)?),
             "contribute.auto_update" => self.contribute.auto_update = parse_bool(value)?,
             "identify_min_confirmations" => {
                 self.identify_min_confirmations = value.parse().map_err(|_| {
@@ -1440,6 +1477,90 @@ mod test_isolation {
         assert!(
             written.exists(),
             "save() should have written the sandbox copy"
+        );
+    }
+}
+
+/// Block-shard serving is opt-in. Regression for the default flip.
+#[cfg(test)]
+mod contribute_shards_is_opt_in {
+    use super::*;
+
+    #[test]
+    fn a_fresh_node_does_not_serve_blocks() {
+        let cfg = KwaaiNetConfig::default();
+        assert!(cfg.contribute.shards_unset(), "nothing chosen");
+        assert!(
+            !cfg.contribute.shards(),
+            "sharding is experimental — a node must opt in"
+        );
+    }
+
+    #[test]
+    fn an_explicit_opt_in_is_honoured() {
+        let mut cfg = KwaaiNetConfig::default();
+        cfg.set_key("contribute.shards", "true").expect("set");
+        assert_eq!(cfg.contribute.shards, Some(true));
+        assert!(cfg.contribute.shards());
+        assert!(!cfg.contribute.shards_unset(), "the operator chose");
+    }
+
+    #[test]
+    fn an_explicit_opt_out_is_distinguishable_from_unset() {
+        let mut cfg = KwaaiNetConfig::default();
+        cfg.set_key("contribute.shards", "false").expect("set");
+        assert_eq!(
+            cfg.contribute.shards,
+            Some(false),
+            "an explicit no must not read as 'never chosen'"
+        );
+        assert!(!cfg.contribute.shards_unset());
+    }
+
+    #[test]
+    fn a_config_written_before_the_flip_still_opts_in() {
+        // Upgrade path: `contribute.shards: true` was written by an older
+        // version. That is an explicit value and must keep serving blocks.
+        let cfg: KwaaiNetConfig =
+            serde_yaml::from_str("contribute:\n  shards: true\n").expect("deserialize");
+        assert!(
+            cfg.contribute.shards(),
+            "an operator who asked for sharding keeps it across the flip"
+        );
+    }
+
+    #[test]
+    fn a_config_with_no_contribute_block_reads_as_opt_in_off() {
+        let cfg: KwaaiNetConfig = serde_yaml::from_str("model: foo/bar\n").expect("deserialize");
+        assert!(!cfg.contribute.shards());
+        assert!(cfg.contribute.shards_unset());
+    }
+
+    #[test]
+    fn storage_contribution_is_untouched_by_the_flip() {
+        let cfg = KwaaiNetConfig::default();
+        assert!(
+            cfg.contribute.storage,
+            "only shard serving became opt-in; storage stays opt-out"
+        );
+    }
+
+    #[test]
+    fn no_contribute_still_overrides_an_explicit_opt_in() {
+        let mut cfg = KwaaiNetConfig::default();
+        cfg.set_key("contribute.shards", "true").expect("set");
+        let policy = cfg.contribute_policy(true);
+        assert!(!policy.shards, "--no-contribute wins over config");
+        assert!(!policy.storage);
+    }
+
+    #[test]
+    fn unset_shards_is_omitted_from_yaml() {
+        let cfg = KwaaiNetConfig::default();
+        let yaml = serde_yaml::to_string(&cfg).expect("serialize");
+        assert!(
+            !yaml.contains("shards:"),
+            "an unchosen value should not be written as though it were a decision"
         );
     }
 }

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -409,6 +409,22 @@ pub struct ContributePolicy {
     pub auto_update: bool,
 }
 
+impl ContributePolicy {
+    /// Whether to start block-shard serving, given an explicit `--shard` flag.
+    ///
+    /// `--shard` is itself an opt-in and must win over an unset config. While
+    /// `contribute.shards` defaulted to true this distinction did not matter,
+    /// because `self.shards` was already true whenever the flag was plausible.
+    /// With shard serving opt-in it matters a great deal: without it,
+    /// `kwaainet start --daemon --shard` refuses and advises the operator to
+    /// set the config key for the thing they just asked for.
+    ///
+    /// `--no-contribute` still outranks both — it is the bigger hammer.
+    pub fn serve_shards(&self, shard_flag: bool, no_contribute: bool) -> bool {
+        self.shards || (shard_flag && !no_contribute)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HealthConfig {
     #[serde(default = "default_true")]
@@ -1556,11 +1572,75 @@ mod contribute_shards_is_opt_in {
 
     #[test]
     fn unset_shards_is_omitted_from_yaml() {
-        let cfg = KwaaiNetConfig::default();
+        // `storage: false` forces the `contribute:` block to serialize at all —
+        // a wholly default config is skipped by `contribute_config_is_default`,
+        // so without this the assertion would hold even if the
+        // `skip_serializing_if` on `shards` were missing, and prove nothing.
+        let mut cfg = KwaaiNetConfig::default();
+        cfg.contribute.storage = false;
         let yaml = serde_yaml::to_string(&cfg).expect("serialize");
+        assert!(
+            yaml.contains("contribute:"),
+            "precondition: the contribute block must actually be serialized"
+        );
         assert!(
             !yaml.contains("shards:"),
             "an unchosen value should not be written as though it were a decision"
         );
+    }
+}
+
+/// `--shard` must win over an unset config. Regression for the opt-in flip.
+#[cfg(test)]
+mod shard_flag_is_an_opt_in {
+    use super::*;
+
+    fn policy(cfg_shards: Option<bool>, no_contribute: bool) -> ContributePolicy {
+        let mut cfg = KwaaiNetConfig::default();
+        cfg.contribute.shards = cfg_shards;
+        cfg.contribute_policy(no_contribute)
+    }
+
+    #[test]
+    fn the_flag_starts_shard_serving_on_an_unset_config() {
+        let p = policy(None, false);
+        assert!(!p.shards, "config alone would not serve");
+        assert!(
+            p.serve_shards(true, false),
+            "`--daemon --shard` must serve; telling the user to set a config \
+             key for what they just typed is not an acceptable answer"
+        );
+    }
+
+    #[test]
+    fn without_the_flag_an_unset_config_does_not_serve() {
+        assert!(!policy(None, false).serve_shards(false, false));
+    }
+
+    #[test]
+    fn config_opt_in_serves_without_the_flag() {
+        assert!(policy(Some(true), false).serve_shards(false, false));
+    }
+
+    #[test]
+    fn no_contribute_outranks_the_flag() {
+        let p = policy(None, true);
+        assert!(
+            !p.serve_shards(true, true),
+            "--no-contribute is the bigger hammer"
+        );
+    }
+
+    #[test]
+    fn no_contribute_outranks_a_config_opt_in_too() {
+        assert!(!policy(Some(true), true).serve_shards(false, true));
+    }
+
+    #[test]
+    fn the_flag_overrides_an_explicit_config_opt_out() {
+        // Deliberate: a flag typed now is a later decision than a config file.
+        let p = policy(Some(false), false);
+        assert!(!p.shards);
+        assert!(p.serve_shards(true, false));
     }
 }

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -322,6 +322,19 @@ async fn main() -> Result<()> {
                         cfg.model
                     ));
                     print_info("Download: kwaainet shard download");
+                } else if !policy.shards
+                    && !args.no_contribute
+                    && cfg.contribute.shards_unset()
+                    && shard_available
+                {
+                    // This node has a model and would have served blocks under
+                    // the old opt-out default. Say so once, rather than letting
+                    // its block contribution vanish silently on upgrade.
+                    print_info(
+                        "Block-shard serving is now opt-in (experimental) — not starting it.",
+                    );
+                    print_info("This node still contributes whole-model inference via Ollama.");
+                    print_info("Serve blocks anyway: kwaainet config set contribute.shards true");
                 }
 
                 // --- Storage serving ---

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -301,10 +301,18 @@ async fn main() -> Result<()> {
                 let policy = cfg.contribute_policy(args.no_contribute);
 
                 // --- Shard serving ---
+                // `--shard` is itself an explicit opt-in. `args.shard` already
+                // overrode the model-present and RAM checks below, but not the
+                // policy — which was harmless while `contribute.shards`
+                // defaulted to true, and is not now: without this, someone who
+                // typed `--shard` would be told to go and set a config key for
+                // the thing they just asked for on the command line.
+                let serve_shards = policy.serve_shards(args.shard, args.no_contribute);
+
                 let shard_explicit = args.shard;
                 let shard_available = shard_explicit || model_is_locally_available(&cfg.model);
                 let enough_ram = shard_explicit || system_total_ram_bytes() >= SHARD_MIN_RAM_BYTES;
-                if policy.shards && shard_available && enough_ram {
+                if serve_shards && shard_available && enough_ram {
                     match ShardManager::spawn_shard_child() {
                         Ok(shard_pid) => {
                             ShardManager::new().write_pid(shard_pid);
@@ -313,16 +321,16 @@ async fn main() -> Result<()> {
                         }
                         Err(e) => print_warning(&format!("Could not start shard serving: {e}")),
                     }
-                } else if policy.shards && shard_available && !enough_ram {
+                } else if serve_shards && shard_available && !enough_ram {
                     print_warning("Low memory (< 10 GB) — skipping shard serving to prevent OOM.");
                     print_info("Override: kwaainet start --daemon --shard");
-                } else if policy.shards && !shard_available {
+                } else if serve_shards && !shard_available {
                     print_info(&format!(
                         "No local model found for '{}' — skipping shard serving.",
                         cfg.model
                     ));
                     print_info("Download: kwaainet shard download");
-                } else if !policy.shards
+                } else if !serve_shards
                     && !args.no_contribute
                     && cfg.contribute.shards_unset()
                     && shard_available
@@ -333,7 +341,7 @@ async fn main() -> Result<()> {
                     print_info(
                         "Block-shard serving is now opt-in (experimental) — not starting it.",
                     );
-                    print_info("This node still contributes whole-model inference via Ollama.");
+                    print_info("This node can still contribute whole-model inference via Ollama.");
                     print_info("Serve blocks anyway: kwaainet config set contribute.shards true");
                 }
 


### PR DESCRIPTION
Replaces **#131**, which GitHub auto-closed and refuses to reopen when its base branch (#128's) was deleted on merge. Same head branch, same commits, all of @dazwin's review already addressed — [his review is on #131](https://github.com/Kwaai-AI-Lab/KwaaiNet/pull/131). Now rebased onto `main`, so this is a clean two-commit diff.

## The problem

`kwaainet start --daemon` enrolled every node in block-shard serving unless it opted out. Sharding is experimental, and on Apple Silicon it does not work at all (#117):

| Path | Decode |
|---|---|
| candle, Metal GPU | 2.3 tok/s |
| candle, CPU | 4.2 tok/s |
| **Ollama (llama.cpp + Metal)** | **47.3 tok/s** |

The opt-out default signed up every Mac for the one path that makes the network *worse*.

## The change

`contribute.shards` becomes `Option<bool>` defaulting to off, matching the `native_p2p` precedent. The three states are load-bearing: a plain `bool` flip cannot distinguish "never chosen" from "explicitly set", so it would silently override operators who deliberately asked for sharding. An existing `contribute.shards: true` keeps serving blocks across the upgrade.

`--shard` is honoured as an explicit opt-in via `ContributePolicy::serve_shards`, and beats both an unset and an explicitly-false config — a flag typed now is a later decision than a config file. `--no-contribute` outranks both.

## This reduces block coverage, not contribution

Whole-model serving over `/kwaai/ollama-proxy/1.0.0` is registered by the node itself on every platform (`node.rs:340`, `node_native.rs:687`), independent of shard serving. A node with `shards` unset still serves inference — on a Mac, ~20× faster than the blocks it stopped advertising.

Expect `shard chain` coverage to drop as nodes upgrade. That is the intended effect.

## Known gap, not fixed here

`kwaainet restart` drops shard serving for a node started with `--shard`, because the flag is never persisted (`contribute_policy(false)`). This predates the PR in spirit, but the flip widens it from low-RAM forced nodes to every unset-config node. The fix is a design choice — persist `--shard` as `contribute.shards: true`, or have `restart` carry the original argv — so it is left for a follow-up. Raised by @dazwin on #131.

## Tests

14 tests: the default; explicit opt-in/opt-out staying distinguishable from unset; the pre-flip upgrade path; `--no-contribute` precedence; storage untouched; the YAML skip (now forcing the `contribute:` block to serialize so it actually exercises `Option::is_none`); and the full `--shard` truth table.

146 pass, clippy clean, real config verified untouched by the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf6kmJpKkcGEVvzzYWnAnP