### PR TITLE
fix(p2p): size relayed circuits for carrying traffic, not just introductions

### DIFF
--- a/core/crates/kwaai-cli/src/vpk_bench.rs
+++ b/core/crates/kwaai-cli/src/vpk_bench.rs
@@ -159,7 +159,8 @@ pub async fn run(args: BenchArgs) -> Result<()> {
     let mut scale_results: Vec<ScaleResult> = Vec::new();
 
     for (si, &n) in scales.iter().enumerate() {
-        let n = n.max(1000); // floor
+        // Floor at 1000, but never past the end of the generated corpus.
+        let n = n.max(1000).min(n_max);
         println!(
             "  [{}/5] Scale {}/{}: {} vectors ({} per shard)",
             si + 2,
@@ -209,7 +210,8 @@ pub async fn run(args: BenchArgs) -> Result<()> {
             .iter()
             .enumerate()
             .map(|(i, shard)| {
-                let start = i * shard_size;
+                // A trailing shard can start past `n`, which would invert the range.
+                let start = (i * shard_size).min(n);
                 let end = ((i + 1) * shard_size).min(n);
                 let client = Arc::clone(&shard.client);
                 let peer_id = shard.peer_id;

--- a/core/crates/kwaai-p2p/src/behaviour.rs
+++ b/core/crates/kwaai-p2p/src/behaviour.rs
@@ -171,14 +171,22 @@ impl KwaaiBehaviour {
             },
         );
 
-        // Hop server. `relay::Config::default()`'s rate limits (30 reservations
-        // per peer per 2min, 60 circuits per IP per min) are left as-is: they
-        // are what stops an open relay from being a free amplifier.
-        let relay_server = Toggle::from(
-            config
-                .relay_server
-                .then(|| relay::Behaviour::new(local_peer_id, relay::Config::default())),
-        );
+        // Hop server: libp2p's rate limiters and concurrency caps stay; only the
+        // per-circuit volume and duration are raised, to match the p2pd relay.
+        let max_circuit_duration = config
+            .relay_max_circuit_duration
+            // libp2p converts this to u32 seconds and panics otherwise.
+            .min(Duration::from_secs(u64::from(u32::MAX)));
+        let relay_server = Toggle::from(config.relay_server.then(|| {
+            relay::Behaviour::new(
+                local_peer_id,
+                relay::Config {
+                    max_circuit_bytes: config.relay_max_circuit_bytes,
+                    max_circuit_duration,
+                    ..relay::Config::default()
+                },
+            )
+        }));
 
         // dcutr has no Config in 0.11 — it acts on relayed connections by
         // itself, so there is nothing to tune and nothing to drive.

--- a/core/crates/kwaai-p2p/src/config.rs
+++ b/core/crates/kwaai-p2p/src/config.rs
@@ -107,6 +107,16 @@ pub struct NetworkConfig {
     #[serde(default = "default_true")]
     pub relay_server: bool,
 
+    /// Bytes one relayed circuit may carry before this node tears it down; `0` is uncapped.
+    /// Defaults to the p2pd relay's `-relayDataLimit`, not libp2p's 128 KiB.
+    #[serde(default = "default_relay_max_circuit_bytes")]
+    pub relay_max_circuit_bytes: u64,
+
+    /// How long one relayed circuit may stay open.
+    /// Defaults to the p2pd relay's `-relayTimeLimit`, not libp2p's 2 minutes.
+    #[serde(default = "default_relay_max_circuit_duration")]
+    pub relay_max_circuit_duration: Duration,
+
     /// Ask the local gateway to map our listen port via UPnP/IGD.
     ///
     /// On by default (parity with p2pd's `-natPortMap`), off in
@@ -176,6 +186,16 @@ fn default_identify_min_confirmations() -> usize {
     2
 }
 
+/// 4 GiB, the p2pd relay's `-relayDataLimit`.
+fn default_relay_max_circuit_bytes() -> u64 {
+    1 << 32
+}
+
+/// 30 minutes, the p2pd relay's `-relayTimeLimit`.
+fn default_relay_max_circuit_duration() -> Duration {
+    Duration::from_secs(30 * 60)
+}
+
 impl Default for NetworkConfig {
     fn default() -> Self {
         Self {
@@ -195,6 +215,8 @@ impl Default for NetworkConfig {
             dht_server: false,
             trusted_relays: Vec::new(),
             relay_server: true,
+            relay_max_circuit_bytes: default_relay_max_circuit_bytes(),
+            relay_max_circuit_duration: default_relay_max_circuit_duration(),
             enable_upnp: true,
             force_private: false,
             external_addr: None,
@@ -346,5 +368,67 @@ impl NetworkConfigBuilder {
     /// Build the configuration
     pub fn build(self) -> NetworkConfig {
         self.config
+    }
+}
+
+#[cfg(test)]
+mod relay_circuit_limits {
+    use super::*;
+
+    /// p2pd's `-relayDataLimit` / `-relayTimeLimit`, pinned against libp2p's
+    /// 128 KiB / 2 min.
+    #[test]
+    fn the_defaults_match_the_p2pd_relay() {
+        let cfg = NetworkConfig::default();
+        assert_eq!(cfg.relay_max_circuit_bytes, 1 << 32);
+        assert_eq!(cfg.relay_max_circuit_duration, Duration::from_secs(30 * 60));
+        assert!(
+            cfg.relay_max_circuit_bytes > 1 << 17
+                && cfg.relay_max_circuit_duration > Duration::from_secs(120),
+            "the point of the override is to exceed libp2p's 128 KiB / 2 min",
+        );
+    }
+
+    /// `behaviour.rs` clamps an operator's value; the default must already fit.
+    #[test]
+    fn the_default_circuit_duration_fits_the_wire_format() {
+        let secs = NetworkConfig::default()
+            .relay_max_circuit_duration
+            .as_secs();
+        assert!(
+            secs <= u32::MAX as u64,
+            "{secs}s exceeds the u32 wire field"
+        );
+    }
+
+    #[test]
+    fn the_limits_round_trip_and_default_when_absent() {
+        let cfg = NetworkConfig {
+            relay_max_circuit_bytes: 4096,
+            relay_max_circuit_duration: Duration::from_secs(30),
+            ..NetworkConfig::default()
+        };
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        let back: NetworkConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.relay_max_circuit_bytes, 4096);
+        assert_eq!(back.relay_max_circuit_duration, Duration::from_secs(30));
+
+        // A config written before these fields existed.
+        let legacy = r#"{
+            "listen_addrs": [], "bootstrap_peers": [], "enable_dht": true,
+            "dht_replication": 20,
+            "connection_timeout": {"secs": 30, "nanos": 0},
+            "request_timeout": {"secs": 60, "nanos": 0},
+            "max_connections": 100, "enable_nat_traversal": true,
+            "enable_relay_client": true, "protocol_version": "x",
+            "agent_version": "y"
+        }"#;
+        let old: NetworkConfig = serde_json::from_str(legacy).expect("legacy config");
+        assert_eq!(old.relay_max_circuit_bytes, 1 << 32);
+        assert_eq!(
+            old.relay_max_circuit_duration,
+            Duration::from_secs(30 * 60),
+            "an old config must pick up the new default, not libp2p's",
+        );
     }
 }


### PR DESCRIPTION
> [!NOTE]
> **Neither new field is reachable from `config.yaml`.** They are `NetworkConfig` fields with new defaults, and the defaults are the only values a node runs with. That is deliberate for this change and named as a follow-up below — but a reviewer who checks whether a control does what its doc says should know it up front. Nothing here claims to be operator-settable.

A NATed peer could be found, dialed and pinged, but not written to. Any bulk transfer over its relay circuit — a VPK vector batch, an inference hidden-state hop — died partway through, and the caller saw `yamux … connection is closed`, surfaced by the daemon as `Network not initialized` , which describes neither the cause nor the layer it happened at.

## The cap, and why 128 KiB is not a throttle here

Every native node is a circuit relay hop server by default — `relay_server` defaults to `true` in `NetworkConfig`, matching p2pd's `-relay`. Before this branch, `behaviour.rs` built that hop server with `relay::Config::default()` and nothing else.

In libp2p-relay 0.21.1 (`core/Cargo.lock:3663-3665`) those defaults are:

| field | libp2p default | what it bounds |
|---|---|---|
| `max_circuit_bytes` | `1 << 17` (128 KiB) | total bytes one circuit may carry |
| `max_circuit_duration` | 2 min | how long one circuit may stay open |
| `max_circuits` | 16 | concurrent circuits on this relay |
| `max_circuits_per_peer` | 4 | concurrent circuits involving one peer |

(vendored source: `libp2p-relay-0.21.1/src/behaviour.rs:160-163`.)

Those first two are sized for a relay that introduces peers and then gets out of the way. On this network a relay is how a NATed peer is *used*. At `vpk bench`'s defaults — `--batch-size 500`, `--dimensions 384`  — one upload RPC carries ~768 KB of f32 payload before framing. An inference hidden-state hop is larger. So 128 KiB did not slow those transfers down; it made them impossible, and the failure arrived as a torn-down connection rather than as a limit being hit.

Two details of the Rust implementation are worth having in front of you, because they change the arithmetic:

- **`max_circuit_bytes` counts both directions in one budget.** `CopyFuture::poll` increments a single `bytes_sent` from *both* `forward_data` calls and compares that one counter (`libp2p-relay-0.21.1/src/copy_future.rs:78-105`). go-libp2p applies its data limit per direction, so a native relay cuts a symmetric exchange at half the volume a Go relay would allow for the same nominal number. The commit message was corrected on this point; it is the reason the two implementations are *aligned*, not identical.
- **`0` means uncapped.** The guard is `if this.max_circuit_bytes > 0 && this.bytes_sent > this.max_circuit_bytes` (`copy_future.rs:78`), so zero switches enforcement off entirely — while still being advertised to the peer as `Limit.data = 0` (`libp2p-relay-0.21.1/src/protocol/inbound_hop.rs:83`, `:136`). Go clients record that value; nothing enforces it. The new default is finite rather than `0` for exactly that reason.

## What changed

`NetworkConfig` gains two fields:

| field | new default | libp2p's | source of the number |
|---|---|---|---|
| `relay_max_circuit_bytes` | `1 << 32` (4 GiB) | 128 KiB | p2pd's `-relayDataLimit` |
| `relay_max_circuit_duration` | 30 min | 2 min | p2pd's `-relayTimeLimit` |

Defaults in `config.rs`, applied to the hop server in `behaviour.rs` (`KwaaiBehaviour::new`).

The argument for these particular numbers is that they are not new numbers: they are the limits the p2pd relays on this network already run with, so a NATed peer reserved on a Python bootstrap was never at 128 KiB — only native Rust hop servers were. Matching them makes a circuit's budget the same whichever implementation happens to serve it, instead of depending on the relay you landed on.

**Where the numbers come from, checked against the binary.** This repo spawns `p2pd` externally (`daemon.rs`) and does not vendor go-libp2p-daemon, so the diff itself cannot prove them; `p2pd -h` from the hivemind build the Python services run does:

```
-relayDataLimit int   maximum data bytes relayed (in each direction) before resetting connection if -relayService=1 (default 4294967296)
-relayTimeLimit duration   maximum duration of a single active relayed connection if -relayService=1 (default 30m0s)
```

Note "in each direction" — the per-direction metering above is stated by the flag's own help text, not inferred.

**The duration is clamped, not trusted.** `behaviour.rs` clamps it with `.min(Duration::from_secs(u64::from(u32::MAX)))`. `relay::Config` documents `max_circuit_duration` as a panic condition (`libp2p-relay-0.21.1/src/behaviour.rs:50-54`), and the actual `expect` is per inbound message inside the hop protocol — once when granting a reservation and once when accepting a circuit (`protocol/inbound_hop.rs:78-81` and `:130-134`), where the `Duration` is converted to the wire format's u32 seconds. An oversize value would therefore panic on every circuit at runtime rather than failing at startup. With no config path to set it, the clamp is defensive only — it matters to anything constructing `NetworkConfig` programmatically, and to whoever wires the key later.

## What deliberately did not change

Everything that bounds *how many* circuits a stranger can obtain stays at libp2p's defaults:

- the four rate limiters — reservations and circuits, each per source peer and per source IP (`libp2p-relay-0.21.1/src/behaviour.rs:126-152`)
- `max_circuits: 16` and `max_circuits_per_peer: 4`
- `max_reservations`, `max_reservations_per_peer`, `reservation_duration`

The distinction is the whole point of the change: the limiters bound how many circuits you can get, and those are what keep an open relay from being a free bandwidth proxy. The two fields this branch touches bound what a circuit is good for once you have it. Raising the second without raising the first is intentional.

It does mean the concurrency caps are now the next wall a heavy user hits, and with circuits living up to 30 minutes instead of 2 they will be hit sooner. The exact behaviour is worth stating because the comparison is strict: a circuit is refused when `num_circuits_of_peer(event_source) > max_circuits_per_peer` (`libp2p-relay-0.21.1/src/behaviour.rs:539-541`), counting the peer as either source or destination (`:786-791`). With the default of 4, a peer gets *five* concurrent circuits and is refused the sixth. So a Bob fanning out through one relay reaches five Eves. The global cap is `>=`, so 16 means 16.

Also unchanged: the timer bounds the *circuit* — the whole relayed connection — not one transfer on it. A peer that stays relay-only (symmetric NAT, where dcutr cannot upgrade to a direct path) is still reconnected at that cadence, and a caller mid-RPC at that instant sees the same closed connection it used to see every two minutes. This moves the cut from every 2 min to every 30; it does not remove it.

## Second, unrelated item: `vpk bench --vectors N` for small N

Same area, small, and in the same commit rather than a separate PR. `vpk bench` sweeps three scales, `[n_max/4, n_max/2, n_max]` (`vpk_bench.rs`), with a floor of 1000 so a small run still measures something. The floor could exceed the corpus that was actually generated, and `corpus[..n]` panicked past its end — `--vectors 100` did exactly that. Separately, with few vectors and several Eves, the last shard's `start` could pass `end`, and `corpus[start..end]` panics on an inverted range. Both slices are now clamped.

## Tests

Three unit tests in a new `relay_circuit_limits` module in `config.rs`. An earlier fourth was tautological and was removed rather than kept for the count.

- `the_defaults_match_the_p2pd_relay` — pins both defaults to `1 << 32` and 30 min, and asserts each strictly exceeds libp2p's `1 << 17` / 120 s. That second assertion is the one with teeth: it fails if someone reverts to `relay::Config::default()`, which is the exact state that broke bulk transfer.
- `the_default_circuit_duration_fits_the_wire_format` — asserts the default's `as_secs()` fits `u32`, i.e. that the shipped default cannot trip the `expect` in the hop handler. `behaviour.rs` clamps anything else.
- `the_limits_round_trip_and_default_when_absent` — serde round trip for both fields, then deserialises a `NetworkConfig` JSON written before these fields existed and asserts it picks up the new defaults rather than `u64::default()` / `Duration::default()`. A config predating the change would otherwise silently deserialise to `0` bytes and `0` seconds, which is uncapped-and-instantly-expired.

Run on the branch as is (1 commit on `main` @ `9190d4a2`), mirroring the CI jobs:

| command | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p kwaai-p2p -p kwaai-hivemind-dht -- -D warnings` | clean |
| `cargo clippy -p kwaainet -- -D warnings` | clean |
| `cargo clippy -p kwaai-p2p -p kwaainet --all-targets -- -D warnings` | clean |
| `cargo test -p kwaai-p2p -p kwaai-hivemind-dht` | **245 passed, 0 failed**, 5 ignored (baseline 242 + the 3 added here) |
| `cargo test -p kwaainet` | **159 passed, 0 failed** |

`git merge-tree` against `feat/bootstrap-serve` (#94) and `feat/decentralized-dht` (#96): no conflicts either way.

Verified end-to-end on the kwaaiai-env sealed nat-test topology, binary built from that repo's `combined` branch: `vpk bench` NAT→NAT (`node-f` → `node-g`, through a Rust bootstrap acting as the relay hop server), 2000 vectors in 500-vector batches, 100% recall at 1000, ~1 ms query RTT. Before this change the same transfer died mid-batch. That run is a manual observation on a Docker topology, not something CI reproduces.

## Follow-ups, not done here

- **Wire both knobs to `config.yaml`.** `node_native.rs` builds `NetworkConfig` field by field and ends with `..NetworkConfig::default()`, so these two arrive from the defaults and there is no `Config` key to map. The p2pd path needs nothing: `daemon.rs` passes no `-relayDataLimit` / `-relayTimeLimit`, and the vendored go-libp2p-daemon (`v0.5.0.hivemind1`, `p2pd/main.go:95-100`) defaults `-relayService` to true at exactly `1<<32` / 30 min — which is where these numbers come from. The case for changing the native defaults alone is that every native relay on the network was silently at 128 KiB, and no amount of configurability helps an operator who does not know that.
- **A better error than `NotInitialized`.** A dropped in-flight reply reports `Network not initialized`, which sent this investigation to the wrong layer for a while. Addressed on #137 (`fix/routed-dial-address-selection`), an independent PR also targeting `main` — that branch and this one were found in the same session but do not depend on each other.
- **Surface the limits.** Nothing reports a circuit torn down for exceeding its budget as anything other than a closed connection. The `Limit` fields are already on the wire in both directions; a client that read them could at least log why.
