### PR TITLE
feat(config): make max_connections settable, so a bootstrap can be sized

### DIFF
--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -287,7 +287,7 @@ pub enum ConfigAction {
     /// Valid keys:
     ///   model, blocks, start_block, port, use_gpu, log_level,
     ///   public_name, public_ip, announce_addr, no_relay, native_p2p,
-    ///   announce_self, enable_upnp,
+    ///   announce_self, enable_upnp, max_connections,
     ///   decentralized_dht, dht_replication,
     ///   vpk_enabled, vpk_mode, vpk_local_port,
     ///   auto_rebalance, rebalance_interval_secs, rebalance_min_redundancy

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -228,6 +228,21 @@ pub struct KwaaiNetConfig {
     #[serde(default = "default_enable_upnp")]
     pub enable_upnp: bool,
 
+    /// Ceiling on simultaneously established connections, inbound and
+    /// outbound, enforced by the swarm's connection-limits behaviour.
+    ///
+    /// Inbound is capped below this total so the node can always dial out;
+    /// see `kwaai_p2p::behaviour` for the split. It bounds memory growth
+    /// because idle connections are now held for ten minutes rather than
+    /// thirty seconds, so nothing else does.
+    ///
+    /// The default suits a participating node. A bootstrap, which mostly
+    /// receives connections rather than making them, wants several hundred to
+    /// low thousands — sized against the memory the host can spare, roughly
+    /// a megabyte per connection once buffers and per-peer state are counted.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: usize,
+
     /// Whether this node publishes DHT records *of its own* — its block range,
     /// `_petals.models`, `_kwaai.inference.nodes` and the VPK registry entry —
     /// and, symmetrically, the `state = -1` tombstone on shutdown.
@@ -761,6 +776,12 @@ fn default_trusted_relays() -> Vec<String> {
 fn default_force_private() -> bool {
     true
 }
+/// Matches `kwaai_p2p::NetworkConfig::default()`, so making the knob
+/// settable changes no node that does not set it.
+fn default_max_connections() -> usize {
+    100
+}
+
 fn default_enable_upnp() -> bool {
     true
 }
@@ -848,6 +869,7 @@ impl Default for KwaaiNetConfig {
             force_private: default_force_private(),
             native_p2p: None,
             enable_upnp: default_enable_upnp(),
+            max_connections: default_max_connections(),
             announce_self: true,
             decentralized_dht: false,
             dht_replication: default_dht_replication(),
@@ -1154,6 +1176,17 @@ impl KwaaiNetConfig {
             "native_p2p" => self.native_p2p = Some(parse_bool(value)?),
             "announce_self" => self.announce_self = parse_bool(value)?,
             "enable_upnp" => self.enable_upnp = parse_bool(value)?,
+            "max_connections" => {
+                let n: usize = value
+                    .parse()
+                    .map_err(|_| anyhow::anyhow!("max_connections must be a positive integer"))?;
+                // Below the bootstraps plus a relay reservation the node cannot
+                // hold the connections it needs to stay reachable.
+                if n < 8 {
+                    anyhow::bail!("max_connections must be at least 8");
+                }
+                self.max_connections = n;
+            }
             "decentralized_dht" => self.decentralized_dht = parse_bool(value)?,
             "dht_replication" => {
                 let k: usize = value
@@ -1479,6 +1512,10 @@ mod tests {
             "a config written before announce_self existed must keep announcing"
         );
         assert!(c.enable_upnp, "likewise for enable_upnp");
+        assert_eq!(
+            c.max_connections, 100,
+            "and max_connections must match the swarm default it mirrors"
+        );
     }
 
     /// `config set` round-trips each key through YAML, which is how an operator
@@ -1504,6 +1541,28 @@ mod tests {
         let yaml = serde_yaml::to_string(&c).expect("serialise");
         let reloaded: KwaaiNetConfig = serde_yaml::from_str(&yaml).expect("reload");
         assert!(reloaded.announce_self);
+    }
+
+    /// An operator raising the ceiling on a bootstrap must survive the YAML
+    /// round-trip, and a value too small to hold the bootstraps plus a relay
+    /// reservation must be refused rather than silently stranding the node.
+    #[test]
+    fn max_connections_round_trips_and_rejects_a_crippling_value() {
+        let mut c = KwaaiNetConfig::default();
+        c.set_key("max_connections", "1024")
+            .expect("max_connections is a valid key");
+
+        let yaml = serde_yaml::to_string(&c).expect("serialise");
+        let reloaded: KwaaiNetConfig = serde_yaml::from_str(&yaml).expect("reload");
+        assert_eq!(reloaded.max_connections, 1024);
+
+        let mut c = reloaded;
+        assert!(c.set_key("max_connections", "0").is_err());
+        assert!(c.set_key("max_connections", "lots").is_err());
+        assert_eq!(
+            c.max_connections, 1024,
+            "a rejected set must not have changed the field"
+        );
     }
 
     /// A non-boolean value is rejected rather than coerced, so a typo'd

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -171,6 +171,10 @@ impl NativeNode {
             // rust-libp2p 0.53, and turning it on would classify the docker
             // nat-test topology's `198.18/15` addresses unreachable.
             require_global_ips: false,
+
+            // The only bound on connection growth, and so on the memory the
+            // swarm holds: idle connections live for ten minutes.
+            max_connections: config.max_connections,
             ..NetworkConfig::default()
         };
 

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -36,6 +36,7 @@ Without these, the process is an ordinary node, not a bootstrap.
 | `announce_addr` | the reachable multiaddr | *(none)* | What identify reports to peers — the `ANNOUNCE_MADDRS` analogue. Declared, so it outranks AutoNAT and is confirmed at t=0 rather than after a probe round. Without it the node advertises only its container-internal address. |
 | `port` | `8000` | `31337` | The listen port. The address built is `/ip4/0.0.0.0/tcp/<port>`. |
 | `no_relay` | `false` | `false` | Keep the circuit relay hop service **on**: NATed nodes reserve circuits through the bootstraps. Set `true` only to deliberately withhold relay. |
+| `max_connections` | sized to the host | `100` | The ceiling on established connections, and the only bound on how far the swarm's memory grows — idle connections are held for ten minutes. 100 suits a node that mostly dials out; a bootstrap mostly receives, and wants several hundred to low thousands. Budget roughly a megabyte per connection. Inbound is capped at 4/5 of this so the node can always still dial. |
 
 ### Independent keys worth setting
 
@@ -72,6 +73,7 @@ initial_peers: []
 announce_addr: /dns4/bootstrap1/tcp/8000
 port: 8000
 no_relay: false
+max_connections: 1024
 vpk_enabled: false
 ollama_manage: false
 health_monitoring:


### PR DESCRIPTION
## What

`max_connections` reaches the swarm only through its default. `node_native` builds `NetworkConfig` field by field and ends `..NetworkConfig::default()`, and `KwaaiNetConfig` had no such key — so every native node, bootstrap included, runs with **100** and no way to say otherwise.

100 suits a node that mostly dials out. A bootstrap mostly *receives*, and this is now the only thing bounding how far the swarm's memory grows: idle connections are held for ten minutes rather than thirty seconds.

## Changes

- `max_connections` on `KwaaiNetConfig`, defaulted to 100 — the same value `NetworkConfig::default()` already used, so no node that does not set the key behaves differently.
- Plumbed through `node_native::start`.
- `config set max_connections <n>`, refusing anything below 8: under that the node cannot hold the bootstraps plus a relay reservation, and would strand itself rather than merely run lean.
- `docs/BOOTSTRAP.md` gains the knob, with sizing guidance.

## Relationship to #154

Enforcement of the ceiling — the `connection_limits` behaviour — is #154. Until that lands this sets a field the swarm reads but does not yet act on. The two are independent: this PR is the operator surface, #154 is the mechanism.

## Tests

`max_connections_round_trips_and_rejects_a_crippling_value` — YAML round-trip at 1024, and `0` / a non-numeric value refused without changing the field. Existing legacy-config test extended to assert the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)