### PR TITLE
fix(config): reload config.yaml before runtime saves

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -911,6 +911,12 @@ impl KwaaiNetConfig {
         }
     }
 
+    /// Re-read config.yaml before a save so writes by other processes are kept;
+    /// falls back to `self` if the file cannot be read.
+    pub fn reloaded(&self) -> Self {
+        Self::load_or_create().unwrap_or_else(|_| self.clone())
+    }
+
     /// Load config from `~/.kwaainet/config.yaml`, creating it with defaults if absent.
     pub fn load_or_create() -> Result<Self> {
         let cfg_file = config_file();

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -247,7 +247,11 @@ async fn main() -> Result<()> {
                                         cfg.model_repository = None;
                                     }
                                     // Persist so the daemon child picks it up.
-                                    let _ = cfg.save();
+                                    let mut persisted = cfg.reloaded();
+                                    persisted.model = cfg.model.clone();
+                                    persisted.model_dht_prefix = cfg.model_dht_prefix.clone();
+                                    persisted.model_repository = cfg.model_repository.clone();
+                                    let _ = persisted.save();
                                 }
                                 None => {
                                     print_info(&format!(

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -401,7 +401,7 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
         // assignment and what the running process announces.
         let assigned_blocks = (e - s) as u32;
         if Some(s as u32) != cfg.start_block || assigned_blocks != cfg.blocks {
-            let mut updated = cfg.clone();
+            let mut updated = cfg.reloaded();
             // Records a pin, so the next start keeps this range instead of
             // re-querying the DHT and possibly moving again.
             updated.start_block = Some(s as u32);
@@ -425,7 +425,7 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
         let s = args.start_block.unwrap_or_else(|| cfg.start_block()) as usize;
         let total = cfg.model_total_blocks() as usize;
         let e = (s + target_blocks).min(total);
-        let mut updated = cfg.clone();
+        let mut updated = cfg.reloaded();
         updated.start_block = Some(s as u32);
         updated.blocks = (e - s) as u32;
         // --start-block / --no-auto is a deliberate placement; the rebalancer


### PR DESCRIPTION
Registered knowledge bases disappear from `config.yaml` while a node is running. `kwaainet rag init` reports success, `rag list` shows the KB, and some minutes later it is gone — no error, no log line. Reported twice in the field — with a caveat on attribution, see the note on #128 below. The same mechanism silently reverts anything else written meanwhile, including `kwaainet config set`.

Targets `main` directly; independent of the bootstrap/decentralized-DHT stack (#94, #96) and of the two `kwaai-p2p` fixes (#137, #138).

## Mechanism

`KwaaiNetConfig::save()` (`core/crates/kwaai-cli/src/config.rs:1029`) serialises the **whole** struct over `config.yaml`. There is no per-key write. So a save is only correct if the struct it is called on reflects what is currently on disk.

Three sites called it on a snapshot taken at process start:

| site | snapshot taken | saved | gap |
|---|---|---|---|
| `main.rs` `Command::Start` | on entering `Command::Start` | after the model matcher picks a model | one `map::fetch_map` round trip |
| `shard_cmd.rs` `cmd_shard_serve` — auto path | on entering the serve pass | after auto-assignment | one `pick_gap_blocks` DHT walk, minutes over p2p |
| `shard_cmd.rs` — manual path | same | after computing an explicit range | short, but the same shape |

Both `shard_cmd.rs` sites built the value to save as `let mut updated = cfg.clone()`. `rag init` is a *separate process*: it loads at `rag_cmd.rs:438` and saves at `:453`, so its write lands in that gap and is then overwritten by a struct that predates it. `rag_kbs` was simply absent from the older snapshot, so the entry vanished rather than reverting to an earlier value.

This is not a new rule. `grpc_server.rs:660` already records it for the RAG handlers — "each handler loads config from disk itself, exactly as the CLI does — the snapshot is never consulted on the RAG path". The three sites here are the ones that did not.

## What changed

`KwaaiNetConfig::reloaded()` — a fresh `load_or_create()`, falling back to `self` if the file cannot be read — and each of the three sites calls it immediately before mutating and saving. `main.rs` copies only the three fields the matcher owns (`model`, `model_dht_prefix`, `model_repository`) onto the fresh read; the two `shard_cmd.rs` sites set `start_block`, `blocks`, `start_block_auto` on it.

13 lines. No signature, config key or control changes.

**This narrows the race; it does not close it.** The window goes from process-lifetime (minutes) to the microseconds between `load_or_create()` and `save()`, but two writers can still interleave inside it and the loser's write is still lost silently. Closing it properly means either an advisory file lock around load→save, or routing every mutation through one read-modify-write helper so there is a single place to hold it. Both are larger than this fix and neither is attempted here.

Two further honest limits:

- `reloaded()` falls back to the stale snapshot if `config.yaml` fails to parse, so it is written over it — the pre-existing behaviour, preserved deliberately so a serve pass is not aborted by a malformed file, but it means a corrupt config is still overwritten rather than reported.
- The change-detection guards in `shard_cmd.rs` still compare against the process-start `cfg`, not against the reloaded config. Consequence: a redundant write plus a spurious `signal_reannounce()` if another process already wrote the same range, or a skipped write if it wrote a different one. Narrow, and separable from the clobbering fix.

## One behaviour change worth a decision

The `main.rs` site previously saved the whole `cfg`, which by then carried the `start` CLI overrides — `--blocks`, `--port`, `--public-name`, `--public-ip`, `--announce-addr`, `--identity-key`, `--no-gpu`, `--no-relay`. `spawn_daemon_child(&[])` passes no arguments, so the daemon child re-reads `config.yaml`; that incidental save was the only route by which those overrides reached it. Copying just the three model fields removes that route.

I think removing it is right, but it is a change, not a no-op, so flagging it: the old behaviour only worked when the whole `if !explicit_model` / map-reachable / model-matched chain fired. Pass `--model`, run without Ollama models, or have the map unreachable, and `--port` was already discarded on the daemon path. Persisting an override sometimes, depending on whether a network fetch matched, is worse than never — but if `start` overrides are meant to reach the daemon child, the fix is to pass them to `spawn_daemon_child`, not to restore a side effect of the model matcher. Happy to split that either way.

## Relationship to #128 and #132

Same symptom, different cause, and neither supersedes this.

- **#128** sandboxed `kwaainet_dir()` under `cfg(test)` after a `cargo test` run destroyed 23 KBs on a developer machine. That was a *test process* reaching the real path.
- **#132** removed the implicit `save()` from the tail of `set_key`, so a setter no longer performs I/O; `config set` persists explicitly.

This defect is in non-test code and survives both: `save()` still writes the whole struct, and these three call sites still held a stale one. It does not duplicate #132 — that PR was about *who* calls `save()`, this is about *what the struct contains* when they do. It composes with #132's stated aim (validate several keys, then commit once): a read-modify-write helper is the natural home for both, and is the follow-up named above.

#128's commit notes that the test-suite writes "also rewrote `blocks` and `start_block`, which is what made the config look like it was being rewritten periodically — the symptom originally blamed on the rebalancer". Worth being precise: that finding may well account for the two field incidents behind this branch's commit message, and I cannot separate them retrospectively. The clobbering path is provable from the code on `main` regardless of which incident it caused.

## Tests

None added. `reloaded()` itself is a one-liner over `load_or_create()`; the save sites are inside `main()`'s match arm and mid-way through `cmd_shard_serve`, past a `P2PClient::connect` to a live p2pd.

The pieces for such a test do exist. #128's `cfg(test)` sandbox gives the test its own `KWAAINET_HOME`, so a test could write a config carrying a `rag_kbs` entry, hold a snapshot taken before it, run the helper, and assert the entry survives. One caveat from #132: `config.rs:1717` records why there is deliberately no test that calls `save()` and asserts on the resulting file — `grpc_server`'s tests set `KWAAINET_HOME` process-wide behind their own mutex, so a concurrent `save()` can be redirected between the write and the assertion, and such a test passes alone and fails in the suite. A test here would need to assert on a returned struct rather than on the file, or take that same env lock.

Run on the branch as is (1 commit on `main` @ `9190d4a2`), mirroring the CI jobs:

| command | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p kwaainet -- -D warnings` | clean |
| `cargo clippy -p kwaai-p2p -p kwaainet --all-targets -- -D warnings` | clean |
| `cargo test -p kwaainet` | **159 passed, 0 failed** |

`git merge-tree` against `feat/bootstrap-serve` (#94) and `feat/decentralized-dht` (#96): no conflicts either way.

## Not done here

- **Atomic save.** `save()` is `serde_yaml::to_string` then `std::fs::write` (`config.rs:1037–1039`) — not temp-file-plus-rename, so a crash mid-write truncates `config.yaml` rather than leaving the previous version. Unrelated to the clobbering but on the same function.
- **A single read-modify-write path**, with a lock, replacing the reload-before-save idiom at every call site. There are fifteen `cfg.save()` sites across `rag_cmd.rs`, `storage.rs`, `vpk.rs`, `main.rs` and `shard_cmd.rs`; this PR fixes the three with a wide window, not the pattern.
- **The stale change-detection guards** in `shard_cmd.rs`, described above.
