### PR TITLE
feat(config): address the bootstraps by /dnsaddr

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -747,11 +747,34 @@ fn default_log_level() -> String {
 }
 fn default_peers() -> Vec<String> {
     vec![
-        "/dns/bootstrap-1.kwaai.ai/tcp/8000/p2p/QmQhRuheeCLEsVD3RsnknM75gPDDqxAb8DhnWgro7KhaJc"
+        "/dnsaddr/bootstrap.kwaai.ai/p2p/QmQhRuheeCLEsVD3RsnknM75gPDDqxAb8DhnWgro7KhaJc"
             .to_string(),
-        "/dns/bootstrap-2.kwaai.ai/tcp/8000/p2p/Qmd3A8N5aQBATe2SYvNikaeCS9CAKN4E86jdCPacZ6RZJY"
+        "/dnsaddr/bootstrap.kwaai.ai/p2p/Qmd3A8N5aQBATe2SYvNikaeCS9CAKN4E86jdCPacZ6RZJY"
             .to_string(),
     ]
+}
+
+/// Bootstrap lists shipped by earlier releases, superseded by [`default_peers`].
+const LEGACY_DEFAULT_PEERS: &[&[&str]] = &[&[
+    "/dns/bootstrap-1.kwaai.ai/tcp/8000/p2p/QmQhRuheeCLEsVD3RsnknM75gPDDqxAb8DhnWgro7KhaJc",
+    "/dns/bootstrap-2.kwaai.ai/tcp/8000/p2p/Qmd3A8N5aQBATe2SYvNikaeCS9CAKN4E86jdCPacZ6RZJY",
+]];
+
+/// Rewrite an untouched shipped bootstrap list to the current default.
+///
+/// `initial_peers` is written to every config.yaml, so a new `default_peers`
+/// alone would never reach an existing install. Only an exact match is
+/// rewritten: an operator's own peers — a sealed test bed's `198.18.0.x` among
+/// them — must survive verbatim.
+fn migrate_default_peers(peers: &mut Vec<String>) -> bool {
+    let is_shipped_default = LEGACY_DEFAULT_PEERS.iter().any(|legacy| {
+        legacy.len() == peers.len() && legacy.iter().all(|a| peers.iter().any(|p| p == a))
+    });
+    if !is_shipped_default {
+        return false;
+    }
+    *peers = default_peers();
+    true
 }
 /// No trusted relays by default — candidates come from identify hop discovery;
 /// see the `trusted_relays` field.
@@ -993,6 +1016,10 @@ impl KwaaiNetConfig {
             if cfg.model.contains('/') {
                 cfg.model_dht_prefix = None;
                 cfg.model_repository = None;
+            }
+            if migrate_default_peers(&mut cfg.initial_peers) {
+                info!("initial_peers migrated to the /dnsaddr bootstrap list");
+                let _ = cfg.save();
             }
             debug!("Loaded config from {}", cfg_file.display());
             Ok(cfg)
@@ -1811,5 +1838,82 @@ mod shard_flag_is_an_opt_in {
         let p = policy(Some(false), false);
         assert!(!p.shards);
         assert!(p.serve_shards(true, false));
+    }
+}
+
+#[cfg(test)]
+mod dnsaddr_bootstrap {
+    use super::*;
+
+    fn v(addrs: &[&str]) -> Vec<String> {
+        addrs.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Every default is `/dnsaddr/<host>/p2p/<id>` and nothing between the two:
+    /// a `/tcp/8000` here would filter out any TXT record that later moves port
+    /// or transport, which is the whole point of publishing them in DNS.
+    #[test]
+    fn the_defaults_pin_identity_and_nothing_else() {
+        for addr in default_peers() {
+            let rest = addr
+                .strip_prefix("/dnsaddr/bootstrap.kwaai.ai")
+                .unwrap_or_else(|| panic!("not a bootstrap dnsaddr: {addr}"));
+            assert!(rest.starts_with("/p2p/"), "extra components in {addr}");
+            assert_eq!(rest.matches('/').count(), 2, "extra components in {addr}");
+        }
+    }
+
+    #[test]
+    fn a_shipped_dns_list_is_rewritten() {
+        let mut peers = v(LEGACY_DEFAULT_PEERS[0]);
+        assert!(migrate_default_peers(&mut peers));
+        assert_eq!(peers, default_peers());
+    }
+
+    /// Order is not part of the match — a config someone reordered by hand is
+    /// still the shipped list.
+    #[test]
+    fn order_does_not_defeat_the_match() {
+        let mut peers = v(LEGACY_DEFAULT_PEERS[0]);
+        peers.reverse();
+        assert!(migrate_default_peers(&mut peers));
+        assert_eq!(peers, default_peers());
+    }
+
+    #[test]
+    fn the_current_default_is_left_alone() {
+        let mut peers = default_peers();
+        assert!(!migrate_default_peers(&mut peers));
+        assert_eq!(peers, default_peers());
+    }
+
+    /// The one that matters: rewriting a test bed's peers would point sealed
+    /// nodes at production.
+    #[test]
+    fn a_test_bed_list_survives_verbatim() {
+        let sealed = v(&[
+            "/ip4/198.18.0.10/tcp/8000/p2p/QmQhRuheeCLEsVD3RsnknM75gPDDqxAb8DhnWgro7KhaJc",
+            "/ip4/198.18.0.11/tcp/8000/p2p/Qmd3A8N5aQBATe2SYvNikaeCS9CAKN4E86jdCPacZ6RZJY",
+        ]);
+        let mut peers = sealed.clone();
+        assert!(!migrate_default_peers(&mut peers));
+        assert_eq!(peers, sealed);
+    }
+
+    /// A partly-edited list is the operator's, not ours.
+    #[test]
+    fn one_changed_entry_blocks_the_rewrite() {
+        let mut peers = v(LEGACY_DEFAULT_PEERS[0]);
+        peers[1] = "/dns/bootstrap-9.example.com/tcp/8000/p2p/QmSomethingElse".to_string();
+        let before = peers.clone();
+        assert!(!migrate_default_peers(&mut peers));
+        assert_eq!(peers, before);
+    }
+
+    #[test]
+    fn an_empty_list_is_never_treated_as_the_default() {
+        let mut peers: Vec<String> = Vec::new();
+        assert!(!migrate_default_peers(&mut peers));
+        assert!(peers.is_empty());
     }
 }

--- a/core/crates/kwaai-p2p/src/config.rs
+++ b/core/crates/kwaai-p2p/src/config.rs
@@ -22,13 +22,15 @@ pub const PETALS_BOOTSTRAP_SERVERS: &[&str] = &[
     //"/ip4/127.0.0.1/tcp/8000/p2p/QmXwErKD4k7aLzgDWGuNj5yjEtiMuicGp72juNB3Yyqtt9"
 ];
 
-/// KwaaiNet bootstrap servers addressed by DNS name rather than by a pinned IP.
+/// KwaaiNet bootstrap servers addressed by `/dnsaddr/`.
 ///
-/// Prefer these for the native swarm: the transport is built `.with_dns()`, and
-/// a DNS name survives the bootstrap hosts being re-addressed.
+/// TXT records at `_dnsaddr.bootstrap.kwaai.ai` name each bootstrap's current
+/// transport, so re-addressing a host is a DNS edit rather than a release. The
+/// `/p2p/<id>` suffix pins the identity and selects that peer's record; adding
+/// a port or transport here would filter out any record that later differs.
 pub const KWAAI_BOOTSTRAP_SERVERS_DNS: &[&str] = &[
-    "/dns/bootstrap-1.kwaai.ai/tcp/8000/p2p/QmQhRuheeCLEsVD3RsnknM75gPDDqxAb8DhnWgro7KhaJc",
-    "/dns/bootstrap-2.kwaai.ai/tcp/8000/p2p/Qmd3A8N5aQBATe2SYvNikaeCS9CAKN4E86jdCPacZ6RZJY",
+    "/dnsaddr/bootstrap.kwaai.ai/p2p/QmQhRuheeCLEsVD3RsnknM75gPDDqxAb8DhnWgro7KhaJc",
+    "/dnsaddr/bootstrap.kwaai.ai/p2p/Qmd3A8N5aQBATe2SYvNikaeCS9CAKN4E86jdCPacZ6RZJY",
 ];
 
 /// Configuration for the P2P network


### PR DESCRIPTION
## What

Bootstrap peers are now addressed by `/dnsaddr/bootstrap.kwaai.ai/p2p/<id>` instead of `/dns/bootstrap-N.kwaai.ai/tcp/8000/p2p/<id>`, resolved from TXT records at `_dnsaddr.bootstrap.kwaai.ai`.

## Why

The bootstrap list was compiled into the binary, so changing a host, port or transport meant shipping a release. It now takes a DNS edit. The peer ID stays in the address, so DNS can *move* a bootstrap but not substitute one — the noise handshake still verifies the identity we committed to.

This matters immediately for the upcoming migration of the bootstrap hosts to the native stack: if the new hosts reuse the existing identity keys, the cutover is a TXT record change with no client release, and rollback is deleting one record.

## Nothing between `/dnsaddr/` and `/p2p/`

Deliberate. Everything after the dnsaddr component is a suffix filter on the resolved TXT records (`a.ends_with(&suffix)` in `libp2p-dns`), so a `/tcp/8000` in the address would silently drop any record that later moves port or adds a transport — the exact flexibility this change buys. This is also the form kubo ships in `boxo/autoconf`'s `FallbackBootstrapPeers`.

## Existing installs

`initial_peers` is serialized into every `config.yaml`, so a new `default_peers()` alone would never reach anyone who has already run the node. `migrate_default_peers` rewrites the list on load, and **only** when it still matches a shipped default exactly (as a set, so hand-reordering doesn't defeat it).

A customised list is never touched. That is the point of the exact match rather than a pattern:

- a sealed test bed's `198.18.0.x` peers survive verbatim — rewriting those would aim sealed nodes at production
- an empty list keeps its own meaning for `announce_self: false` nodes
- a partly-edited list is the operator's, not ours

## Why no other code changed

- the native swarm already builds `.with_dns()`, and `libp2p-dns` resolves `Dnsaddr` including the recursive TXT lookups
- `dial()` stores the entry stripped of `/p2p`, and kad re-attaches it via `with_p2p` when dialing, restoring the suffix filter
- on the p2pd path, go-libp2p passes the expected peer ID into `ResolveDNSAddr`, so the filter applies there too even though `AddrInfoFromP2pAddr` split the `/p2p` off
- the `/p2p`-splitting in `announce.rs`, `node.rs` and `placement.rs` keeps working because every entry still carries one
- `/dnsaddr` is no more announceable than `/dns` was (`addresses.rs` already asserts this), so address classification and relay selection are unaffected

## Testing

`cargo test -p kwaainet --bin kwaainet` (214 passed) and `cargo test -p kwaai-p2p --lib` (96 passed); clippy and fmt clean. Seven new tests cover the migration, including the test-bed and empty-list cases.

Verified end to end against the live TXT records before opening this.

## Follow-ups, not in this PR

- consider keeping a concrete `/ip4/` entry as a DNS-independent fallback, as kubo does — `KWAAI_BOOTSTRAP_SERVERS` is the natural home
- there is no `/dnsaddr` coverage in the live test suite; the sealed nat-test bed can't provide it (no outbound DNS, and the seal greps rendered configs for `kwaai.ai`), so it would need to sit alongside `live_dht_announce.rs`