### PR TITLE
feat(grpc): per-instance control surface — home-scoped socket, settable port

### DIFF
--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -167,7 +167,16 @@ A coordinator discovers the chain via DHT and orchestrates inference hop-by-hop.
 
     /// Internal: run the node in the foreground (used by daemon mode)
     #[command(hide = true)]
-    RunNode,
+    RunNode(RunNodeArgs),
+}
+
+/// `run-node` is spawned by `start --daemon`, so anything `start` accepts and
+/// the node needs has to be forwarded here explicitly.
+#[derive(Args, Debug)]
+pub struct RunNodeArgs {
+    /// TCP port for the gRPC control surface (0 = ephemeral)
+    #[arg(long)]
+    pub grpc_port: Option<u16>,
 }
 
 // ---------------------------------------------------------------------------
@@ -187,6 +196,11 @@ pub struct StartArgs {
     /// TCP port for P2P connections
     #[arg(long)]
     pub port: Option<u16>,
+
+    /// TCP port for the gRPC control surface (0 = ephemeral). Forwarded to
+    /// the daemon child; also settable via KWAAINET_GRPC_PORT.
+    #[arg(long)]
+    pub grpc_port: Option<u16>,
 
     /// Disable GPU acceleration (use CPU only)
     #[arg(long)]

--- a/core/crates/kwaai-cli/src/daemon.rs
+++ b/core/crates/kwaai-cli/src/daemon.rs
@@ -307,16 +307,31 @@ impl DaemonManager {
 /// process was terminated by SIGTERM (which bypasses Rust destructors, so
 /// the kwaai-p2p-daemon Drop impl never fires to clean them up).
 /// Without this, a new daemon start fails because p2pd can't bind the port.
+///
+/// Scoped to this instance's control socket when `KWAAINET_SOCKET` names one:
+/// p2pd carries it in `-listen`, and without the filter a second node's stop
+/// SIGKILLs the first node's p2pd. With no override there is only one socket
+/// on the machine, so every p2pd is ours and the name alone is enough.
 pub fn kill_orphaned_p2pd() {
     use sysinfo::ProcessRefreshKind;
 
     let mut sys = System::new();
     sys.refresh_processes_specifics(ProcessRefreshKind::new());
 
+    let socket = std::env::var("KWAAINET_SOCKET")
+        .ok()
+        .filter(|s| !s.is_empty());
+
     let mut found = false;
     for (pid, process) in sys.processes() {
         let name = process.name();
         if name == "p2pd" || name == "p2pd.exe" {
+            if let Some(ref sock) = socket {
+                if !process.cmd().iter().any(|a| a.contains(sock.as_str())) {
+                    debug!("Leaving p2pd PID {} alone — not on {}", pid, sock);
+                    continue;
+                }
+            }
             info!("Killing orphaned p2pd process (PID {})", pid);
             found = true;
             #[cfg(unix)]

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -56,13 +56,21 @@ use std::time::Instant;
 
 use crate::config::KwaaiNetConfig;
 
-/// Default TCP loopback port. Picked from the IANA dynamic range; not
-/// currently configurable but trivial to move into `KwaaiNetConfig` later.
+/// Default TCP loopback port, used when nothing asks for a specific one.
 pub const DEFAULT_GRPC_TCP_PORT: u16 = 8093;
 
-/// Relative path (under `~/.kwaainet/run/`) where we bind the Unix socket.
+/// Env var naming the TCP port to bind. Same name the GUI already uses on the
+/// client side, and the only way a port survives `start --daemon`, which
+/// re-execs `run-node` with no arguments but inherits the environment.
+pub const GRPC_PORT_ENV: &str = "KWAAINET_GRPC_PORT";
+
+/// Relative path (under the KwaaiNet dir) where we bind the Unix socket.
 #[cfg(unix)]
 const UNIX_SOCKET_RELPATH: &str = "run/kwaai.sock";
+
+/// File under `run/` recording the port we actually bound, so a supervisor
+/// that restarts (or a second GUI attaching to a live daemon) can find it.
+const GRPC_PORT_RELPATH: &str = "run/kwaainet.grpc";
 
 // ---------------------------------------------------------------------------
 // Service implementation
@@ -1898,31 +1906,66 @@ fn stream_via_llama_cpp(
 // Bind / serve
 // ---------------------------------------------------------------------------
 
-/// Resolve `~/.kwaainet/run/kwaai.sock`.
+/// Resolve `<kwaainet dir>/run/kwaai.sock`. `kwaainet_dir()` rather than
+/// `dirs::home_dir()`, so the socket follows `KWAAINET_HOME` like the rest of
+/// `run/` — two daemons sharing one path meant the second one's bind
+/// *unlinked* the first one's live socket.
 #[cfg(unix)]
 fn unix_socket_path() -> PathBuf {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    home.join(".kwaainet").join(UNIX_SOCKET_RELPATH)
+    crate::config::kwaainet_dir().join(UNIX_SOCKET_RELPATH)
+}
+
+/// Resolve `<kwaainet dir>/run/kwaainet.grpc`.
+pub fn grpc_port_file() -> PathBuf {
+    crate::config::kwaainet_dir().join(GRPC_PORT_RELPATH)
+}
+
+/// Resolve the TCP port: explicit request, then [`GRPC_PORT_ENV`], then the
+/// default. The flag says the port was *asked for* rather than defaulted,
+/// which is what makes a bind failure fatal instead of a warning.
+fn resolve_tcp_port(requested: Option<u16>) -> (u16, bool) {
+    if let Some(p) = requested {
+        return (p, true);
+    }
+    match std::env::var(GRPC_PORT_ENV)
+        .ok()
+        .and_then(|s| s.trim().parse::<u16>().ok())
+    {
+        Some(p) => (p, true),
+        None => (DEFAULT_GRPC_TCP_PORT, false),
+    }
 }
 
 /// Spawn the gRPC server task(s) and return a handle that, when dropped,
 /// signals graceful shutdown.
 ///
-/// On POSIX we bind both transports concurrently; on other platforms we bind
-/// TCP only. Either failure is logged but non-fatal: the daemon must keep
-/// running even if the IPC surface didn't come up (the node still serves
-/// p2p traffic).
-pub fn spawn(config: KwaaiNetConfig) -> GrpcServerHandle {
-    spawn_on_tcp_port(config, DEFAULT_GRPC_TCP_PORT)
+/// `requested_port` is the `--grpc-port` flag; absent, [`GRPC_PORT_ENV`] then
+/// [`DEFAULT_GRPC_TCP_PORT`] apply. Port 0 binds an ephemeral port and reports
+/// the real one in [`grpc_port_file`].
+pub fn spawn(config: KwaaiNetConfig, requested_port: Option<u16>) -> Result<GrpcServerHandle> {
+    let (tcp_port, explicit) = resolve_tcp_port(requested_port);
+    spawn_bound(config, tcp_port, explicit)
 }
 
-/// As [`spawn`], but binds TCP on an explicit port.
+/// Bind on an explicit port. Tests take an ephemeral one rather than the
+/// well-known port, which a running `kwaainet run-node` holds for the life of
+/// the machine — the listener they assert has closed would be the daemon's.
 ///
-/// Exists so tests can take an ephemeral port instead of the well-known one.
-/// Binding the real port made the lifecycle tests fail on any machine with a
-/// node already running — the listener they were asserting had closed was the
-/// daemon's, not theirs.
+/// Panics on a bind failure: a test that cannot have the port it picked has
+/// nothing left to assert.
+#[cfg(test)]
 pub(crate) fn spawn_on_tcp_port(config: KwaaiNetConfig, tcp_port: u16) -> GrpcServerHandle {
+    spawn_bound(config, tcp_port, true).expect("test gRPC server binds")
+}
+
+/// As [`spawn`], but with the port already resolved.
+///
+/// `explicit` decides what a failed TCP bind means. Defaulting to the
+/// well-known port and losing it is survivable — the node still serves p2p, and
+/// that leniency predates this argument. But when a supervisor *asked* for a
+/// port, coming up without it strands it: a live pid, a written status file,
+/// and nothing listening. That case exits instead, so the caller can retry.
+fn spawn_bound(config: KwaaiNetConfig, tcp_port: u16, explicit: bool) -> Result<GrpcServerHandle> {
     let (shutdown_tcp_tx, shutdown_tcp_rx) = oneshot::channel::<()>();
     #[cfg(unix)]
     let (shutdown_unix_tx, shutdown_unix_rx) = oneshot::channel::<()>();
@@ -1931,22 +1974,49 @@ pub(crate) fn spawn_on_tcp_port(config: KwaaiNetConfig, tcp_port: u16) -> GrpcSe
     let net_slot = svc_state.net.clone();
     let service = KwaaiNetServer::new(svc_state);
 
-    // TCP: every platform.
-    let tcp_addr: std::net::SocketAddr = format!("127.0.0.1:{tcp_port}")
-        .parse()
-        .expect("valid loopback addr");
-    let tcp_service = service.clone();
-    tokio::spawn(async move {
-        info!("gRPC: binding TCP at {tcp_addr}");
-        let serve = Server::builder()
-            .add_service(tcp_service)
-            .serve_with_shutdown(tcp_addr, async {
-                let _ = shutdown_tcp_rx.await;
-            });
-        if let Err(e) = serve.await {
-            warn!("gRPC TCP server exited with error: {e}");
+    // Bind up front rather than inside the serve task: a clash has to be
+    // visible here, and it is what resolves port 0 to a real number.
+    let listener = match std::net::TcpListener::bind(("127.0.0.1", tcp_port)) {
+        Ok(l) => Some(l),
+        Err(e) if explicit => {
+            return Err(anyhow::anyhow!("binding gRPC TCP port {tcp_port}: {e}"));
         }
-    });
+        Err(e) => {
+            warn!("gRPC: could not bind TCP port {tcp_port} ({e}) — TCP disabled");
+            None
+        }
+    };
+
+    let mut bound_port = None;
+    let mut shutdown_tcp = None;
+    if let Some(listener) = listener {
+        let addr = listener.local_addr().context("gRPC TCP local_addr")?;
+        listener
+            .set_nonblocking(true)
+            .context("gRPC TCP set_nonblocking")?;
+        let listener =
+            tokio::net::TcpListener::from_std(listener).context("adopting gRPC TCP listener")?;
+        bound_port = Some(addr.port());
+        shutdown_tcp = Some(shutdown_tcp_tx);
+
+        let tcp_service = service.clone();
+        tokio::spawn(async move {
+            info!("gRPC: binding TCP at {addr}");
+            let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+            let serve = Server::builder()
+                .add_service(tcp_service)
+                .serve_with_incoming_shutdown(incoming, async {
+                    let _ = shutdown_tcp_rx.await;
+                });
+            if let Err(e) = serve.await {
+                warn!("gRPC TCP server exited with error: {e}");
+            }
+        });
+    }
+
+    // Written only once the listener exists, so the file's presence means
+    // "connectable" — the backlog holds dials until tonic starts accepting.
+    let port_file = bound_port.and_then(|p| write_port_file(p).ok());
 
     // Unix socket: POSIX only.
     #[cfg(unix)]
@@ -1958,21 +2028,36 @@ pub(crate) fn spawn_on_tcp_port(config: KwaaiNetConfig, tcp_port: u16) -> GrpcSe
                 warn!("gRPC Unix server exited with error: {e}");
             }
         });
-        GrpcServerHandle {
-            shutdown_tcp: Some(shutdown_tcp_tx),
+        Ok(GrpcServerHandle {
+            shutdown_tcp,
             #[cfg(unix)]
             shutdown_unix: Some(shutdown_unix_tx),
             net: net_slot,
-        }
+            port_file,
+        })
     }
     #[cfg(not(unix))]
     {
         drop(service); // suppress unused warning on non-unix
-        GrpcServerHandle {
-            shutdown_tcp: Some(shutdown_tcp_tx),
+        Ok(GrpcServerHandle {
+            shutdown_tcp,
             net: net_slot,
-        }
+            port_file,
+        })
     }
+}
+
+/// Record the bound port under `run/`, returning the path so shutdown can
+/// clear it. Best-effort: a daemon that cannot write here still serves.
+fn write_port_file(port: u16) -> Result<PathBuf> {
+    let path = grpc_port_file();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    std::fs::write(&path, format!("{port}\n"))
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(path)
 }
 
 #[cfg(unix)]
@@ -2026,6 +2111,8 @@ pub struct GrpcServerHandle {
     /// The service's swarm-handle slot, shared so the node can fill it once
     /// p2p is up. See [`GrpcServerHandle::attach_network`].
     net: Arc<RwLock<Option<NetworkHandle>>>,
+    /// `run/kwaainet.grpc`, when we managed to write it. Removed on shutdown.
+    port_file: Option<PathBuf>,
 }
 
 impl GrpcServerHandle {
@@ -2042,6 +2129,9 @@ impl GrpcServerHandle {
     /// Trigger a graceful shutdown of both transports. Safe to call multiple
     /// times; subsequent calls are no-ops.
     pub fn shutdown(&mut self) {
+        if let Some(path) = self.port_file.take() {
+            let _ = std::fs::remove_file(path);
+        }
         if let Some(tx) = self.shutdown_tcp.take() {
             let _ = tx.send(());
         }
@@ -2139,6 +2229,99 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
+    }
+
+    /// `KWAAINET_HOME` must move the gRPC endpoint files, not just
+    /// pid/lock/status. When it did not, a second daemon's bind unlinked the
+    /// first one's socket.
+    #[test]
+    fn run_artifacts_follow_kwaainet_home() {
+        let _serial = TEST_LOCK.blocking_lock();
+        let tmp = tempfile::tempdir().expect("create tempdir for fake HOME");
+        let _env = EnvGuard::set(tmp.path());
+
+        // The socket is POSIX-only; the port file is how Windows finds the
+        // daemon, so that half of the assertion has to run everywhere.
+        #[cfg(unix)]
+        assert_eq!(unix_socket_path(), tmp.path().join(UNIX_SOCKET_RELPATH));
+        assert_eq!(grpc_port_file(), tmp.path().join(GRPC_PORT_RELPATH));
+    }
+
+    /// Precedence: explicit flag, then the env var, then the default. The
+    /// bool is what makes a failed bind fatal, so it is asserted too.
+    #[test]
+    fn tcp_port_resolves_flag_then_env_then_default() {
+        let _serial = TEST_LOCK.blocking_lock();
+        let prev = std::env::var_os(GRPC_PORT_ENV);
+        let restore = || match prev.clone() {
+            Some(v) => std::env::set_var(GRPC_PORT_ENV, v),
+            None => std::env::remove_var(GRPC_PORT_ENV),
+        };
+
+        std::env::remove_var(GRPC_PORT_ENV);
+        assert_eq!(resolve_tcp_port(None), (DEFAULT_GRPC_TCP_PORT, false));
+        assert_eq!(resolve_tcp_port(Some(9101)), (9101, true));
+
+        std::env::set_var(GRPC_PORT_ENV, "9102");
+        assert_eq!(resolve_tcp_port(None), (9102, true));
+        // A flag still outranks the env var.
+        assert_eq!(resolve_tcp_port(Some(9103)), (9103, true));
+
+        // Garbage falls back to the default rather than failing to start.
+        std::env::set_var(GRPC_PORT_ENV, "not-a-port");
+        assert_eq!(resolve_tcp_port(None), (DEFAULT_GRPC_TCP_PORT, false));
+
+        restore();
+    }
+
+    /// A port we asked for and could not get must abort, so the supervisor
+    /// can retry — the old behaviour left a live pid with nothing listening.
+    /// The same clash on the *default* port stays survivable.
+    #[tokio::test]
+    async fn explicit_port_clash_is_fatal_and_default_clash_is_not() {
+        let _serial = TEST_LOCK.lock().await;
+        let tmp = tempfile::tempdir().expect("create tempdir for fake HOME");
+        let _env = EnvGuard::set(tmp.path());
+
+        let squatter = std::net::TcpListener::bind("127.0.0.1:0").expect("bind squatter");
+        let taken = squatter.local_addr().expect("squatter addr").port();
+
+        assert!(
+            spawn_bound(KwaaiNetConfig::default(), taken, true).is_err(),
+            "explicit port clash must abort"
+        );
+
+        let lenient = spawn_bound(KwaaiNetConfig::default(), taken, false)
+            .expect("default-port clash must still come up");
+        // No listener means no port file to mislead a client into dialling.
+        assert!(!grpc_port_file().exists());
+        drop(lenient);
+    }
+
+    /// The port file is the contract that lets a restarted GUI find a live
+    /// daemon: written once bound, gone once shut down.
+    #[tokio::test]
+    async fn port_file_records_the_bound_port_and_clears_on_shutdown() {
+        let _serial = TEST_LOCK.lock().await;
+        let tmp = tempfile::tempdir().expect("create tempdir for fake HOME");
+        let _env = EnvGuard::set(tmp.path());
+
+        // Port 0 exercises the ephemeral path the GUI's retry falls back on.
+        let handle = spawn_bound(KwaaiNetConfig::default(), 0, true).expect("ephemeral bind");
+
+        let recorded = std::fs::read_to_string(grpc_port_file()).expect("port file written");
+        let port: u16 = recorded.trim().parse().expect("port file holds a number");
+        assert_ne!(
+            port, 0,
+            "the resolved port must be reported, not the request"
+        );
+        assert!(
+            std::net::TcpStream::connect(("127.0.0.1", port)).is_ok(),
+            "the recorded port must actually be listening"
+        );
+
+        drop(handle);
+        assert!(!grpc_port_file().exists(), "port file removed on shutdown");
     }
 
     /// Ask the OS for a free loopback port.

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -2129,8 +2129,16 @@ impl GrpcServerHandle {
     /// Trigger a graceful shutdown of both transports. Safe to call multiple
     /// times; subsequent calls are no-ops.
     pub fn shutdown(&mut self) {
+        // Both files mean "the listener is up", so both have to go. The serve
+        // tasks clean up after themselves too, but a SIGTERM'd process exits
+        // before they observe the signal — and a stale socket file makes a
+        // client's exists() check say yes to a daemon that has gone.
         if let Some(path) = self.port_file.take() {
             let _ = std::fs::remove_file(path);
+        }
+        #[cfg(unix)]
+        {
+            let _ = std::fs::remove_file(unix_socket_path());
         }
         if let Some(tx) = self.shutdown_tcp.take() {
             let _ = tx.send(());

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<()> {
     // Spawn a background update check that runs concurrently with the command.
     // Uses a 24-hour on-disk cache so it only hits the network once per day.
     // Skipped for `update` (redundant) and `run-node` (internal daemon process).
-    let skip_update_hint = matches!(cli.command, Command::Update(_) | Command::RunNode);
+    let skip_update_hint = matches!(cli.command, Command::Update(_) | Command::RunNode(_));
     let update_task = (!skip_update_hint)
         .then(|| tokio::spawn(async { updater::UpdateChecker::new().check(false).await }));
 
@@ -130,9 +130,9 @@ async fn main() -> Result<()> {
         // -------------------------------------------------------------------
         // Internal: run the native node (used in daemon mode)
         // -------------------------------------------------------------------
-        Command::RunNode => {
+        Command::RunNode(args) => {
             let cfg = KwaaiNetConfig::load_or_create()?;
-            node::run_node(&cfg).await?;
+            node::run_node(&cfg, args.grpc_port).await?;
         }
 
         // -------------------------------------------------------------------
@@ -298,7 +298,13 @@ async fn main() -> Result<()> {
             print_separator();
 
             if args.daemon {
-                let child_pid = DaemonManager::spawn_daemon_child(&[])?;
+                // The child re-execs as `run-node`, so anything the node needs
+                // has to be forwarded — it inherits the environment, not argv.
+                let child_args: Vec<String> = args
+                    .grpc_port
+                    .map(|p| vec!["--grpc-port".to_string(), p.to_string()])
+                    .unwrap_or_default();
+                let child_pid = DaemonManager::spawn_daemon_child(&child_args)?;
                 println!();
                 print_success(&format!("KwaaiNet daemon started (PID {})", child_pid));
 
@@ -379,7 +385,7 @@ async fn main() -> Result<()> {
                 print_separator();
             } else {
                 // Foreground – run until Ctrl-C
-                node::run_node(&cfg).await?;
+                node::run_node(&cfg, args.grpc_port).await?;
             }
         }
 

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -41,7 +41,7 @@ use crate::announce::{dht_id, DHTServerInfo, ModelInfo, VpkInfo};
 // Public entry point
 // ---------------------------------------------------------------------------
 
-pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
+pub async fn run_node(config: &KwaaiNetConfig, grpc_port: Option<u16>) -> Result<()> {
     // Register the SIGHUP handler BEFORE writing the PID file — see
     // [`SigHup::register`] for why the ordering is load-bearing.
     let mut sighup = SigHup::register();
@@ -63,13 +63,15 @@ pub async fn run_node(config: &KwaaiNetConfig) -> Result<()> {
     // Ops that depend on p2p state (shard_run, distributed status)
     // will simply return UNAVAILABLE / NO_PEERS_FOR_MODEL until the
     // node is fully up; ops that don't (ping, status, generate) work
-    // straight away. Failure here is non-fatal: the p2p node must
-    // keep running even if the IPC surface didn't come up. The
-    // handle's Drop signals graceful shutdown when run_node returns.
+    // straight away. Failure on the default port is non-fatal: the p2p
+    // node must keep running even if the IPC surface didn't come up. An
+    // explicitly requested port that cannot bind does abort — see
+    // `spawn_on_tcp_port`. The handle's Drop signals graceful shutdown
+    // when run_node returns.
     //
     // The native path also hands it the swarm once that exists, which is what
     // lets the Network op serve; see `attach_network`.
-    let grpc_handle = crate::grpc_server::spawn(config.clone());
+    let grpc_handle = crate::grpc_server::spawn(config.clone(), grpc_port)?;
 
     // -----------------------------------------------------------------------
     // Persistent identity — load or generate the keypair so the PeerId is


### PR DESCRIPTION
## Why

Two KwaaiNetGUI instances on one machine cannot coexist. Every daemon-identity
artifact is machine-global, so the second GUI to start attaches to the first
one's daemon, and a quit from either kills the other's node:

| Artifact | Where | Problem |
|---|---|---|
| gRPC Unix socket | `~/.kwaainet/run/kwaai.sock` via `dirs::home_dir()` | ignores `KWAAINET_HOME`, unlike pid/lock/status |
| gRPC TCP port | hardcoded `127.0.0.1:8093` | no flag, no env, no config key |
| p2pd children | — | `kill_orphaned_p2pd()` SIGKILLs *every* `p2pd` on the machine |

The GUI-side changes are separate; this is the daemon half, and it is useful on
its own to anyone running two nodes under different `KWAAINET_HOME`s.

## What

**The Unix socket follows `KWAAINET_HOME`.** `unix_socket_path()` now resolves
through `config::kwaainet_dir()` rather than `dirs::home_dir()`. This is the
highest-value line in the change: `serve_unix` unlinks any existing socket
before binding (`grpc_server.rs`, "stale socket blocks bind() with EADDRINUSE"),
so two daemons on one path meant **the second one deleted the first one's live
socket**.

**The TCP port is settable.** `--grpc-port` on `start` / `run-node`, else
`KWAAINET_GRPC_PORT`, else the existing `DEFAULT_GRPC_TCP_PORT` (8093).
The env layer is what a supervisor can actually rely on, because
`start --daemon` re-execs `run-node` with no argv (`spawn_daemon_child(&[])`)
but does inherit the environment; the flag is forwarded explicitly so the CLI
form works too. This also fixes a latent bug — `start --daemon --port N`
silently dropped `N` for the same reason. Port 0 binds an ephemeral port.

**Bind failure is fatal only when the port was requested.** The listener is now
bound up front instead of inside the detached serve task, so a clash surfaces
immediately and port 0 resolves to a real number. Defaulting to the well-known
port and losing it stays survivable — the node still serves p2p, and that
leniency predates this change. But a port a supervisor *asked* for and did not
get used to leave a live pid, a written status file, and nothing listening;
that case now exits so the caller can retry.

**The bound port is reported** in `run/kwaainet.grpc`, written once the listener
exists and removed on shutdown — so a supervisor that restarts can find a daemon
it did not spawn. The socket file is removed there too: `serve_unix` cleans up
after itself, but a SIGTERM'd process exits before that task observes the
signal, and a stale socket makes a client's `exists()` check say yes to a daemon
that has gone.

**`kill_orphaned_p2pd()` is scoped** to this instance's `KWAAINET_SOCKET`, which
p2pd carries in `-listen`. With no override there is only one socket on the
machine, so every p2pd is ours and the name-only match is unchanged.

## Compatibility

Nothing changes for a single default-configured daemon: same port, same socket
path, same leniency on a default-port clash. `KWAAINET_HOME` users get a socket
that matches where the rest of their `run/` already lives.

## Tests

Four new tests in `grpc_server.rs`, using the existing `EnvGuard` / `TEST_LOCK`
helpers: the socket and port file follow `KWAAINET_HOME`; flag-then-env-then-
default precedence; an explicit-port clash errors while a default-port clash
does not; and the port file records the resolved port (via port 0) and clears on
shutdown. `cargo test -p kwaainet` — 211 pass; clippy and fmt clean.

Verified end to end on macOS: two daemons under separate `KWAAINET_HOME`s, each
with its own pid, socket and gRPC port, and stopping one leaves the other
running. `~/.kwaainet/run/` untouched throughout.
