### PR TITLE
feat(grpc): report bootstrap reachability on StatusReply and NetworkUpdate

### DIFF
--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -244,18 +244,25 @@ impl KwaaiNet for KwaaiNetService {
                     }
 
                     client_frame::Body::Status(_) => {
-                        // Routing-table size, matching the field's documented
-                        // meaning. 0 when the swarm is not up yet, or on the Go
-                        // p2p path where there is no handle to ask — the same
-                        // value this reported unconditionally before.
-                        let peer_count = match net_slot.read().await.clone() {
-                            Some(handle) => handle
-                                .routing_peers()
-                                .await
-                                .map(|p| p.len() as u32)
-                                .unwrap_or(0),
-                            None => 0,
-                        };
+                        // peer_count is the routing-table size, matching the
+                        // field's documented meaning. All three are 0 when the
+                        // swarm is not up yet, or on the Go p2p path where
+                        // there is no handle to ask — the same value this
+                        // reported unconditionally before.
+                        let (peer_count, bootstrap_total, bootstrap_reachable) =
+                            match net_slot.read().await.clone() {
+                                Some(handle) => match handle.network_snapshot().await {
+                                    Ok(snapshot) => {
+                                        let bootstraps =
+                                            crate::peers_view::bootstrap_peer_ids();
+                                        let (total, reachable) =
+                                            bootstrap_health(&snapshot, &bootstraps);
+                                        (snapshot.routing.len() as u32, total, reachable)
+                                    }
+                                    Err(_) => (0, 0, 0),
+                                },
+                                None => (0, 0, 0),
+                            };
 
                         let reply = StatusReply {
                             server_time: now_rfc3339(),
@@ -267,6 +274,8 @@ impl KwaaiNet for KwaaiNetService {
                             // the version reported over the wire can never
                             // drift from the one used for update checks.
                             version: crate::updater::CURRENT_VERSION.to_string(),
+                            bootstrap_total,
+                            bootstrap_reachable,
                         };
                         let _ = out_tx
                             .send(Ok(ServerFrame {
@@ -1314,6 +1323,11 @@ type NetworkIdentity = (
     String,
     BTreeSet<String>,
     BTreeSet<String>,
+    // (bootstrap_total, bootstrap_reachable). A bootstrap appearing already
+    // changes the connected set, but the count can also *fall* with no other
+    // change — the contact window expiring on a bootstrap that went quiet —
+    // and that flip is exactly what the GUI's banner is watching for.
+    (u32, u32),
 );
 
 fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
@@ -1371,6 +1385,7 @@ fn network_identity(u: &NetworkUpdate) -> NetworkIdentity {
         self_status.local_protocols.join(","),
         connected,
         routing,
+        (u.bootstrap_total, u.bootstrap_reachable),
     )
 }
 
@@ -1605,6 +1620,42 @@ async fn spawn_session_connect(
     });
 }
 
+/// A bootstrap counts as reachable while it is connected or accepted a
+/// connection within this window. Recency rather than the live set because
+/// bootstraps close idle connections (~30 s), and the announce loop
+/// re-contacts every bootstrap every ~300 s ± 30 s — so a healthy idle node
+/// refreshes well inside the window, while one that cannot reach any
+/// bootstrap ages out after missing two-plus cycles. The routing table is
+/// deliberately not consulted: kad seeds it with the configured addresses
+/// before any dial succeeds, so membership proves nothing.
+const BOOTSTRAP_CONTACT_WINDOW: std::time::Duration = std::time::Duration::from_secs(900);
+
+/// `(bootstrap_total, bootstrap_reachable)` for the configured bootstrap
+/// set, as defined on `StatusReply` in kwaai.proto — the one computation
+/// behind both the status frame and the network feed, so the two surfaces
+/// can never disagree.
+fn bootstrap_health(
+    snapshot: &kwaai_p2p::NetworkSnapshot,
+    bootstraps: &std::collections::HashSet<libp2p::PeerId>,
+) -> (u32, u32) {
+    use std::collections::HashSet;
+    // Both checks are load-bearing: `last_contact` is stamped at establish
+    // time, so a connection older than the window that is still open would
+    // read as gone without the live-set check.
+    let connected: HashSet<_> = snapshot.peers.iter().map(|p| p.peer_id).collect();
+    let recent: HashSet<_> = snapshot
+        .last_contact
+        .iter()
+        .filter(|(_, ago)| *ago <= BOOTSTRAP_CONTACT_WINDOW)
+        .map(|(p, _)| *p)
+        .collect();
+    let reachable = bootstraps
+        .iter()
+        .filter(|b| connected.contains(b) || recent.contains(b))
+        .count();
+    (bootstraps.len() as u32, reachable as u32)
+}
+
 /// Project a [`kwaai_p2p::NetworkSnapshot`] onto the wire type.
 ///
 /// Classification (relay-vs-direct, bootstrap, trusted-relay) and the sort
@@ -1698,6 +1749,8 @@ fn build_network_update(
         Reachability::Private => ("private", ""),
     };
 
+    let (bootstrap_total, bootstrap_reachable) = bootstrap_health(snapshot, bootstraps);
+
     NetworkUpdate {
         server_time: now_rfc3339(),
         reason: reason as i32,
@@ -1724,6 +1777,8 @@ fn build_network_update(
         }),
         connected: connected.into_iter().map(|(_, _, w)| w).collect(),
         routing,
+        bootstrap_total,
+        bootstrap_reachable,
     }
 }
 

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -253,8 +253,7 @@ impl KwaaiNet for KwaaiNetService {
                             match net_slot.read().await.clone() {
                                 Some(handle) => match handle.network_snapshot().await {
                                     Ok(snapshot) => {
-                                        let bootstraps =
-                                            crate::peers_view::bootstrap_peer_ids();
+                                        let bootstraps = crate::peers_view::bootstrap_peer_ids();
                                         let (total, reachable) =
                                             bootstrap_health(&snapshot, &bootstraps);
                                         (snapshot.routing.len() as u32, total, reachable)
@@ -2600,6 +2599,7 @@ mod tests {
             }),
             connected: peers,
             routing: vec![],
+            ..Default::default()
         }
     }
 

--- a/core/crates/kwaai-network-tests/tests/03_unit_rpc.rs
+++ b/core/crates/kwaai-network-tests/tests/03_unit_rpc.rs
@@ -176,6 +176,8 @@ fn server_frame_status_roundtrip() {
         // daemon reports. Nothing here tracks CARGO_PKG_VERSION, so a version
         // bump never needs to touch this test.
         version: "9.9.9-test".to_string(),
+        bootstrap_total: 2,
+        bootstrap_reachable: 1,
     };
     let decoded = encode_decode_server_frame(server_frame::Body::Status(reply));
     if let Some(server_frame::Body::Status(s)) = decoded.body {
@@ -184,6 +186,8 @@ fn server_frame_status_roundtrip() {
         assert_eq!(s.peer_count, 12);
         assert_eq!(s.uptime_secs, 3600);
         assert_eq!(s.version, "9.9.9-test");
+        assert_eq!(s.bootstrap_total, 2);
+        assert_eq!(s.bootstrap_reachable, 1);
     } else {
         panic!("wrong variant");
     }
@@ -210,6 +214,10 @@ fn server_frame_status_version_defaults_empty_for_old_daemons() {
     let decoded = encode_decode_server_frame(server_frame::Body::Status(reply));
     if let Some(server_frame::Body::Status(s)) = decoded.body {
         assert_eq!(s.version, "");
+        // Bootstrap fields decode as 0 from old daemons — the "unknowable"
+        // value clients are told not to alarm on.
+        assert_eq!(s.bootstrap_total, 0);
+        assert_eq!(s.bootstrap_reachable, 0);
         // The pre-existing fields must still decode alongside the new one.
         assert_eq!(s.uptime_secs, 3600);
     } else {

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -154,6 +154,12 @@ pub struct NetworkSnapshot {
     /// more useful answer anyway: it is what this node will *do* for a peer,
     /// which is what a reader comparing it against a peer's list wants.
     pub local_protocols: Vec<String>,
+    /// How long ago each peer last *established* a connection, in either
+    /// direction. Peers that never connected are absent — which is the point:
+    /// a routing-table entry exists the moment a configured address is seeded
+    /// into kad, but an entry here proves a dial actually succeeded. Bounded
+    /// recency cache (see the service), not a full history.
+    pub last_contact: Vec<(PeerId, Duration)>,
 }
 
 /// A peer we know at least one dialable address for, as reported by

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -55,6 +55,11 @@ const KAD_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
 /// serialize on the event loop, shallow enough to apply backpressure.
 const COMMAND_CHANNEL_SIZE: usize = 64;
 
+/// Upper bound on `last_connected` entries. Sized for its one consumer —
+/// bootstrap-health recency — with room for a busy node's whole active
+/// neighbourhood, not as a history of every peer ever seen.
+const LAST_CONNECTED_CAP: usize = 1024;
+
 /// How often the relay manager retries candidates whose backoff has expired.
 const RELAY_TICK_INTERVAL: Duration = Duration::from_secs(15);
 
@@ -121,6 +126,15 @@ pub struct NetworkService {
     /// Live connections, per peer, keyed by connection so multiple connections
     /// to one peer are tracked independently.
     connections: HashMap<PeerId, HashMap<ConnectionId, Connection>>,
+    /// When each peer last *established* a connection to us, in either
+    /// direction. Unlike `connections` this survives the close, which is what
+    /// makes bootstrap health readable: kad seeds its routing table with the
+    /// configured bootstrap addresses before any dial succeeds, so table
+    /// membership proves nothing, and bootstraps drop idle connections after
+    /// ~30 s, so the live set reads empty on a healthy node. "Connected
+    /// recently" is the signal that distinguishes the two. Recency cache, not
+    /// a ledger — capped at [`LAST_CONNECTED_CAP`], oldest evicted.
+    last_connected: HashMap<PeerId, Instant>,
     /// Addresses peers reported observing us at → the set of peers that said so.
     /// A set (not a counter) so repeated identifies from one peer count once.
     observed_addrs: HashMap<Multiaddr, HashSet<PeerId>>,
@@ -381,6 +395,7 @@ impl NetworkService {
             pending_routed: HashMap::new(),
             routed_attempts: HashMap::new(),
             connections: HashMap::new(),
+            last_connected: HashMap::new(),
             observed_addrs: HashMap::new(),
             require_global_ips: config.require_global_ips,
             peer_protocols: HashMap::new(),
@@ -536,6 +551,11 @@ impl NetworkService {
                     observed_addrs: observed,
                     listen_addrs: self.swarm.listeners().cloned().collect(),
                     local_protocols: self.collect_local_protocols(),
+                    last_contact: self
+                        .last_connected
+                        .iter()
+                        .map(|(p, at)| (*p, at.elapsed()))
+                        .collect(),
                 });
             }
 
@@ -1561,6 +1581,20 @@ impl NetworkService {
                     ),
                 };
                 debug!(peer = %peer_id, %addr, direction = direction.as_str(), "connection established");
+
+                if self.last_connected.len() >= LAST_CONNECTED_CAP
+                    && !self.last_connected.contains_key(&peer_id)
+                {
+                    if let Some(oldest) = self
+                        .last_connected
+                        .iter()
+                        .min_by_key(|(_, at)| **at)
+                        .map(|(p, _)| *p)
+                    {
+                        self.last_connected.remove(&oldest);
+                    }
+                }
+                self.last_connected.insert(peer_id, Instant::now());
 
                 self.connections.entry(peer_id).or_default().insert(
                     connection_id,

--- a/core/crates/kwaai-rpc/proto/kwaai.proto
+++ b/core/crates/kwaai-rpc/proto/kwaai.proto
@@ -276,6 +276,26 @@ message StatusReply {
     // Empty when talking to a daemon built before this field existed;
     // clients should treat "" as unknown rather than as a version.
     string version = 6;
+
+    // Bootstrap connectivity, for surfacing "my configured initial peers
+    // are down" to clients. `bootstrap_total` counts the distinct peer IDs
+    // derivable from the configured bootstrap set (initial_peers, or the
+    // built-in defaults when that list is absent); entries without a /p2p
+    // component contribute nothing, so 0 with peers configured means the
+    // condition is unknowable, not healthy.
+    //
+    // `bootstrap_reachable` counts those that are currently connected OR
+    // successfully established a connection within the last ~15 minutes.
+    // Recency, not the live set, because bootstraps close idle connections
+    // (~30s) while the announce loop re-contacts them every ~5 minutes, so
+    // a healthy idle node keeps refreshing inside the window. And not the
+    // routing table, because kad seeds it with the configured addresses
+    // before any dial succeeds — membership proves nothing.
+    //
+    // Both 0 on daemons built before these fields existed and on the Go
+    // p2p path; clients should only act on reachable == 0 when total > 0.
+    uint32 bootstrap_total = 7;
+    uint32 bootstrap_reachable = 8;
 }
 
 // `kwaainet shard chain` — model block coverage from the DHT.
@@ -592,6 +612,21 @@ message NetworkUpdate {
 
     // The Kademlia routing table, sorted by peer id.
     repeated RoutingPeer routing = 5;
+
+    // Bootstrap connectivity, so a client can tell "my configured initial
+    // peers are down" apart from ordinary churn. Same definitions as the
+    // StatusReply pair: `bootstrap_total` is the distinct peer IDs derivable
+    // from the configured bootstrap set (0 = unknowable, not healthy), and
+    // `bootstrap_reachable` counts those connected or successfully connected
+    // within the last ~15 minutes — see StatusReply for why neither the live
+    // set nor the routing table can carry this on its own.
+    //
+    // Both fields are part of the subscription's change identity, so a flip
+    // in either direction — a bootstrap appearing, or the count falling as
+    // the contact window expires — is pushed on the next sample rather than
+    // suppressed as an unchanged snapshot.
+    uint32 bootstrap_total = 6;
+    uint32 bootstrap_reachable = 7;
 }
 
 // `kwaainet vpk discover` — VPK storage nodes from the DHT.

--- a/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
+++ b/core/crates/kwaai-rpc/tests/proto_roundtrip.rs
@@ -278,6 +278,8 @@ fn network_update_roundtrip_all_sections() {
                 addrs: vec!["/ip4/198.18.0.99/tcp/8000".to_string()],
             },
         ],
+        bootstrap_total: 2,
+        bootstrap_reachable: 1,
     };
 
     let decoded = NetworkUpdate::decode(original.encode_to_vec().as_slice())
@@ -304,6 +306,7 @@ fn network_update_roundtrip_disjoint_peer_sets() {
             ..Default::default()
         }],
         routing: vec![],
+        ..Default::default()
     };
     let decoded = NetworkUpdate::decode(young.encode_to_vec().as_slice()).expect("must decode");
     assert_eq!(decoded, young);
@@ -325,6 +328,7 @@ fn network_update_roundtrip_disjoint_peer_sets() {
             // and an empty list must survive the wire as one.
             addrs: vec![],
         }],
+        ..Default::default()
     };
     let decoded =
         NetworkUpdate::decode(known_not_connected.encode_to_vec().as_slice()).expect("must decode");


### PR DESCRIPTION
## Problem

A node whose configured `initial_peers` are all down starts, logs a warn, and then looks healthy on every client surface — nothing on the wire distinguishes it from a connected node. `start_bootstrap` even logs "Bootstrapped to N peer(s)" for dials that merely *started*.

## Change

New fields, same definition on both surfaces:

- `StatusReply.bootstrap_total = 7` / `bootstrap_reachable = 8`
- `NetworkUpdate.bootstrap_total = 6` / `bootstrap_reachable = 7`

`bootstrap_total` is the distinct peer ids derivable from the configured bootstrap set. `bootstrap_reachable` counts those **connected now or successfully connected within a 15-minute window**. Neither existing view could carry this alone:

- bootstraps close idle connections (~30 s), so the live-connection set reads 0 on a perfectly healthy idle node;
- kad seeds its routing table with the configured addresses *before any dial succeeds*, so table membership proves nothing (verified live: a node with unroutable bootstrap addrs shows both peers tabled, never connected).

The window spans the announce loop's ~300 s re-contact cadence, so a healthy node keeps refreshing inside it while a dead or gone-quiet bootstrap ages out.

## Implementation

- The swarm service stamps every `ConnectionEstablished` into a bounded (1024-entry) last-connected map, exposed as `NetworkSnapshot.last_contact`.
- One `bootstrap_health()` helper in the grpc layer feeds both the status frame and the network feed, so the two surfaces cannot disagree.
- The counts join the network subscription's change identity, so a flip in either direction is pushed on the next sample rather than suppressed as an unchanged snapshot.
- Both fields decode as 0 from older daemons and on the Go p2p path; clients must treat `total=0` as unknowable, not healthy.

Consumed by the KwaaiNetGUI `feat/bootstrap-down-banner` branch (app-level red banner).

## Testing

- `proto_roundtrip`: fields survive encode/decode; old-daemon zero-default pinned.
- `03_unit_rpc`: StatusReply roundtrip incl. new fields.
- `cargo test -p kwaai-p2p --lib`: 96 passed.
- Live: sealed-config node with unroutable bootstrap addrs reports 0/2 over the wire; healthy node reports 2/2 across idle closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)