### PR TITLE
ci: gate Windows so a cfg(not(unix)) break can't reach main again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ name: CI
 #   - Single unified cargo cache key shared by clippy + test (same artifacts)
 #   - clippy uses default features only (was --all-features; CUDA/Metal are
 #     only needed for the release build, not the lint gate)
-#   - test matrix: ubuntu only on PRs; ubuntu + macOS on pushes to main
+#   - test matrix: ubuntu only on PRs; ubuntu + macOS + Windows on pushes to
+#     main, with a Windows `cargo check` gate on every PR (see job 3)
 #   - wasm-pack binary cached so `cargo install wasm-pack` only runs once
 #   - dropped `build --release` job (slow, redundant with release.yml)
 #   - dropped `docs` job (nice-to-have, not a merge gate)
@@ -94,17 +95,91 @@ jobs:
         working-directory: core
         run: cargo clippy --all-targets -- -D warnings
 
-  # ── 3. Tests (ubuntu for PRs; ubuntu + macOS on pushes to main) ────────────
+  # ── 3. Windows compile gate (every PR) ────────────────────────────────────
+  # Windows had no CI at all, and main reached a state where `cargo check -p
+  # kwaainet` failed outright on it: #130 added a field to GrpcServerHandle and
+  # populated it only in the cfg(unix) arm, so the cfg(not(unix)) arm no longer
+  # compiled. Nothing on Linux or macOS can see that — the broken arm is
+  # cfg'd out — and it went unnoticed until someone tried to build on Windows.
+  #
+  # `check`, not `test`: this catches the whole class of cfg(windows)-only
+  # compile breaks in a fraction of a full Windows test run, which keeps it
+  # affordable on every PR. --all-targets so test-only code is compiled too
+  # (Windows-gated tests live behind cfg(test) + cfg(windows) and would
+  # otherwise never be built anywhere). Execution is left to the push-to-main
+  # test matrix below.
+  windows-check:
+    name: Windows check
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: fetch patched deps
+        # Git Bash: the script probes for a working shasum/sha256sum itself.
+        shell: bash
+        run: bash core/patches/fetch-multistream-select.sh
+        working-directory: ${{ github.workspace }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Configure sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
+      # build.rs shells out to `go build` for p2pd.
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+          cache-dependency-path: '**/go.sum'
+
+      # Mirrors the Windows CUDA job in release.yml, which needs this to link.
+      - name: Set OpenSSL paths
+        shell: pwsh
+        run: |
+          $dir = Get-ChildItem "C:\Program Files" -Filter "OpenSSL*" -ErrorAction SilentlyContinue |
+                 Select-Object -First 1 -ExpandProperty FullName
+          if ($dir) {
+            echo "OPENSSL_DIR=$dir" >> $env:GITHUB_ENV
+          }
+
+      - name: Cache cargo + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            core/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/build.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      # --workspace: the default-members list is just kwaai-cli, so a plain
+      # check would leave every other crate's Windows build unguarded.
+      - name: Check
+        working-directory: core
+        run: cargo check --workspace --all-targets
+
+  # ── 4. Tests (ubuntu for PRs; ubuntu + macOS + Windows on pushes to main) ──
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'pull_request' && fromJson('["ubuntu-latest"]') || fromJson('["ubuntu-latest", "macos-latest"]') }}
+        os: ${{ github.event_name == 'pull_request' && fromJson('["ubuntu-latest"]') || fromJson('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - name: fetch patched deps
+        # Windows runs this under Git Bash; the script probes for a working
+        # shasum/sha256sum itself.
+        shell: bash
         run: bash core/patches/fetch-multistream-select.sh
         working-directory: ${{ github.workspace }}
 
@@ -134,6 +209,18 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
 
+      # No Windows equivalent: build.rs fetches protoc itself when it isn't on
+      # PATH, which is what the Windows release job already relies on.
+      - name: Set OpenSSL paths (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dir = Get-ChildItem "C:\Program Files" -Filter "OpenSSL*" -ErrorAction SilentlyContinue |
+                 Select-Object -First 1 -ExpandProperty FullName
+          if ($dir) {
+            echo "OPENSSL_DIR=$dir" >> $env:GITHUB_ENV
+          }
+
       - name: Cache cargo + target
         uses: actions/cache@v4
         with:
@@ -150,7 +237,7 @@ jobs:
         working-directory: core
         run: cargo test --all
 
-  # ── 4. WASM build (wasm-pack cached to avoid reinstall every run) ──────────
+  # ── 5. WASM build (wasm-pack cached to avoid reinstall every run) ──────────
   wasm:
     name: WASM
     runs-on: ubuntu-latest
@@ -200,7 +287,7 @@ jobs:
         working-directory: core/crates/kwaai-wasm
         run: wasm-pack build --target web
 
-  # ── 5. Dev binaries (push to main only — gives devs/QA a downloadable build) ─
+  # ── 6. Dev binaries (push to main only — gives devs/QA a downloadable build) ─
   dev-binary:
     name: Dev binary (${{ matrix.target }})
     if: github.event_name == 'push'


### PR DESCRIPTION
> **Stacked on #142** — based on `fix/windows-grpc-handle-net-field` so the new job can actually go green and demonstrate itself. On `main` it would (correctly) fail. Retarget to `main` once #142 merges.

## Why

Windows had **no CI of any kind** — not fmt, not clippy, not test, not even a compile check. `main` duly reached a state where `cargo check -p kwaainet` fails outright on Windows (#142): #130 added a field to `GrpcServerHandle` and populated it only in the `cfg(unix)` arm.

Linux and macOS cannot catch that class of bug by construction — the broken arm is `cfg`'d out before it reaches the type checker. It surfaced only when someone tried to build on Windows, days later.

## What

**1. New `windows-check` job, every PR** — `cargo check --workspace --all-targets`

- `check` not `test`: catches the entire class of `cfg(windows)`-only compile failures at a fraction of a full Windows test run, so it's affordable as a per-PR gate.
- `--all-targets`: Windows-only tests sit behind `cfg(test)` + `cfg(windows)` and would otherwise be compiled nowhere (see #143, which adds exactly such tests).
- `--workspace`: `default-members` is only `kwaai-cli`, so a bare check leaves every other crate's Windows build unguarded — the same blind spot that let this through.

**2. `windows-latest` added to the push-to-main test matrix** — so Windows tests are *executed*, not merely compiled. PRs keep the ubuntu-only matrix; the check job is the PR-time gate.

Windows specifics all mirror the already-working Windows job in `release.yml`: Git Bash for the patch-fetch script (it already probes for a usable `shasum`/`sha256sum`, #93), Go for `build.rs`'s p2pd build, and the OpenSSL path shim. No protoc step — `build.rs` fetches it when absent, which is what the Windows release job already relies on.

## Test plan

- [x] Verified the gate catches the real bug: `cargo check --workspace --all-targets` on Windows 11 x86_64 (MSVC) **fails** on `455c7e7`, **passes** with #142's fix. So this isn't a hypothetical gate — it reproduces the exact failure it exists to prevent.
- [x] YAML parses (`yaml.safe_load`); job graph is `fmt, clippy, windows-check, test, wasm, dev-binary`.
- [ ] **The job itself can only be proven by running here** — runner-specific steps (Git Bash invocation, Go/OpenSSL setup, cache behaviour) are unverifiable locally and may need a follow-up iteration.

## Cost note

Adds one Windows runner per PR (billed at 2× Linux minutes). If that's unwelcome, the cheaper variants are: restrict the job to PRs touching Rust/CI paths, or move it to push-to-main only — though the latter gives up pre-merge protection, which is what failed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)