### PR TITLE
fix(p2p): disable QUIC by default

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -228,10 +228,10 @@ pub struct KwaaiNetConfig {
     #[serde(default = "default_enable_upnp")]
     pub enable_upnp: bool,
 
-    /// Listen on and dial QUIC as well as TCP. Turn it off for a network that
-    /// blocks or throttles UDP. Bound at startup, so changing it needs a
+    /// Listen on and dial QUIC as well as TCP. Off by default: some networks
+    /// block or throttle UDP. Bound at startup, so changing it needs a
     /// restart.
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub enable_quic: bool,
     /// Ceiling on simultaneously established connections, inbound and
     /// outbound, enforced by the swarm's connection-limits behaviour.
@@ -897,7 +897,7 @@ impl Default for KwaaiNetConfig {
             force_private: default_force_private(),
             native_p2p: None,
             enable_upnp: default_enable_upnp(),
-            enable_quic: true,
+            enable_quic: false,
             max_connections: default_max_connections(),
             announce_self: true,
             decentralized_dht: false,

--- a/core/crates/kwaai-p2p/src/config.rs
+++ b/core/crates/kwaai-p2p/src/config.rs
@@ -58,9 +58,9 @@ pub struct NetworkConfig {
     /// Maximum concurrent connections, inbound and outbound.
     pub max_connections: usize,
 
-    /// Listen on and dial QUIC as well as TCP. Off for networks that block or
-    /// throttle UDP. Defaulted so a config predating the field still loads.
-    #[serde(default = "default_true")]
+    /// Listen on and dial QUIC as well as TCP. Off by default: some networks
+    /// block or throttle UDP. Defaulted so a config predating the field still loads.
+    #[serde(default)]
     pub enable_quic: bool,
 
     /// Enable NAT traversal
@@ -216,7 +216,7 @@ impl Default for NetworkConfig {
             idle_connection_timeout: Duration::from_secs(10 * 60),
             request_timeout: Duration::from_secs(60),
             max_connections: 100,
-            enable_quic: true,
+            enable_quic: false,
             enable_nat_traversal: true,
             enable_relay_client: true,
             protocol_version: crate::behaviour::DEFAULT_PROTOCOL_VERSION.to_string(),

--- a/core/crates/kwaai-p2p/tests/quic.rs
+++ b/core/crates/kwaai-p2p/tests/quic.rs
@@ -40,6 +40,7 @@ fn spawn_quic_only() -> (NetworkHandle, tokio::task::JoinHandle<()>, PeerId) {
     let (handle, task) = NetworkService::spawn(
         NetworkConfig {
             listen_addrs: vec!["/ip4/127.0.0.1/udp/0/quic-v1".to_string()],
+            enable_quic: true,
             ..NetworkConfig::for_tests()
         },
         keypair,


### PR DESCRIPTION
## Summary

Flips the `enable_quic` default introduced in #155 from on to off, in both `kwaai-p2p`'s `NetworkConfig` and the CLI `Config`. QUIC remains fully supported — a node now opts in with `enable_quic: true` instead of opting out.

The serde default follows the flipped default: a `config.yaml` that omits the key gets TCP only, matching the behaviour of a config written before the field existed.

## Changes

- `kwaai-p2p/src/config.rs`: `Default` impl and serde default → `false`
- `kwaai-cli/src/config.rs`: same
- `kwaai-p2p/tests/quic.rs`: the QUIC-only test nodes set `enable_quic: true` explicitly (they previously inherited it from the default)

## Testing

- `cargo test -p kwaai-p2p` — 96 unit + all integration tests pass, including the three QUIC tests (connect over QUIC, listener presence follows the flag, disabled node cannot dial QUIC)
- `cargo test -p kwaainet` — 219 pass
- `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)