### PR TITLE
fix(kwaai-cli): restore the Windows build of the gRPC server handle

### DIFF
--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -1970,6 +1970,7 @@ pub(crate) fn spawn_on_tcp_port(config: KwaaiNetConfig, tcp_port: u16) -> GrpcSe
         drop(service); // suppress unused warning on non-unix
         GrpcServerHandle {
             shutdown_tcp: Some(shutdown_tcp_tx),
+            net: net_slot,
         }
     }
 }


### PR DESCRIPTION
## Summary

Current `main` does not compile on Windows — the whole `kwaainet` binary, not just tests:

```
error[E0063]: missing field `net` in initializer of `GrpcServerHandle`
```

#130 added the `net` slot to `GrpcServerHandle` and populated it in `spawn_on_tcp_port`'s `cfg(unix)` branch, but not the `cfg(not(unix))` one. The field itself is not cfg-gated, so the Windows branch constructs the struct with a field missing.

`net_slot` is already bound at function scope and visible to both branches (it was simply unused on Windows), so filling it in is the entire fix. As a bonus this makes `attach_network` actually meaningful on Windows instead of dropping the service's only route to the swarm.

## Test plan
- [x] `cargo check -p kwaainet` on Windows 11 x86_64 (MSVC): **fails** on `455c7e7`, **clean** with this commit
- [x] Change is inside `cfg(not(unix))`, so Unix/macOS builds are untouched by construction
- [ ] CI: worth confirming why this reached `main` — a Windows `cargo check`/`cargo test` job would have caught it

Found while trying to run tests for a separate updater fix on a Windows node; that work is blocked on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)