### PR TITLE
fix(p2p): routed dials fall back to a DHT walk and never dial our own address

### DIFF
--- a/core/crates/kwaai-p2p/src/addresses.rs
+++ b/core/crates/kwaai-p2p/src/addresses.rs
@@ -675,6 +675,11 @@ mod tests {
 /// one `NewListenAddr` per interface, including the loopback one, so exact
 /// comparison is enough. `/p2p/…` is stripped from both sides before comparing,
 /// since dial candidates often carry it and listen addresses do not.
+///
+/// Circuit addresses are out of scope on both sides: stripped of `/p2p` hops,
+/// our own relay reservation and another peer's circuit through the same relay
+/// are the same string, and a circuit can only ever reach the destination the
+/// swarm appends to it.
 #[derive(Debug, Default)]
 pub struct OwnAddresses {
     addrs: HashSet<Multiaddr>,
@@ -685,15 +690,11 @@ impl OwnAddresses {
     /// behaviour's `on_swarm_event`, before using [`Self::is_ours`].
     pub fn on_swarm_event(&mut self, event: &FromSwarm) {
         match event {
-            FromSwarm::NewListenAddr(e) => {
-                self.addrs.insert(strip_p2p(e.addr));
-            }
+            FromSwarm::NewListenAddr(e) => self.insert(e.addr.clone()),
             FromSwarm::ExpiredListenAddr(e) => {
                 self.addrs.remove(&strip_p2p(e.addr));
             }
-            FromSwarm::ExternalAddrConfirmed(e) => {
-                self.addrs.insert(strip_p2p(e.addr));
-            }
+            FromSwarm::ExternalAddrConfirmed(e) => self.insert(e.addr.clone()),
             FromSwarm::ExternalAddrExpired(e) => {
                 self.addrs.remove(&strip_p2p(e.addr));
             }
@@ -701,9 +702,18 @@ impl OwnAddresses {
         }
     }
 
+    /// Record one of our own addresses directly, for callers reading
+    /// `listeners()` and `external_addresses()` off a swarm they already hold.
+    pub fn insert(&mut self, addr: Multiaddr) {
+        if is_circuit(&addr) {
+            return;
+        }
+        self.addrs.insert(strip_p2p(&addr));
+    }
+
     /// True when `addr` is one of ours and must not be dialed.
     pub fn is_ours(&self, addr: &Multiaddr) -> bool {
-        self.addrs.contains(&strip_p2p(addr))
+        !is_circuit(addr) && self.addrs.contains(&strip_p2p(addr))
     }
 
     /// Drop our own addresses from a set of dial candidates.
@@ -756,6 +766,29 @@ mod own_addresses {
             own.is_ours(&candidate),
             "the /p2p/ suffix must not defeat the check"
         );
+    }
+
+    // -- circuits: shared relays must not look like us ---------------------
+
+    #[test]
+    fn another_peers_circuit_through_our_relay_is_not_ours() {
+        // Stripped of `/p2p` hops these two are the same string.
+        let mut own = OwnAddresses::default();
+        own.insert(ma(
+            "/ip4/198.18.0.10/tcp/8000/p2p/12D3KooWLMizEbViSoL4WGJUMsLVRyLccyymosX36MDKdbYgGFzE/p2p-circuit",
+        ));
+        let x_via_same_relay = ma(
+            "/ip4/198.18.0.10/tcp/8000/p2p/12D3KooWLMizEbViSoL4WGJUMsLVRyLccyymosX36MDKdbYgGFzE/p2p-circuit/p2p/12D3KooWSPadT7aj7Ff3Z9ZuY4qW3zjyj6BnWuq3Cz4nbbNxHi3h",
+        );
+        assert!(
+            !own.is_ours(&x_via_same_relay),
+            "a circuit names its destination; it cannot reach us under X's id"
+        );
+        assert_eq!(
+            own.reject_self(vec![x_via_same_relay.clone()]),
+            vec![x_via_same_relay]
+        );
+        assert!(own.addrs.is_empty(), "a reservation is not recorded at all");
     }
 
     // -- what a routability filter would have broken ----------------------

--- a/core/crates/kwaai-p2p/src/error.rs
+++ b/core/crates/kwaai-p2p/src/error.rs
@@ -61,6 +61,11 @@ pub enum P2PError {
     #[error("Network not initialized")]
     NotInitialized,
 
+    /// The service took the command but dropped its reply channel — unlike
+    /// [`Self::NotInitialized`], which means it was gone before the send.
+    #[error("request abandoned before a reply — the connection carrying it closed, or the service stopped")]
+    Abandoned,
+
     /// Internal error
     #[error("Internal error: {0}")]
     Internal(String),

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -364,15 +364,15 @@ impl NetworkHandle {
         self.local_peer_id.to_base58()
     }
 
-    /// Send a command and await its reply, mapping a dead event loop onto
-    /// [`P2PError::NotInitialized`].
+    /// Send a command and await its reply: a rejected send means the event
+    /// loop is gone, a dropped reply that it lost the responder.
     async fn call<T>(&self, make: impl FnOnce(oneshot::Sender<T>) -> Command) -> P2PResult<T> {
         let (tx, rx) = oneshot::channel();
         self.commands
             .send(make(tx))
             .await
             .map_err(|_| P2PError::NotInitialized)?;
-        rx.await.map_err(|_| P2PError::NotInitialized)
+        rx.await.map_err(|_| P2PError::Abandoned)
     }
 
     /// Dial `multiaddr_str`, which must include a `/p2p/<peer-id>` component.

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -34,7 +34,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::addresses::{
     dest_peer_id, is_announceable_with, is_circuit, peer_id_from_multiaddr, strip_dest_p2p,
-    strip_p2p,
+    strip_p2p, OwnAddresses,
 };
 use crate::behaviour::{KwaaiBehaviour, KwaaiBehaviourEvent};
 use crate::config::NetworkConfig;
@@ -116,6 +116,8 @@ pub struct NetworkService {
     /// Stream requests parked behind a `RoutedDial` lookup, flushed when the
     /// lookup completes or a connection to the peer establishes first.
     pending_routed: HashMap<PeerId, Vec<RoutedRequest>>,
+    /// What each peer's parked routed requests are waiting on.
+    routed_attempts: HashMap<PeerId, RoutedAttempt>,
     /// Live connections, per peer, keyed by connection so multiple connections
     /// to one peer are tracked independently.
     connections: HashMap<PeerId, HashMap<ConnectionId, Connection>>,
@@ -207,6 +209,27 @@ enum RoutedRequest {
     Connect {
         reply: oneshot::Sender<P2PResult<PeerId>>,
     },
+}
+
+/// How far one burst of parked routed requests has got: dial, then at most one
+/// DHT lookup, then dial again.
+#[derive(Default)]
+struct RoutedAttempt {
+    /// The dial in flight, if any.
+    dial: Option<RoutedDial>,
+    /// Whether the attempt's one lookup has been used.
+    lookup_spent: bool,
+    /// Routing-table entries [`NetworkService::forget_exhausted_entry`] took
+    /// out, put back if the lookup finds nothing better.
+    evicted: Vec<Multiaddr>,
+}
+
+enum RoutedDial {
+    /// A dial we started; only this connection's outcome ends the attempt.
+    Ours(ConnectionId),
+    /// Ours was refused because a dial to the peer was already in flight, so
+    /// any outcome for that peer is the one we are waiting on.
+    Shared,
 }
 
 impl NetworkService {
@@ -356,6 +379,7 @@ impl NetworkService {
             pending_dials: HashMap::new(),
             pending_kad: HashMap::new(),
             pending_routed: HashMap::new(),
+            routed_attempts: HashMap::new(),
             connections: HashMap::new(),
             observed_addrs: HashMap::new(),
             require_global_ips: config.require_global_ips,
@@ -915,10 +939,26 @@ impl NetworkService {
         }
     }
 
-    /// Addresses we already know for `peer`: routing table entries first, then
-    /// any live connection's address.
+    /// Announceable addresses we know for `peer`: routing-table entries first,
+    /// then any live connection's address.
     fn known_addresses(&mut self, peer: &PeerId) -> Vec<Multiaddr> {
         let strict = self.require_global_ips;
+        self.candidate_addresses(peer, |a| is_announceable_with(a, strict))
+    }
+
+    /// Every address we could try for `peer`; unlike [`Self::known_addresses`]
+    /// it keeps loopback and LAN, which is how two nodes on one host reach each other.
+    fn dial_candidates(&mut self, peer: &PeerId) -> Vec<Multiaddr> {
+        self.candidate_addresses(peer, |_| true)
+    }
+
+    /// `table_filter` decides which routing-table entries qualify; a live
+    /// connection's address always does, since we are on it.
+    fn candidate_addresses(
+        &mut self,
+        peer: &PeerId,
+        table_filter: impl Fn(&Multiaddr) -> bool,
+    ) -> Vec<Multiaddr> {
         let mut addrs: Vec<Multiaddr> = Vec::new();
 
         if let Some(bucket) = self.swarm.behaviour_mut().kad.kbucket(*peer) {
@@ -926,23 +966,12 @@ impl NetworkService {
                 if entry.node.key.preimage() == peer {
                     // Skip empty entries: an address with no transport cannot
                     // be dialed, only mistaken for reachability.
-                    //
-                    // Filter here, on the way *out*, because kad has more ways
-                    // in than we control. Identify is filtered at the handler,
-                    // but `kad::Behaviour::discovered` also inserts whatever
-                    // `multiaddrs` a remote peer reports during a query walk,
-                    // verbatim and inside libp2p — so a peer's loopback and LAN
-                    // addresses arrive without passing anything of ours. This
-                    // is the one place every consumer (connect, routed dial,
-                    // the GUI's peer table) reads them back, so one check here
-                    // covers paths that would otherwise need finding one at a
-                    // time.
                     addrs.extend(
                         entry
                             .node
                             .value
                             .iter()
-                            .filter(|a| !a.is_empty() && is_announceable_with(a, strict))
+                            .filter(|a| !a.is_empty() && table_filter(a))
                             .cloned(),
                     );
                 }
@@ -972,30 +1001,178 @@ impl NetworkService {
             *addr = strip_dest_p2p(addr);
         }
         addrs.retain(|a| !a.is_empty());
+
+        // An address of ours filed under someone else's id reaches our own
+        // listener and fails `WrongPeerId` (issue #108, at the other supplier).
+        let own = self.own_addrs();
+        addrs.retain(|a| !own.is_ours(a));
+
         addrs.dedup();
 
         addrs
     }
 
+    /// Our own listen and confirmed-external addresses, snapshotted from the
+    /// swarm so they cannot drift out of step with the listener set.
+    fn own_addrs(&self) -> OwnAddresses {
+        let mut own = OwnAddresses::default();
+        for addr in self.swarm.listeners() {
+            own.insert(addr.clone());
+        }
+        for addr in self.swarm.external_addresses() {
+            own.insert(addr.clone());
+        }
+        own
+    }
+
     /// Route a stream request to `peer`, looking its addresses up in the DHT
     /// first when we have none — Go's routed-host semantics (see
-    /// [`RoutedRequest`]). With a connection or known addresses, dispatch is
-    /// immediate.
+    /// [`RoutedRequest`]). With a live connection, dispatch is immediate.
     fn dispatch_routed(&mut self, peer: PeerId, request: RoutedRequest) {
-        if self.swarm.is_connected(&peer) || !self.known_addresses(&peer).is_empty() {
+        if self.swarm.is_connected(&peer) {
             self.forward_routed(peer, request);
             return;
         }
+
         let parked = self.pending_routed.entry(peer).or_default();
-        // One lookup per burst: requests parked while a lookup is in flight
-        // ride along on its completion.
-        if parked.is_empty() {
-            let query_id = self.swarm.behaviour_mut().kad.get_closest_peers(peer);
-            self.pending_kad
-                .insert(query_id, PendingKad::RoutedDial { target: peer });
-            debug!(%peer, "no addresses for stream request — running find_peer first");
-        }
+        // One attempt per burst: requests parked while a dial or lookup is in
+        // flight ride along on its outcome.
+        let first = parked.is_empty();
         parked.push(request);
+        if !first {
+            return;
+        }
+
+        if !self.dial_routed(peer) {
+            self.start_routed_lookup(peer);
+        }
+    }
+
+    /// Dial `peer` for its parked routed requests; `false` means nothing is in
+    /// flight and the caller should fall back to a lookup. The address list is
+    /// explicit so the behaviours cannot add our own address filed under `peer`.
+    fn dial_routed(&mut self, peer: PeerId) -> bool {
+        use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
+
+        // The relay transport needs the destination `/p2p/<peer>` that
+        // `dial_candidates` strips, to know which end of the circuit to open.
+        let addrs: Vec<Multiaddr> = self
+            .dial_candidates(&peer)
+            .into_iter()
+            .map(|a| a.with(libp2p::multiaddr::Protocol::P2p(peer)))
+            .collect();
+        debug!(%peer, seeded = addrs.len(), "routed request — dialing");
+
+        let opts = DialOpts::peer_id(peer)
+            .addresses(addrs)
+            .condition(PeerCondition::DisconnectedAndNotDialing)
+            // As in `dial()`: reuse asks the transport to bind our listen
+            // port, which `EADDRINUSE`s against our own listener.
+            .allocate_new_port()
+            .build();
+        let connection_id = opts.connection_id();
+
+        let dial = match self.swarm.dial(opts) {
+            Ok(()) => RoutedDial::Ours(connection_id),
+            Err(DialError::DialPeerConditionFalse(_)) => RoutedDial::Shared,
+            Err(e) => {
+                debug!(%peer, error = %e, "routed dial could not be started");
+                return false;
+            }
+        };
+        self.routed_attempts.entry(peer).or_default().dial = Some(dial);
+        true
+    }
+
+    /// Whether `connection_id` is the dial `peer`'s parked requests were
+    /// waiting on, clearing it when it is.
+    fn routed_dial_ended(&mut self, peer: &PeerId, connection_id: ConnectionId) -> bool {
+        let Some(attempt) = self.routed_attempts.get_mut(peer) else {
+            return false;
+        };
+        match attempt.dial {
+            Some(RoutedDial::Ours(id)) if id != connection_id => false,
+            Some(_) => {
+                attempt.dial = None;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Drop `peer` from the routing table once every address it holds has failed:
+    /// kad never re-dials a tabled peer, so a walk can only re-route one it treats
+    /// as new. The entry is stashed in [`RoutedAttempt::evicted`] for `fail_routed`.
+    fn forget_exhausted_entry(&mut self, peer: &PeerId, error: &DialError) {
+        let failed: Vec<Multiaddr> = match error {
+            DialError::Transport(attempts) => attempts.iter().map(|(a, _)| strip_p2p(a)).collect(),
+            DialError::WrongPeerId { address, .. } => vec![strip_p2p(address)],
+            _ => return,
+        };
+        let remaining: Vec<Multiaddr> = self
+            .swarm
+            .behaviour_mut()
+            .kad
+            .kbucket(*peer)
+            .into_iter()
+            .flat_map(|bucket| {
+                bucket
+                    .iter()
+                    .filter(|entry| entry.node.key.preimage() == peer)
+                    .flat_map(|entry| entry.node.value.iter().cloned())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        if remaining.is_empty() || !remaining.iter().all(|a| failed.contains(&strip_p2p(a))) {
+            return;
+        }
+        debug!(
+            %peer,
+            tried = failed.len(),
+            "every routing-table address for the peer failed — evicting so a lookup can replace it"
+        );
+        self.swarm.behaviour_mut().kad.remove_peer(peer);
+        self.routed_attempts.entry(*peer).or_default().evicted = remaining;
+    }
+
+    /// Walk the DHT for `peer`'s addresses on behalf of parked requests.
+    fn start_routed_lookup(&mut self, peer: PeerId) {
+        self.routed_attempts.entry(peer).or_default().lookup_spent = true;
+        let query_id = self.swarm.behaviour_mut().kad.get_closest_peers(peer);
+        self.pending_kad
+            .insert(query_id, PendingKad::RoutedDial { target: peer });
+        debug!(%peer, "routed request — running find_peer");
+    }
+
+    /// Fail every request parked for `peer`, restoring any evicted table entry.
+    fn fail_routed(&mut self, peer: PeerId, text: String) {
+        let evicted = self
+            .routed_attempts
+            .remove(&peer)
+            .map(|attempt| attempt.evicted)
+            .unwrap_or_default();
+        if !evicted.is_empty() {
+            debug!(%peer, count = evicted.len(), "lookup found nothing better — restoring the evicted entry");
+            for addr in evicted {
+                self.swarm.behaviour_mut().kad.add_address(&peer, addr);
+            }
+        }
+        let Some(parked) = self.pending_routed.remove(&peer) else {
+            return;
+        };
+        for request in parked {
+            match request {
+                RoutedRequest::Unary { reply, .. } => {
+                    let _ = reply.send(Err(unary::UnaryError::DialFailure(text.clone())));
+                }
+                RoutedRequest::RawStream { reply, .. } => {
+                    let _ = reply.send(Err(raw_stream::RawStreamError::DialFailure(text.clone())));
+                }
+                RoutedRequest::Connect { reply } => {
+                    let _ = reply.send(Err(P2PError::DialFailed(text.clone())));
+                }
+            }
+        }
     }
 
     /// Hand a routed request to its behaviour, which owns `reply` from here on.
@@ -1043,30 +1220,29 @@ impl NetworkService {
     /// an incidental connection) produced a way to reach the peer, fail them
     /// with a clear error when it did not.
     fn flush_routed(&mut self, peer: PeerId) {
-        let Some(parked) = self.pending_routed.remove(&peer) else {
+        if !self.pending_routed.contains_key(&peer) {
             return;
-        };
-        if self.swarm.is_connected(&peer) || !self.known_addresses(&peer).is_empty() {
+        }
+
+        if self.swarm.is_connected(&peer) {
+            self.routed_attempts.remove(&peer);
+            let parked = self.pending_routed.remove(&peer).unwrap_or_default();
             for request in parked {
                 self.forward_routed(peer, request);
             }
             return;
         }
-        let text = format!("{peer}: peer not found in DHT (no addresses)");
-        debug!(%peer, "find_peer produced no addresses — failing parked requests");
-        for request in parked {
-            match request {
-                RoutedRequest::Unary { reply, .. } => {
-                    let _ = reply.send(Err(unary::UnaryError::DialFailure(text.clone())));
-                }
-                RoutedRequest::RawStream { reply, .. } => {
-                    let _ = reply.send(Err(raw_stream::RawStreamError::DialFailure(text.clone())));
-                }
-                RoutedRequest::Connect { reply } => {
-                    let _ = reply.send(Err(P2PError::DialFailed(text.clone())));
-                }
-            }
+
+        // Not connected after the walk: dial once more from whatever it learned.
+        if self.dial_routed(peer) {
+            return;
         }
+
+        debug!(%peer, "find_peer produced no usable addresses — failing parked requests");
+        self.fail_routed(
+            peer,
+            format!("{peer}: peer not found in DHT (no addresses)"),
+        );
     }
 
     /// Seed one routing-table address for `peer`, holding the per-peer list at
@@ -1239,6 +1415,7 @@ impl NetworkService {
                 let _ = reply.send(Err(error.clone()));
             }
         }
+        self.routed_attempts.clear();
         for (_, parked) in self.pending_routed.drain() {
             for request in parked {
                 match request {
@@ -1358,6 +1535,9 @@ impl NetworkService {
                 // us, or another dial landed): flush now rather than making
                 // the parked requests wait out the DHT walk. The lookup's
                 // completion then finds nothing parked and is a no-op.
+                if let Some(attempt) = self.routed_attempts.get_mut(&peer_id) {
+                    attempt.dial = None;
+                }
                 if self.pending_routed.contains_key(&peer_id) {
                     self.flush_routed(peer_id);
                 }
@@ -1449,6 +1629,26 @@ impl NetworkService {
                     );
                     let addr = address.clone();
                     self.swarm.behaviour_mut().kad.remove_address(&peer, &addr);
+                }
+
+                // A routed dial's first failure buys one DHT walk. Must follow the
+                // WrongPeerId eviction above so that address is never stashed and restored.
+                if let Some(peer) = peer_id {
+                    if self.routed_dial_ended(&peer, connection_id)
+                        && self.pending_routed.contains_key(&peer)
+                    {
+                        let spent = self
+                            .routed_attempts
+                            .get(&peer)
+                            .is_some_and(|attempt| attempt.lookup_spent);
+                        if spent {
+                            self.fail_routed(peer, dial_error(&error, Some(peer)).to_string());
+                        } else {
+                            debug!(%peer, error = %error, "routed dial failed — falling back to a DHT lookup");
+                            self.forget_exhausted_entry(&peer, &error);
+                            self.start_routed_lookup(peer);
+                        }
+                    }
                 }
 
                 // A relay we cannot reach will never give us a reservation.

--- a/core/crates/kwaai-p2p/tests/service_unary.rs
+++ b/core/crates/kwaai-p2p/tests/service_unary.rs
@@ -626,3 +626,212 @@ async fn connect_by_bare_peer_id_resolves_through_the_dht() {
     .expect("the routed connection must carry calls");
     assert_eq!(response, b"ping");
 }
+
+// ---------------------------------------------------------------------------
+// Routed dial: bad addresses must not end the attempt
+// ---------------------------------------------------------------------------
+
+/// Strip `/p2p/<id>` so the address is shaped the way kad stores it.
+fn stripped(addr: &str) -> libp2p::Multiaddr {
+    addr.parse::<libp2p::Multiaddr>()
+        .expect("valid multiaddr")
+        .iter()
+        .filter(|p| !matches!(p, libp2p::multiaddr::Protocol::P2p(_)))
+        .collect()
+}
+
+/// A dead table entry is the normal case for a NATed peer: kad holds its
+/// listen addresses, and only its DHT record has the relay circuit that works.
+#[tokio::test]
+async fn a_routed_call_falls_back_to_the_dht_when_the_known_address_is_dead() {
+    let (bootstrap, bootstrap_task, bootstrap_id) = spawn_service();
+    let (responder, responder_task, responder_id) = spawn_service();
+    let (caller, caller_task, _caller_id) = spawn_service();
+    let _tasks = [bootstrap_task, responder_task, caller_task];
+
+    responder
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("register handler");
+
+    let bootstrap_addr = dialable_addr(&bootstrap, bootstrap_id).await;
+    responder
+        .connect_peer(&bootstrap_addr)
+        .await
+        .expect("responder dials bootstrap");
+    caller
+        .connect_peer(&bootstrap_addr)
+        .await
+        .expect("caller dials bootstrap");
+
+    within(
+        "the bootstrap to learn the responder",
+        wait_in_routing_table(&bootstrap, responder_id),
+    )
+    .await;
+    within(
+        "the caller to learn the bootstrap",
+        wait_in_routing_table(&caller, bootstrap_id),
+    )
+    .await;
+
+    // Seeded last so the bootstrap handshake above cannot overwrite it.
+    let dead = format!("/ip4/127.0.0.1/tcp/{}", free_port());
+    caller
+        .add_kad_address(responder_id, stripped(&dead))
+        .await
+        .expect("seed the dead address");
+    assert!(
+        caller
+            .list_peers()
+            .await
+            .expect("list_peers")
+            .iter()
+            .all(|p| p.peer_id != responder_id),
+        "precondition: the caller must not already be connected to the responder",
+    );
+
+    let response = within(
+        "a routed call that must survive a dead address",
+        caller.call_unary_handler(responder_id, PROTO, b"fallback"),
+    )
+    .await
+    .expect("the dead address must not end the attempt");
+    assert_eq!(response, b"fallback");
+}
+
+/// One of *our own* addresses, filed in kad under someone else's peer id, must
+/// never be offered as a way to reach them: dialing it fails `WrongPeerId`.
+#[tokio::test]
+async fn our_own_address_filed_under_another_peer_is_not_a_route_to_them() {
+    let (caller, _caller_task, caller_id) = spawn_service();
+    let ghost_id = Keypair::generate_ed25519().public().to_peer_id();
+
+    let own = dialable_addr(&caller, caller_id).await;
+    caller
+        .add_kad_address(ghost_id, stripped(&own))
+        .await
+        .expect("seed our own address under the ghost's id");
+
+    let routes = caller
+        .dht_find_peer(ghost_id)
+        .await
+        .expect("dht_find_peer should answer");
+    assert!(
+        routes.is_empty(),
+        "our own address is not a route to anyone else, but was offered: {routes:?}",
+    );
+}
+
+/// The same invariant on the dial path: a peer filed under both our address
+/// and its own must be dialled only at its own. No bootstrap here, so a
+/// self-dial has no DHT walk to recover with and the call fails.
+#[tokio::test]
+async fn a_routed_call_never_dials_our_own_address_even_when_kad_holds_it() {
+    let (caller, _caller_task, caller_id) = spawn_service();
+    let (responder, _responder_task, responder_id) = spawn_service();
+
+    responder
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("register handler");
+
+    let own = dialable_addr(&caller, caller_id).await;
+    let real = dialable_addr(&responder, responder_id).await;
+    // Ours first, so anything dialling the table in order tries it first.
+    caller
+        .add_kad_address(responder_id, stripped(&own))
+        .await
+        .expect("seed our own address under the responder's id");
+    caller
+        .add_kad_address(responder_id, stripped(&real))
+        .await
+        .expect("seed the responder's real address");
+
+    let response = within(
+        "a routed call with our own address filed under the callee",
+        caller.call_unary_handler(responder_id, PROTO, b"not-us"),
+    )
+    .await
+    .expect("the call must reach the responder without a self-dial");
+    assert_eq!(response, b"not-us");
+}
+
+/// The complement: the filter is `is_ours`, not "is it loopback", so a sibling
+/// node on the same interface stays reachable.
+#[tokio::test]
+async fn a_second_local_node_on_another_port_is_still_reachable() {
+    let (caller, _caller_task, _caller_id) = spawn_service();
+    let (responder, _responder_task, responder_id) = spawn_service();
+
+    responder
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("register handler");
+
+    let responder_addr = dialable_addr(&responder, responder_id).await;
+    caller
+        .add_kad_address(responder_id, stripped(&responder_addr))
+        .await
+        .expect("seed the sibling's loopback address");
+
+    let response = within(
+        "a call to a second node on the same machine",
+        caller.call_unary_handler(responder_id, PROTO, b"sibling"),
+    )
+    .await
+    .expect("a sibling node's loopback address is a real route");
+    assert_eq!(response, b"sibling");
+}
+
+/// A port nothing is listening on: bound and released, so a small race window.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("binding an ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+/// A peer whose lookup finds nothing better keeps its routing-table entry: the
+/// eviction that lets the walk re-dial it is provisional, not a forgetting.
+#[tokio::test]
+async fn an_evicted_entry_is_restored_when_the_lookup_finds_nothing_better() {
+    let (caller, _caller_task, _caller_id) = spawn_service();
+    let (bootstrap, _bootstrap_task, bootstrap_id) = spawn_service();
+    let absent_id = Keypair::generate_ed25519().public().to_peer_id();
+
+    // Somebody to ask, who has never heard of the target.
+    caller
+        .connect_peer(&dialable_addr(&bootstrap, bootstrap_id).await)
+        .await
+        .expect("caller dials bootstrap");
+    within(
+        "the caller to learn the bootstrap",
+        wait_in_routing_table(&caller, bootstrap_id),
+    )
+    .await;
+
+    let dead = format!("/ip4/127.0.0.1/tcp/{}", free_port());
+    caller
+        .add_kad_address(absent_id, stripped(&dead))
+        .await
+        .expect("seed the dead address");
+
+    let err = within(
+        "a routed call to an unreachable peer",
+        caller.call_unary_handler(absent_id, PROTO, b"nobody"),
+    )
+    .await
+    .expect_err("nothing answers at the dead address and nobody knows the peer");
+    assert!(matches!(err, P2PError::DialFailed(_)), "{err:?}");
+
+    assert!(
+        caller
+            .routing_peers()
+            .await
+            .expect("routing_peers")
+            .contains(&absent_id),
+        "the failed lookup must hand the old entry back, not leave the peer forgotten",
+    );
+}


### PR DESCRIPTION
On the native stack, a unary or stream request addressed by a bare `PeerId` failed on the **first** call to any peer with `WrongPeerId`, and a NATed peer failed on every call. The same peer was discoverable, pingable, and reachable via `p2p peers connect` — which looks the peer up in the DHT before dialing. This is what made the VPK storage protocol (`/kwaai/storage/1.0.0`) look unreachable while everything around it looked healthy.

Two separate defects, one code path.

## The path

`NetworkService::dispatch_routed` (`service.rs`) is where a call by peer id enters the swarm. On `main` it forwarded the request the moment the routing table held *any* address for the peer:

```rust
if self.swarm.is_connected(&peer) || !self.known_addresses(&peer).is_empty() {
    self.forward_routed(peer, request);   // -> unary.send_request / raw_stream.open_stream
    return;
}
```

`forward_routed` hands the request to the behaviour, and the behaviour's dial is **open to the behaviours' address suppliers**. It never uses the address list we just checked.

### 1. Our own address, filed under someone else's id

`kad::Behaviour::discovered` inserts whatever `multiaddrs` a remote peer reports during a query walk — verbatim, inside libp2p, without passing anything of ours. Every node on this network listens on the same port, so a peer's `/ip4/127.0.0.1/tcp/8080` arrives filed under *its* id and resolves to *us*.

The swarm's own self-dial filter does not catch it: that filter drops an address that is exactly a bare listen address of ours, and the `/p2p/<other>` suffix defeats the comparison. So the swarm dialled our own listener alongside the real address, `ConcurrentDial` took whichever handshake finished first, and loopback-to-self usually won — the whole attempt failed `WrongPeerId`.

`unary::Behaviour::handle_pending_outbound_connection` (`unary.rs`) already rejects our own addresses from *its* supplier — that was issue #108. Kad's and identify's suppliers were not covered, and they are the ones holding the raw entry.

### 2. A NATed peer's table entries are its listen addresses

Kad stores what a peer *listens* on. For a NATed peer that is a LAN address on another subnet, or a port mapping that has since closed. The address that reaches it is the **relay circuit in its DHT record**, which kad never holds. So the first dial failing is the normal case for a NATed peer, not an exceptional one — and on `main` the first dial failing was the end of the attempt.

## What changed

**The routed dial is explicit and closed.** `dispatch_routed` no longer forwards on "we have some address". The first request in a burst calls `dial_routed` (`service.rs`), which dials `DialOpts::peer_id(peer).addresses(dial_candidates)` — and *only* that list. An explicit address list is the one filter the swarm honours; leaving the dial open to the behaviours is what supplied our own address in the first place.

**Two address sets, split from one.** `known_addresses` and the new `dial_candidates` share a body, `candidate_addresses` (`service.rs`), and differ in exactly one predicate:

| | routing-table entries | live-connection address | our own addresses | read by |
|---|---|---|---|---|
| `known_addresses` | announceable only | always kept | dropped | `DhtFindPeer` |
| `dial_candidates` | all non-empty | always kept | dropped | `dial_routed` |

The announceability filter answers "worth telling the world about". Dialing is a different question: loopback and RFC1918 are exactly how two nodes on one machine, or one subnet, reach each other, so filtering them out of a *dial* set makes a reachable peer unreachable. The only address dropped from both is one that provably cannot name anyone else — ours. The test is `is_ours`, not "is it loopback".

**Our own addresses are read off the swarm, not accumulated.** `own_addrs()` (`service.rs`) builds an `OwnAddresses` per call from `swarm.listeners()` and `swarm.external_addresses()`. A snapshot cannot drift out of step with the listener set the way a separately-maintained copy can. `OwnAddresses::insert` (`addresses.rs`) is the new entry point for that; `on_swarm_event` now routes through it, so both ways in agree.

**`OwnAddresses` ignores circuit addresses entirely** (`addresses.rs`). Our relay reservation and another peer's circuit through the same relay are the *same string* once `/p2p` hops are stripped — and on this network every NATed node reserves on the same bootstraps. Without this, a peer whose only route is that circuit disappears from `dht_find_peer` and from `unary`'s supplier. A circuit is also never the hazard the type exists for: the swarm appends the destination id and the relay opens a circuit to *that* peer or refuses, so a circuit address filed under X can only ever reach X. Only a direct address can be ours and labelled as someone else's.

**On failure, exactly one DHT walk, then one more dial.** In the `OutgoingConnectionError` arm (`service.rs`), a failed dial that belongs to a routed attempt goes to `start_routed_lookup` instead of failing the request. `lookup_spent` bounds it: the post-lookup dial failing ends the attempt rather than walking the DHT forever.

The attempt state is one `RoutedAttempt` per peer (`dial`, `lookup_spent`, `evicted`), cleared in `fail_all_pending`. `dial` is a `RoutedDial`: `Ours(ConnectionId)` — only that connection's outcome ends the attempt — or `Shared`, when our dial was refused by `PeerCondition::DisconnectedAndNotDialing` because another dial to the peer was already in flight, in which case any outcome for that peer is the one we were waiting on.

**The walk needs the stale entry out of the way first.** `forget_exhausted_entry` (`service.rs`) removes the peer from the routing table before the lookup starts. This is load-bearing, and it is the least obvious part of the change: kad keeps a walk's discoveries in the query's own address book and never in the table, so the only way a walk delivers a peer is by dialing it *itself* — and it will not do that for a peer already in the table. The iterator contacts it at the table's dead address, marks it failed, and never retries it when a bootstrap reports the live one.

Two constraints on that eviction:

- **Evidence-based.** Only addresses the swarm reports having tried count (`DialError::Transport` attempt list, or the single `WrongPeerId` address), and only when they cover the *whole* entry. Kad's own `on_dial_failure` has already removed all but the last failed address by the time this runs.
- **Provisional.** The removed entries go into `RoutedAttempt::evicted`, and `fail_routed` puts them back if the lookup finds nothing better. A peer that is merely restarting is still best reached where it was; without the restore, a transient refusal costs it its table entry until something happens to re-seed it.

Ordering matters here and is deliberate: the pre-existing `WrongPeerId` eviction (`service.rs`) runs **before** `forget_exhausted_entry`, so an address proven to belong to someone else is never put in the stash and restored. Otherwise it comes straight back and every later call repeats the same wrong dial, walk and restore.

**`flush_routed` re-dials rather than assuming the walk's discoveries survive** (`service.rs`). It now branches on `is_connected` alone. If we are connected, forward. If not, this is a completed lookup that left us unconnected, and it tries `dial_routed` once more before failing. Nothing is lost by not reading the walk's in-query address book: kad removes a finished query before reporting `OutboundQueryProgressed`, so those addresses are gone by the time `flush_routed` runs *whichever way the dial is built*. A walk that finds the peer connects to it itself, and `ConnectionEstablished` flushes the parked requests directly — which also promotes the live address into the table, which is what the retry dial reads.

**New error variant: `P2PError::Abandoned`** (`error.rs`). `NetworkHandle::call` mapped *both* failure modes onto `NotInitialized`: a rejected send (the event loop is gone — the node really is down) and a dropped reply (the loop took the command and then lost the responder). On the routed paths the second one happens when the connection carrying an in-flight request dies, taking the handler and the request's reply channel with it. Reporting that as "Network not initialized" describes a dead local node and sends the reader looking in the wrong place. `call` (`handle.rs`) now keeps `NotInitialized` for the send and returns `Abandoned` for the dropped reply.

This is additive: nothing in the workspace matches exhaustively on `P2PError`, and the only consumers of these two variants are inside `kwaai-p2p`. `dht_service::maintenance_loop` stops on any `Err` from `routing_peers()`, so its documented "the service is gone" behaviour is unchanged; the shutdown test at `service_unary.rs:446` still asserts `NotInitialized`, because `fail_all_pending` delivers that as a *value* on the reply channel, not as a drop.

## What deliberately did not change

- **No new config keys, and nothing here is tunable.** The behaviour is unconditional. There is nothing an operator can set that would half-work.
- **p2pd is untouched.** This is `kwaai-p2p`'s native swarm only.
- **The `WrongPeerId` eviction is unchanged** — it is only *ordered* relative to the new one.
- **`known_addresses` keeps its announceability filter.** It is the advertising answer (`dht_find_peer`), and the dial path no longer reads it. Its one behavioural change is that it, too, now drops our own addresses — that is the whole point of the `our_own_address_filed_under_another_peer_is_not_a_route_to_them` test.
- **`collect_routing_peers`** (`service.rs`) still reports raw table entries with no filter, including unusable ones, so the peer table keeps showing "known of but not dialable" as distinct from "not connected yet".
- **`forward_routed`'s `Connect` arm still builds a behaviour-supplied dial** (`service.rs`). It is only reached when the swarm reports us connected, where it returns early — a race-window path, left alone rather than duplicating the candidate logic into it.
- **The retry is bounded at one lookup.** Not a loop, not a backoff, no timer.

## Tests

Five integration tests in `core/crates/kwaai-p2p/tests/service_unary.rs`, all spawning real services on loopback:

| test | what it pins |
|---|---|
| `a_routed_call_falls_back_to_the_dht_when_the_known_address_is_dead` | the reported defect, minus NAT: the caller's only entry for the responder is a closed port; the call must still complete via the walk. Fails on `main`. |
| `our_own_address_filed_under_another_peer_is_not_a_route_to_them` | our own dialable address seeded under a ghost id; `dht_find_peer` must return nothing rather than offering it. |
| `a_routed_call_never_dials_our_own_address_even_when_kad_holds_it` | the same invariant on the *dial* path, which is the one that matters. Our address is seeded **first** so anything dialing the table in order hits it first, and there is no bootstrap in this test — so there is no walk to recover with, and a self-dial makes the call fail outright. |
| `a_second_local_node_on_another_port_is_still_reachable` | the complement — the case a blanket "reject loopback" rule would have broken. |
| `an_evicted_entry_is_restored_when_the_lookup_finds_nothing_better` | the provisional half of `forget_exhausted_entry`: dead address, a bootstrap that has never heard of the target, call fails `DialFailed` — and the peer is still in `routing_peers()` afterwards. |

One unit test in `addresses.rs`, `another_peers_circuit_through_our_relay_is_not_ours`: with a reservation held on relay R, X's circuit through the same R must survive `is_ours` and `reject_self` — and our own reservation must not be recorded at all.

Two helpers are added: `stripped()` shapes an address the way kad stores it, and `free_port()` binds and releases an ephemeral port. `free_port` has a small race window by construction, noted in its doc comment — the alternative is naming a port before it is known.

Run on the branch as is (1 commit on `main` @ `9190d4a2`), mirroring the CI jobs:

| command | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p kwaai-p2p -p kwaai-hivemind-dht -- -D warnings` | clean |
| `cargo clippy -p kwaai-p2p -p kwaainet --all-targets -- -D warnings` | clean |
| `cargo test -p kwaai-p2p -p kwaai-hivemind-dht` | **248 passed, 0 failed**, 5 ignored (baseline 242 + the 6 added here) |

`git merge-tree` against `feat/bootstrap-serve` (#94) and `feat/decentralized-dht` (#96): no conflicts either way.

### End-to-end

Verified on the `kwaaiai-env` NAT-test Docker topology (simulated internet on 198.18.0.0/24, RFC1918 LANs behind iptables NAT routers), with a Bob→Eve reachability matrix over `/kwaai/storage/1.0.0` across the NAT axis — public and NATed on both sides. Each pair is run **cold** (a bare RPC by `PeerId`, no connection held) and **warm** (after `p2p peers connect`, which walks the DHT first). Warm passed on `main`; cold did not. With this branch all four pairs pass cold and warm, including NAT→NAT.

A NAT→NAT `vpk bench` through a relay circuit also completes, **but that result depends on a sibling PR**: `relay::Config::default()` caps a circuit at 128 KiB / 2 min, so a multi-hundred-KB batch dies mid-write regardless of this change. That fix is #138 — independent, targets `main` separately, and is not in this diff. This PR fixes the dial path — reaching a peer at all; large transfers over a circuit need the relay-limits PR as well.

## Follow-ups / not done here

Nothing is deferred out of this change — the dial path is complete as it stands, and the bound of one lookup per burst is intended rather than a placeholder. Two observations from the work, neither actionable in this PR:

- The address-supplier problem is structural: any dial left open to the behaviours can be handed our own address under another peer's id, because kad's raw entry is the source and libp2p does not filter it. This branch closes the routed path by supplying an explicit list; `unary` closed its own supplier in #108. Any *future* dial path has to do one or the other, and there is nothing in the type system that says so.
- `forget_exhausted_entry` exists because kad will not re-dial a tabled peer whose address failed. That is upstream behaviour we work around rather than something we can fix here.
