### PR TITLE
fix(p2p): make DCUtR hole punching work, and survive

### DIFF
--- a/core/crates/kwaai-network-tests/tests/02_unit_p2p.rs
+++ b/core/crates/kwaai-network-tests/tests/02_unit_p2p.rs
@@ -51,14 +51,14 @@ fn config_builder_overrides() {
     let rec = MetricsRecorder::start("unit::p2p::config_builder_overrides", "unit");
     let cfg = NetworkConfig::builder()
         .max_connections(50)
-        .connection_timeout(Duration::from_secs(10))
+        .idle_connection_timeout(Duration::from_secs(10))
         .request_timeout(Duration::from_secs(5))
         .listen_addrs(vec!["/ip4/0.0.0.0/tcp/9000".to_string()])
         .bootstrap_peers(vec!["/ip4/1.2.3.4/tcp/8000".to_string()])
         .build();
 
     assert_eq!(cfg.max_connections, 50);
-    assert_eq!(cfg.connection_timeout, Duration::from_secs(10));
+    assert_eq!(cfg.idle_connection_timeout, Duration::from_secs(10));
     assert_eq!(cfg.listen_addrs, vec!["/ip4/0.0.0.0/tcp/9000"]);
     assert_eq!(cfg.bootstrap_peers.len(), 1);
     rec.finish(true);

--- a/core/crates/kwaai-p2p/src/behaviour.rs
+++ b/core/crates/kwaai-p2p/src/behaviour.rs
@@ -40,7 +40,7 @@
 use std::time::Duration;
 
 use libp2p::{
-    autonat, dcutr, identify, kad,
+    autonat, connection_limits, dcutr, identify, kad,
     kad::store::MemoryStore,
     ping, relay,
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
@@ -66,6 +66,9 @@ pub fn default_agent_version() -> String {
 /// The composed behaviour driven by [`crate::service::NetworkService`].
 #[derive(NetworkBehaviour)]
 pub struct KwaaiBehaviour {
+    /// First so a refusal happens before anything else allocates for the
+    /// connection.
+    pub connection_limits: connection_limits::Behaviour,
     pub ping: ping::Behaviour,
     pub identify: identify::Behaviour,
     pub kad: kad::Behaviour<MemoryStore>,
@@ -92,6 +95,25 @@ impl KwaaiBehaviour {
         relay_client: relay::client::Behaviour,
     ) -> Self {
         let local_peer_id = PeerId::from(keypair.public());
+
+        // `max_connections` has been in the config all along, enforced nowhere.
+        // It matters now: idle connections are kept for ten minutes rather than
+        // thirty seconds, so this is the only thing bounding growth, and a
+        // bootstrap is where that bites first.
+        //
+        // Incoming is capped below the total so a node can always dial out. If
+        // inbound filled every slot the node would go deaf — unable to re-dial
+        // the bootstraps and relays that keep it reachable.
+        //
+        // Deliberately no per-peer cap: DCUtR holds the relayed and the punched
+        // connection at once, and refusing the second is refusing the punch.
+        let max = u32::try_from(config.max_connections).unwrap_or(u32::MAX);
+        let connection_limits = connection_limits::Behaviour::new(
+            connection_limits::ConnectionLimits::default()
+                .with_max_established(Some(max))
+                .with_max_established_incoming(Some((max / 5 * 4).max(1)))
+                .with_max_pending_incoming(Some((max / 4).max(4))),
+        );
 
         let ping = ping::Behaviour::new(ping::Config::new().with_interval(Duration::from_secs(30)));
 
@@ -197,6 +219,7 @@ impl KwaaiBehaviour {
         let upnp = Toggle::from(config.enable_upnp.then(upnp::tokio::Behaviour::default));
 
         Self {
+            connection_limits,
             ping,
             identify,
             kad,

--- a/core/crates/kwaai-p2p/src/config.rs
+++ b/core/crates/kwaai-p2p/src/config.rs
@@ -47,16 +47,6 @@ pub struct NetworkConfig {
     pub dht_replication: usize,
 
     /// How long a connection may sit idle before the swarm closes it.
-    ///
-    /// This is the *only* thing the value drives — it is not a dial timeout.
-    /// It was 30s, which is why hole punching appeared not to work: a punched
-    /// connection carries no traffic of its own, so it was reaped within a
-    /// minute and the peer went back to reading as relayed. The p2pd path had
-    /// no equivalent — go-libp2p's connection manager keeps peers until the
-    /// high-water mark (~96) is passed — so peers stayed visible there.
-    ///
-    /// Paired with `max_connections`: keeping idle connections is only safe
-    /// because their number is capped.
     #[serde(alias = "connection_timeout")]
     pub idle_connection_timeout: Duration,
 
@@ -64,9 +54,6 @@ pub struct NetworkConfig {
     pub request_timeout: Duration,
 
     /// Maximum concurrent connections, inbound and outbound.
-    ///
-    /// Mirrors go-libp2p's connection-manager high-water mark, and is what
-    /// bounds the cost of the long `idle_connection_timeout` above.
     pub max_connections: usize,
 
     /// Enable NAT traversal

--- a/core/crates/kwaai-p2p/src/config.rs
+++ b/core/crates/kwaai-p2p/src/config.rs
@@ -46,13 +46,27 @@ pub struct NetworkConfig {
     /// DHT replication factor
     pub dht_replication: usize,
 
-    /// Connection timeout
-    pub connection_timeout: Duration,
+    /// How long a connection may sit idle before the swarm closes it.
+    ///
+    /// This is the *only* thing the value drives — it is not a dial timeout.
+    /// It was 30s, which is why hole punching appeared not to work: a punched
+    /// connection carries no traffic of its own, so it was reaped within a
+    /// minute and the peer went back to reading as relayed. The p2pd path had
+    /// no equivalent — go-libp2p's connection manager keeps peers until the
+    /// high-water mark (~96) is passed — so peers stayed visible there.
+    ///
+    /// Paired with `max_connections`: keeping idle connections is only safe
+    /// because their number is capped.
+    #[serde(alias = "connection_timeout")]
+    pub idle_connection_timeout: Duration,
 
     /// Request timeout
     pub request_timeout: Duration,
 
-    /// Maximum concurrent connections
+    /// Maximum concurrent connections, inbound and outbound.
+    ///
+    /// Mirrors go-libp2p's connection-manager high-water mark, and is what
+    /// bounds the cost of the long `idle_connection_timeout` above.
     pub max_connections: usize,
 
     /// Enable NAT traversal
@@ -203,7 +217,9 @@ impl Default for NetworkConfig {
             bootstrap_peers: Vec::new(),
             enable_dht: true,
             dht_replication: 20,
-            connection_timeout: Duration::from_secs(30),
+            // Long enough that a punched connection survives to be seen and
+            // used. `max_connections` is what keeps this bounded.
+            idle_connection_timeout: Duration::from_secs(10 * 60),
             request_timeout: Duration::from_secs(60),
             max_connections: 100,
             enable_nat_traversal: true,
@@ -322,8 +338,8 @@ impl NetworkConfigBuilder {
     }
 
     /// Set connection timeout
-    pub fn connection_timeout(mut self, timeout: Duration) -> Self {
-        self.config.connection_timeout = timeout;
+    pub fn idle_connection_timeout(mut self, timeout: Duration) -> Self {
+        self.config.idle_connection_timeout = timeout;
         self
     }
 
@@ -417,7 +433,7 @@ mod relay_circuit_limits {
         let legacy = r#"{
             "listen_addrs": [], "bootstrap_peers": [], "enable_dht": true,
             "dht_replication": 20,
-            "connection_timeout": {"secs": 30, "nanos": 0},
+            "idle_connection_timeout": {"secs": 600, "nanos": 0},
             "request_timeout": {"secs": 60, "nanos": 0},
             "max_connections": 100, "enable_nat_traversal": true,
             "enable_relay_client": true, "protocol_version": "x",

--- a/core/crates/kwaai-p2p/src/raw_stream.rs
+++ b/core/crates/kwaai-p2p/src/raw_stream.rs
@@ -464,9 +464,7 @@ impl Behaviour {
                 // establishes.
                 if parked.is_empty() {
                     self.pending_events.push_back(ToSwarm::Dial {
-                        // A new port: binding our listen port as a dial
-                        // source fails `EADDRINUSE` against our own listener.
-                        opts: DialOpts::peer_id(peer).allocate_new_port().build(),
+                        opts: DialOpts::peer_id(peer).build(),
                     });
                 }
                 parked.push(open);

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -1774,21 +1774,8 @@ impl NetworkService {
                         }
                     }
 
-                    // Retire the circuit the punch just replaced.
-                    //
-                    // Nothing migrates traffic onto a newly punched connection:
-                    // libp2p opens each new substream on whichever connection
-                    // it picks, and kad, identify and ping keep flowing over
-                    // the relay that was already carrying them. The direct path
-                    // therefore sits idle and `idle_connection_timeout` reaps
-                    // it — measured in the nat-test bed at ~50s from punch to
-                    // `cause=KeepAlive`, after which the peer reads as relayed
-                    // again. Hole punching worked and left nothing behind.
-                    //
-                    // Closing the circuit leaves one path, which then carries
-                    // the traffic that keeps it alive. That is what a relay is
-                    // for: introduction, not carriage — the same reason
-                    // `relay::Config` defaults a circuit to 128 KiB / 2 min.
+                    // Retire the circuit the punch just replaced, migrating
+                    // traffic onto the newly punched connection
                     let circuits: Vec<ConnectionId> = self
                         .connections
                         .get(&remote_peer_id)
@@ -1815,11 +1802,7 @@ impl NetworkService {
                         }
                     }
                 }
-                // Info, not debug: "no hole punch has ever happened" and "every
-                // hole punch fails" look identical from the outside, and the
-                // difference is the whole diagnosis. This was debug for the
-                // release in which hole punching did not work at all.
-                Err(e) => info!(peer = %remote_peer_id, error = %e, "dcutr hole punch failed"),
+                Err(e) => debug!(peer = %remote_peer_id, error = %e, "dcutr hole punch failed"),
             },
 
             KwaaiBehaviourEvent::Upnp(event) => self.handle_upnp_event(event),

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -881,21 +881,16 @@ impl NetworkService {
         let peer = peer_id_from_multiaddr(&addr);
         let condition_safe = peer.is_some() && !is_circuit(&addr);
 
-        // Both arms call `allocate_new_port()`, overriding the `DialOpts`
-        // default of best-effort port reuse.
+        // Nothing here touches the port policy. `DialOpts` defaults to
+        // `PortUse::Reuse` — `#[default]` on the enum itself — and that default
+        // exists for one reason: reusing the listen port as a dial's source
+        // port is what makes NAT traversal work. It puts our listen port's NAT
+        // binding into the address peers observe for us, and that observed
+        // address is the only thing DCUtR has to punch at.
         //
-        // Reuse asks the transport to bind our listen port as the dial's source
-        // port. That is right for a DCUtR hole punch — `libp2p-dcutr` requests
-        // it on its own dials and still gets it — but wrong for an ordinary
-        // dial, because the bind fails outright: `SO_REUSEPORT` lets several
-        // *listeners* share a port, not a listener plus an outbound connect.
-        // Measured on macOS (errno 48) and Linux (errno 98) alike, with no
-        // prior connection to the target.
-        //
-        // libp2p-tcp 0.44 does retry on a fresh port, but only for
-        // `AddrNotAvailable` raised by `connect`. Our failure is `EADDRINUSE`
-        // from `bind`, one step earlier, where the `?` propagates before the
-        // fallback can run — so the dial simply fails.
+        // Overriding it with `allocate_new_port()` is what silently disabled
+        // hole punching for a release. The upstream dcutr example sets no port
+        // policy at all; neither do we.
         let opts = match peer {
             // DisconnectedAndNotDialing rather than Disconnected: the latter
             // still permits a second dial while the first is in flight, which
@@ -903,15 +898,10 @@ impl NetworkService {
             Some(peer) if condition_safe => DialOpts::peer_id(peer)
                 .addresses(vec![addr.clone()])
                 .condition(PeerCondition::DisconnectedAndNotDialing)
-                .allocate_new_port()
                 .build(),
-            // `unknown_peer_id().address(..)` rather than
-            // `DialOpts::from(addr)`, because only the builder exposes
-            // `allocate_new_port()`; the two are otherwise the same dial.
-            _ => DialOpts::unknown_peer_id()
-                .address(addr.clone())
-                .allocate_new_port()
-                .build(),
+            // `unknown_peer_id().address(..)` and `DialOpts::from(addr)` are
+            // the same dial; the builder form just reads consistently above.
+            _ => DialOpts::unknown_peer_id().address(addr.clone()).build(),
         };
         let connection_id = opts.connection_id();
         match self.swarm.dial(opts) {
@@ -1112,9 +1102,6 @@ impl NetworkService {
         let opts = DialOpts::peer_id(peer)
             .addresses(addrs)
             .condition(PeerCondition::DisconnectedAndNotDialing)
-            // As in `dial()`: reuse asks the transport to bind our listen
-            // port, which `EADDRINUSE`s against our own listener.
-            .allocate_new_port()
             .build();
         let connection_id = opts.connection_id();
 
@@ -1245,10 +1232,7 @@ impl NetworkService {
                     let _ = reply.send(Ok(peer));
                     return;
                 }
-                // A new port for the same reason as `dial()`: reuse
-                // asks the transport to bind our listen port, which
-                // `EADDRINUSE`s against our own listener.
-                let opts = DialOpts::peer_id(peer).allocate_new_port().build();
+                let opts = DialOpts::peer_id(peer).build();
                 let connection_id = opts.connection_id();
                 match self.swarm.dial(opts) {
                     Ok(()) => {
@@ -1714,6 +1698,17 @@ impl NetworkService {
 
             SwarmEvent::Behaviour(event) => self.handle_behaviour_event(event),
 
+            // The candidate feed *is* DCUtR's punch-target list: `dcutr` builds
+            // its address candidates from this event and nothing else — notably
+            // not from `ExternalAddrConfirmed`, so what the reachability machine
+            // confirms never reaches it. Logged because a punch aimed at the
+            // wrong port is otherwise invisible: on a NATed node these should
+            // carry the port the NAT mapped, which is only true while dials
+            // leave from our listen port.
+            SwarmEvent::NewExternalAddrCandidate { address } => {
+                info!(%address, "external address candidate (DCUtR punch target)");
+            }
+
             other => trace!(?other, "unhandled swarm event"),
         }
     }
@@ -1779,7 +1774,11 @@ impl NetworkService {
                         }
                     }
                 }
-                Err(e) => debug!(peer = %remote_peer_id, error = %e, "dcutr hole punch failed"),
+                // Info, not debug: "no hole punch has ever happened" and "every
+                // hole punch fails" look identical from the outside, and the
+                // difference is the whole diagnosis. This was debug for the
+                // release in which hole punching did not work at all.
+                Err(e) => info!(peer = %remote_peer_id, error = %e, "dcutr hole punch failed"),
             },
 
             KwaaiBehaviourEvent::Upnp(event) => self.handle_upnp_event(event),

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -1773,6 +1773,47 @@ impl NetworkService {
                             conn.dcutr = true;
                         }
                     }
+
+                    // Retire the circuit the punch just replaced.
+                    //
+                    // Nothing migrates traffic onto a newly punched connection:
+                    // libp2p opens each new substream on whichever connection
+                    // it picks, and kad, identify and ping keep flowing over
+                    // the relay that was already carrying them. The direct path
+                    // therefore sits idle and `idle_connection_timeout` reaps
+                    // it — measured in the nat-test bed at ~50s from punch to
+                    // `cause=KeepAlive`, after which the peer reads as relayed
+                    // again. Hole punching worked and left nothing behind.
+                    //
+                    // Closing the circuit leaves one path, which then carries
+                    // the traffic that keeps it alive. That is what a relay is
+                    // for: introduction, not carriage — the same reason
+                    // `relay::Config` defaults a circuit to 128 KiB / 2 min.
+                    let circuits: Vec<ConnectionId> = self
+                        .connections
+                        .get(&remote_peer_id)
+                        .map(|conns| {
+                            conns
+                                .iter()
+                                .filter(|(id, c)| {
+                                    // `via` is what identifies an *inbound*
+                                    // relayed connection: its `addr` is a bare
+                                    // `/p2p/<peer>` with no circuit component.
+                                    **id != connection_id
+                                        && (is_circuit(&c.addr) || c.via.is_some())
+                                })
+                                .map(|(id, _)| *id)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    for id in circuits {
+                        if self.swarm.close_connection(id) {
+                            debug!(
+                                peer = %remote_peer_id, ?id,
+                                "closing the relayed path the punch replaced"
+                            );
+                        }
+                    }
                 }
                 // Info, not debug: "no hole punch has ever happened" and "every
                 // hole punch fails" look identical from the outside, and the

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -292,7 +292,7 @@ impl NetworkService {
             })
             .map_err(|e| anyhow::anyhow!("configuring behaviour: {e}"))?
             .with_swarm_config(|c| {
-                c.with_idle_connection_timeout(config.connection_timeout)
+                c.with_idle_connection_timeout(config.idle_connection_timeout)
                     // 0-RTT protocol negotiation on outbound substreams.
                     //
                     // The default, `V1`, writes the multistream-select proposal,

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -796,9 +796,7 @@ impl Behaviour {
                 // flight ride along on the connection it establishes.
                 if parked.is_empty() {
                     self.pending_events.push_back(ToSwarm::Dial {
-                        // A new port: binding our listen port as a dial
-                        // source fails `EADDRINUSE` against our own listener.
-                        opts: DialOpts::peer_id(peer).allocate_new_port().build(),
+                        opts: DialOpts::peer_id(peer).build(),
                     });
                 }
                 parked.push(message);

--- a/core/crates/kwaai-p2p/tests/connection_limits.rs
+++ b/core/crates/kwaai-p2p/tests/connection_limits.rs
@@ -1,0 +1,111 @@
+//! `max_connections`, which was configurable and enforced nowhere.
+//!
+//! It matters now that idle connections are kept for ten minutes rather than
+//! thirty seconds: nothing else bounds growth, and a bootstrap — which mostly
+//! receives connections rather than making them — is where that bites first.
+
+use std::time::Duration;
+
+use kwaai_p2p::{NetworkConfig, NetworkHandle, NetworkService};
+use libp2p::{identity::Keypair, Multiaddr, PeerId};
+
+const SETTLE_TIMEOUT: Duration = Duration::from_secs(30);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+async fn eventually<T, F, Fut>(what: &str, mut f: F) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<T>>,
+{
+    let deadline = tokio::time::Instant::now() + SETTLE_TIMEOUT;
+    loop {
+        if let Some(value) = f().await {
+            return value;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out after {SETTLE_TIMEOUT:?} waiting for: {what}");
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+fn spawn(max_connections: usize) -> (NetworkHandle, tokio::task::JoinHandle<()>, PeerId) {
+    let keypair = Keypair::generate_ed25519();
+    let peer_id = keypair.public().to_peer_id();
+    let (handle, task) = NetworkService::spawn(
+        NetworkConfig {
+            max_connections,
+            ..NetworkConfig::for_tests()
+        },
+        keypair,
+    )
+    .expect("node should start");
+    (handle, task, peer_id)
+}
+
+async fn dialable_addr(handle: &NetworkHandle, peer_id: PeerId) -> Multiaddr {
+    let addr = eventually("swarm to report a listen address", || async {
+        handle.listen_addrs().await.ok()?.into_iter().next()
+    })
+    .await;
+    addr.with(libp2p::multiaddr::Protocol::P2p(peer_id))
+}
+
+/// `max_connections: 2` leaves an inbound cap of one, so the second dialer is
+/// refused rather than accepted and remembered.
+#[tokio::test]
+async fn inbound_connections_are_capped() {
+    let (limited, _limited_task, limited_id) = spawn(2);
+    let addr = dialable_addr(&limited, limited_id).await.to_string();
+
+    let (first, _first_task, _) = spawn(100);
+    first.connect_peer(&addr).await.expect("first dialer");
+    eventually("the first connection to be established", || async {
+        limited.list_peers().await.ok()?.first().map(|_| ())
+    })
+    .await;
+
+    // Assert on the *limited* node's view, not the dialer's: the denial happens
+    // in `handle_established_inbound_connection`, after the transport upgrade,
+    // so the dialer can see its own connection established and only then be
+    // closed. What matters is that the limited node never keeps the second.
+    let (second, _second_task, second_id) = spawn(100);
+    let _ = second.connect_peer(&addr).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let peers = limited.list_peers().await.expect("list_peers");
+    assert_eq!(
+        peers.len(),
+        1,
+        "inbound is capped at one, so the second dialer must not be kept: {peers:?}"
+    );
+    assert!(
+        peers.iter().all(|p| p.peer_id != second_id),
+        "the kept connection should be the first dialer, not the refused one"
+    );
+}
+
+/// The inbound cap sits below the total on purpose. A node whose inbound slots
+/// are full must still be able to dial: if inbound could consume every slot the
+/// node would go deaf, unable to re-dial the bootstraps and relays that keep it
+/// reachable.
+#[tokio::test]
+async fn a_full_inbound_cap_still_leaves_room_to_dial_out() {
+    let (limited, _limited_task, limited_id) = spawn(2);
+    let addr = dialable_addr(&limited, limited_id).await.to_string();
+
+    let (inbound, _inbound_task, _) = spawn(100);
+    inbound.connect_peer(&addr).await.expect("inbound dialer");
+    eventually("the inbound connection to be established", || async {
+        limited.list_peers().await.ok()?.first().map(|_| ())
+    })
+    .await;
+
+    // Inbound is now at its cap of one. The outbound slot must remain.
+    let (peer, _peer_task, peer_id) = spawn(100);
+    let peer_addr = dialable_addr(&peer, peer_id).await.to_string();
+    limited
+        .connect_peer(&peer_addr)
+        .await
+        .expect("a node at its inbound cap must still be able to dial out");
+}

--- a/core/crates/kwaai-p2p/tests/dcutr.rs
+++ b/core/crates/kwaai-p2p/tests/dcutr.rs
@@ -145,6 +145,36 @@ async fn a_relayed_connection_is_upgraded_to_a_direct_one() {
         direct.addr
     );
 
+    // And it must be *reported* as punched, not merely be direct. This flag is
+    // the only thing distinguishing "there was no NAT in the way" from "a NAT
+    // was traversed", and it is what the GUI renders as `p2p` rather than
+    // `direct`. The service sets it from the dcutr event, which arrives after
+    // the `ConnectionEstablished` that registers the connection — assert it
+    // rather than trusting that ordering to hold across a libp2p upgrade.
+    let punched = eventually("the upgraded connection to be flagged dcutr", || async {
+        let peers = bob.list_peers().await.ok()?;
+        peers.into_iter().find(|p| p.peer_id == alice_id && p.dcutr)
+    })
+    .await;
+    assert!(
+        !kwaai_p2p::is_circuit(&punched.addr),
+        "the dcutr-flagged connection should be the direct one: {}",
+        punched.addr
+    );
+
+    // The circuit it replaced is retired. Leaving it up is what made hole
+    // punching pointless in practice: new substreams keep landing on whichever
+    // connection libp2p picks, so kad and identify carry on over the relay, the
+    // punched path sits idle, and the idle timeout reaps it inside a minute.
+    eventually("the relayed path to be closed", || async {
+        let peers = alice.list_peers().await.ok()?;
+        peers
+            .iter()
+            .all(|p| p.peer_id != bob_id || !kwaai_p2p::is_circuit(&p.addr))
+            .then_some(())
+    })
+    .await;
+
     // Alice sees Bob too, and by a peer id she was never given out of band.
     eventually("alice to see bob", || async {
         let peers = alice.list_peers().await.ok()?;

--- a/core/crates/kwaai-p2p/tests/port_reuse.rs
+++ b/core/crates/kwaai-p2p/tests/port_reuse.rs
@@ -1,0 +1,133 @@
+//! Which local port a dial leaves from.
+//!
+//! DCUtR is a property of NATs and cannot be demonstrated on loopback (see
+//! `tests/dcutr.rs`). Its *precondition* can be, because the source port of a
+//! dial is visible to the peer being dialed: it arrives as the connection's
+//! send-back address.
+//!
+//! That precondition is the whole of the fix. `DialOpts` defaults to
+//! `PortUse::Reuse` so that a dial leaves from the listen port, which is what
+//! puts that port's NAT binding into the address peers observe for us — and
+//! that observed address is the only thing DCUtR has to punch at. Override it
+//! with `allocate_new_port()` and libp2p-identify rewrites the observation to
+//! our listen port (`address_translation`), naming a port the NAT never
+//! mapped. Every hole punch then aims at a closed door.
+//!
+//! So these tests exist to catch a re-introduced `allocate_new_port()`.
+
+use std::time::Duration;
+
+use kwaai_p2p::{Direction, NetworkConfig, NetworkHandle, NetworkService};
+use libp2p::{identity::Keypair, Multiaddr, PeerId};
+
+const SETTLE_TIMEOUT: Duration = Duration::from_secs(30);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+async fn eventually<T, F, Fut>(what: &str, mut f: F) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<T>>,
+{
+    let deadline = tokio::time::Instant::now() + SETTLE_TIMEOUT;
+    loop {
+        if let Some(value) = f().await {
+            return value;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out after {SETTLE_TIMEOUT:?} waiting for: {what}");
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("binding an ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+/// A node on a port we choose, so the test can compare a dial's source port
+/// against it.
+fn spawn_on(port: u16) -> (NetworkHandle, tokio::task::JoinHandle<()>, PeerId) {
+    let keypair = Keypair::generate_ed25519();
+    let peer_id = keypair.public().to_peer_id();
+    let (handle, task) = NetworkService::spawn(
+        NetworkConfig {
+            listen_addrs: vec![format!("/ip4/127.0.0.1/tcp/{port}")],
+            ..NetworkConfig::for_tests()
+        },
+        keypair,
+    )
+    .expect("node should start");
+    (handle, task, peer_id)
+}
+
+async fn dialable_addr(handle: &NetworkHandle, peer_id: PeerId) -> Multiaddr {
+    let addr = eventually("swarm to report a listen address", || async {
+        handle.listen_addrs().await.ok()?.into_iter().next()
+    })
+    .await;
+    addr.with(libp2p::multiaddr::Protocol::P2p(peer_id))
+}
+
+/// The port `observer` saw an inbound connection from `peer` arrive on.
+async fn inbound_source_port(observer: &NetworkHandle, peer: PeerId) -> u16 {
+    let info = eventually("an inbound connection from the dialer", || async {
+        observer
+            .list_peers()
+            .await
+            .ok()?
+            .into_iter()
+            .find(|p| p.peer_id == peer && p.direction == Direction::Inbound)
+    })
+    .await;
+    info.addr
+        .iter()
+        .find_map(|p| match p {
+            libp2p::multiaddr::Protocol::Tcp(port) => Some(port),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("no tcp port in the send-back address: {}", info.addr))
+}
+
+#[tokio::test]
+async fn a_bootstrap_dial_leaves_from_our_listen_port() {
+    let (bootstrap, _bootstrap_task, bootstrap_id) = spawn_on(free_port());
+    let bootstrap_addr = dialable_addr(&bootstrap, bootstrap_id).await;
+
+    let listen_port = free_port();
+    let (node, _node_task, node_id) = spawn_on(listen_port);
+    node.bootstrap(vec![bootstrap_addr])
+        .await
+        .expect("bootstrap dial");
+
+    assert_eq!(
+        inbound_source_port(&bootstrap, node_id).await,
+        listen_port,
+        "a bootstrap dial must leave from our listen port, or identify teaches \
+         the network a mapping no hole punch can use"
+    );
+}
+
+#[tokio::test]
+async fn an_explicit_connect_leaves_from_our_listen_port() {
+    // The same rule for the other dial path. Both are `PortUse::Reuse` only
+    // because neither overrides the default, so this fails the moment someone
+    // reaches for `allocate_new_port()` again.
+    let (peer, _peer_task, peer_id) = spawn_on(free_port());
+    let peer_addr = dialable_addr(&peer, peer_id).await;
+
+    let listen_port = free_port();
+    let (node, _node_task, node_id) = spawn_on(listen_port);
+    node.connect_peer(&peer_addr.to_string())
+        .await
+        .expect("connect_peer");
+
+    assert_eq!(
+        inbound_source_port(&peer, node_id).await,
+        listen_port,
+        "an explicit connect must leave from our listen port too"
+    );
+}


### PR DESCRIPTION
No DCUtR hole punch has ever succeeded on the native stack. Three independent
causes, each of which alone leaves nothing visible.

### 1. Every dial overrode libp2p's port-reuse default

`DialOpts` defaults to `PortUse::Reuse` — `#[default]` on the enum in
libp2p-core — and that default exists for NAT traversal: reusing the listen
port as a dial's source port is what puts that port's NAT binding into the
address peers observe for us. `dcutr::Behaviour` builds its punch-target list
from `NewExternalAddrCandidate` and nothing else, and libp2p-identify rewrites
an ephemeral-port connection's observed address to our *listen* port
(`_address_translation`) precisely because it knows the ephemeral one is
useless.

So on a NATed node every candidate was `<public-ip>:<listen-port>` — a port the
NAT has never mapped. Both peers knocked at a closed door.

b3cf962 introduced six `allocate_new_port()` calls while migrating off libp2p
0.53's global `port_reuse(true)`, on two beliefs that were both wrong:

- that binding a dial socket to the listen port fails `EADDRINUSE`. A probe
  mirroring libp2p-tcp's `create_socket` reproduces that only when the
  *listener* lacks `SO_REUSEPORT`, which `listen_on` always sets. The real
  collision is a duplicate 4-tuple, one step later at `connect`.
- that reuse breaks ordinary dialing, evidenced by
  `routing_peers_reach_the_storage`. That failed under 0.53's *global* flag,
  which forced reuse on AutoNAT dial-backs that collide on the 5-tuple by
  construction (upstream #3889). 0.54's per-connection policy plus libp2p-tcp's
  fresh-port fallback (#4568) is the fix for exactly that. It passes 5/5 with
  the defaults restored.

The upstream `examples/dcutr` sets no port policy at all. Neither do we now.

### 2. The circuit the punch replaced was never retired

Punches then succeeded and still left nothing behind. Nothing migrates traffic
onto a newly punched connection: libp2p opens each substream on whichever
connection it picks, and kad/identify keep flowing over the relay. The direct
path starves. Closing the circuit leaves one path, which carries the traffic
that keeps it alive.

### 3. Idle connections were reaped after 30s

`connection_timeout` drove only `with_idle_connection_timeout`, despite the
name. A punched connection carries no traffic of its own, so it died within a
minute — measured: punch at 18:23:40, gone by 18:24:30. The p2pd path had no
equivalent, since go-libp2p's connection manager keeps peers until its
high-water mark (~96), which is why hole punching looked like a regression from
the native port rather than a policy difference.

Renamed to `idle_connection_timeout` (serde alias keeps old configs working),
raised to 10 minutes.

### 4. `max_connections` was enforced nowhere

Which was survivable at a 30s idle timeout and is not at ten minutes: nothing
else bounds growth, and a bootstrap — which mostly receives connections — is
where that runs out of memory first. `libp2p::connection_limits` is now wired,
placed first in the behaviour so a refusal happens before anything else
allocates. Incoming is capped below the total so a node at its inbound cap can
still dial out rather than going deaf; there is deliberately no per-peer cap,
since DCUtR holds the relayed and punched connection at the same moment.

## Verification

Sealed nat-test topology, TCP only. Routers d/f/g are `SNAT --persistent`
(endpoint-independent); router-h is `MASQUERADE --random` (symmetric), which
cannot punch by design. Every cone-NAT pair should therefore end up direct and
only node-h fall back to relay. It does, with connections forming unprompted
and holding:

```
from/to   node-d    node-f    node-g    node-h
node-d    -         DIRECT    DIRECT    DIRECT
node-f    DIRECT    -         DIRECT    relay
node-g    DIRECT    DIRECT    -         relay
node-h    DIRECT    relay     relay     -
```

```
dcutr hole punch succeeded                    ConnectionId(15)
closing the relayed path the punch replaced   ConnectionId(13)
```
leaving one connection: `[direct] /ip4/198.18.0.32/tcp/8080`.

`tests/port_reuse.rs` pins the source-port precondition (loopback has no NAT,
but a dial's source port is visible to the peer as its send-back address);
verified failing before the change and passing after. `tests/dcutr.rs` now
asserts the upgraded connection is direct, is *reported* as punched, and that
its circuit is gone.

All three commits apply cleanly onto `main` on their own and pass the full
suite in isolation — but the value is cumulative, so they are best taken
together.

QUIC is deliberately not here. p2pd hole punched on this topology with TCP
alone, and so does this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
