### PR TITLE
fix(tests): Windows has never actually run the test suite — make it

### DIFF
--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -2407,34 +2407,55 @@ mod tests {
             .is_ok()
     }
 
-    /// True iff a fresh TCP connect to `port` is refused quickly (used to
-    /// assert the listener is gone after shutdown).
-    async fn tcp_refused(port: u16) -> bool {
-        // ConnectionRefused is the happy-path answer; any other Err (e.g.
-        // network unreachable) we also treat as "not accepting".
-        //
-        // Silence must NOT count as "not accepting". Winsock retries a RST'd
-        // connect in-stack and reports WSAECONNREFUSED only after ~1s, so the
-        // budget has to clear that — but treating a timeout as "closed" would
-        // make the assertion unfalsifiable from the other direction. These are
-        // current-thread `#[tokio::test]`s and `timeout` measures wall clock,
-        // including time the inner future is not polled; the probe runs while
-        // the server task, its connection drain and the client channel are all
-        // still scheduled on this one thread. A starved runtime would then
-        // report a live listener as closed, which is precisely the
-        // serve_with_shutdown regression these tests exist to catch.
-        //
-        // So: wait long enough for Winsock to answer, and keep silence
-        // meaning "still up".
+    /// What one connect probe learned about a port.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    enum Probe {
+        Accepting,
+        /// Refused, or unreachable — either way nothing is serving.
+        Refused,
+        /// No answer inside the ceiling; tells us nothing either way.
+        Silent,
+    }
+
+    /// Winsock answers a refused loopback connect only after a fixed in-stack
+    /// retry, measured at ~2.04s on Windows and the same for a port that never
+    /// had a listener. Probing below that reads every closed port as `Silent`.
+    const REFUSAL_PROBE_CEILING: Duration = Duration::from_secs(4);
+
+    /// Three probes at the ceiling, so one starved answer is not the verdict.
+    /// Kept next to the ceiling it derives from: as independent literals the
+    /// two drifted apart twice, each time breaking the assertion below.
+    const LISTENER_CLOSE_BUDGET: Duration = Duration::from_secs(12);
+
+    async fn probe_port(port: u16) -> Probe {
         match tokio::time::timeout(
-            Duration::from_millis(1500),
+            REFUSAL_PROBE_CEILING,
             tokio::net::TcpStream::connect(("127.0.0.1", port)),
         )
         .await
         {
-            Ok(Ok(_)) => false, // still accepting
-            Ok(Err(_)) => true, // refused / unreachable
-            Err(_) => false,    // timed out — something is listening but not answering yet
+            Ok(Ok(_)) => Probe::Accepting,
+            Ok(Err(_)) => Probe::Refused,
+            Err(_) => Probe::Silent,
+        }
+    }
+
+    /// Poll until `port` refuses. `Silent` never counts as closed: `timeout`
+    /// measures wall clock, so on these current-thread tests a probe starved by
+    /// the server task it is shutting down would report a live listener as gone
+    /// — the `serve_with_shutdown` regression these tests exist to catch.
+    /// Returns the last outcome seen, so a failure says which one it was.
+    async fn wait_for_close(port: u16) -> Result<(), Probe> {
+        let deadline = Instant::now() + LISTENER_CLOSE_BUDGET;
+        loop {
+            let seen = probe_port(port).await;
+            if seen == Probe::Refused {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(seen);
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
         }
     }
 
@@ -2497,11 +2518,11 @@ mod tests {
         // tonic's serve_with_shutdown returns -> listener is closed.
         drop(handle);
 
-        let down = wait_for(Duration::from_secs(10), || tcp_refused(port)).await;
-        assert!(
-            down,
-            "TCP listener on 127.0.0.1:{port} did not close within 10s of dropping the handle"
-        );
+        wait_for_close(port).await.unwrap_or_else(|last| {
+            panic!(
+                "TCP listener on 127.0.0.1:{port} still {last:?} {LISTENER_CLOSE_BUDGET:?} after dropping the handle"
+            )
+        });
 
         #[cfg(unix)]
         {
@@ -2581,8 +2602,9 @@ mod tests {
         drop(handle);
         // Wait for the listener to actually go away before the next test
         // tries to bind the same port.
-        let down = wait_for(Duration::from_secs(10), || tcp_refused(port)).await;
-        assert!(down, "TCP listener did not close after handle drop");
+        wait_for_close(port).await.unwrap_or_else(|last| {
+            panic!("TCP listener still {last:?} {LISTENER_CLOSE_BUDGET:?} after handle drop")
+        });
     }
 
     #[test]

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -2413,6 +2413,13 @@ mod tests {
         // ConnectionRefused is the happy-path answer; any other Err (e.g.
         // network unreachable) we also treat as "not accepting". We bound
         // the dial with a short timeout so a slow stack can't lie to us.
+        //
+        // Silence counts as "not accepting" too: Winsock retries a RST'd
+        // connect in-stack and reports WSAECONNREFUSED only after ~1s, so on
+        // Windows a closed port looks like a timeout from inside this window.
+        // The reverse cannot mislead us — a live loopback listener completes
+        // the handshake in-kernel (backlog) long before 250ms, without the
+        // server ever calling accept.
         match tokio::time::timeout(
             Duration::from_millis(250),
             tokio::net::TcpStream::connect(("127.0.0.1", port)),
@@ -2420,8 +2427,7 @@ mod tests {
         .await
         {
             Ok(Ok(_)) => false, // still accepting
-            Ok(Err(_)) => true, // refused / unreachable
-            Err(_) => false,    // timed out = something is listening but not answering yet
+            _ => true,          // refused, unreachable, or silence
         }
     }
 

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -2418,14 +2418,31 @@ mod tests {
     }
 
     /// Winsock answers a refused loopback connect only after a fixed in-stack
-    /// retry, measured at ~2.04s on Windows and the same for a port that never
-    /// had a listener. Probing below that reads every closed port as `Silent`.
-    const REFUSAL_PROBE_CEILING: Duration = Duration::from_secs(4);
+    /// retry — identical for a port that never had a listener, so it is the
+    /// stack, not the server. Probing below it reads every closed port as
+    /// `Silent`, which is a test that cannot pass on Windows.
+    ///
+    /// Measured, `MaxSynRetransmissions = 4` and no registry overrides on both:
+    ///
+    /// | box | | worst |
+    /// |---|---|---|
+    /// | Win 11 Pro Workstations, 64 cores | ~2.04s | 2.12s |
+    /// | Win 10 22H2, i7-3667U 2c/4t | ~2.30s | 2.43s |
+    ///
+    /// Same retry count, different per-retry latency: the floor tracks the
+    /// hardware, so it is not a constant to sit just above. This is 4x the
+    /// slower reading rather than a tight margin on either, because the two
+    /// directions do not cost the same. Too low and every probe expires as
+    /// silence and the assertion can never pass — shipped twice, at 250ms and
+    /// 1500ms. Too high costs only how long a *genuinely* failing test takes
+    /// to give up: the probe returns the moment Winsock answers, so a healthy
+    /// shutdown still resolves in one refusal latency whatever this says.
+    const REFUSAL_PROBE_CEILING: Duration = Duration::from_secs(10);
 
     /// Three probes at the ceiling, so one starved answer is not the verdict.
     /// Kept next to the ceiling it derives from: as independent literals the
     /// two drifted apart twice, each time breaking the assertion below.
-    const LISTENER_CLOSE_BUDGET: Duration = Duration::from_secs(12);
+    const LISTENER_CLOSE_BUDGET: Duration = Duration::from_secs(30);
 
     async fn probe_port(port: u16) -> Probe {
         match tokio::time::timeout(

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -2407,70 +2407,59 @@ mod tests {
             .is_ok()
     }
 
-    /// What one connect probe learned about a port.
-    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-    enum Probe {
-        Accepting,
-        /// Refused, or unreachable — either way nothing is serving.
-        Refused,
-        /// No answer inside the ceiling; tells us nothing either way.
-        Silent,
+    /// Whether a fresh listener can be bound to `port` — which is the
+    /// question these tests actually ask, and unlike "is the port refusing
+    /// connections?" it has an immediate, unambiguous answer on every
+    /// platform.
+    ///
+    /// The connect-probe this replaces had to tell "closed" from "slow to
+    /// answer" by waiting, and on Windows a refused loopback connect is only
+    /// reported after an in-stack SYN retry — ~2.04s on one box, ~2.30s on a
+    /// slower one, scaling with the hardware. Every version of that test was a
+    /// guess at a threshold, and two of them shipped wrong in the direction
+    /// that cannot pass at all.
+    ///
+    /// `bind` needs no threshold. Measured on Windows 10 22H2, and matching
+    /// how the server binds (`std::net::TcpListener::bind`, no socket options
+    /// set — std sets `SO_REUSEADDR` on Unix only):
+    ///
+    /// - against a live listener it fails in under a millisecond with
+    ///   `WSAEADDRINUSE`; on Unix `SO_REUSEADDR` permits `TIME_WAIT`, never an
+    ///   active listener;
+    /// - after a connection closed *server-side*, leaving `TIME_WAIT` on this
+    ///   very port, it succeeds in ~0.3ms with the entry still in `netstat`.
+    ///   That was the failure mode worth fearing, and it does not occur.
+    ///
+    /// The one way this differs from the old probe: it answers "is the port
+    /// bindable", not "did *our* listener close". Something else taking the
+    /// port in between would report a leak that isn't there. That is a
+    /// spurious *failure*, never a silent pass — a leaked listener still holds
+    /// the port and still fails the assertion — which is the direction to err
+    /// in for a test guarding a shutdown regression.
+    fn port_is_free(port: u16) -> bool {
+        // Bound and dropped inside the call: holding it would be indis-
+        // tinguishable from the leak we are testing for.
+        std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
     }
 
-    /// Winsock answers a refused loopback connect only after a fixed in-stack
-    /// retry — identical for a port that never had a listener, so it is the
-    /// stack, not the server. Probing below it reads every closed port as
-    /// `Silent`, which is a test that cannot pass on Windows.
+    /// How long to wait for an asynchronous shutdown to release the port.
     ///
-    /// Measured, `MaxSynRetransmissions = 4` and no registry overrides on both:
-    ///
-    /// | box | | worst |
-    /// |---|---|---|
-    /// | Win 11 Pro Workstations, 64 cores | ~2.04s | 2.12s |
-    /// | Win 10 22H2, i7-3667U 2c/4t | ~2.30s | 2.43s |
-    ///
-    /// Same retry count, different per-retry latency: the floor tracks the
-    /// hardware, so it is not a constant to sit just above. This is 4x the
-    /// slower reading rather than a tight margin on either, because the two
-    /// directions do not cost the same. Too low and every probe expires as
-    /// silence and the assertion can never pass — shipped twice, at 250ms and
-    /// 1500ms. Too high costs only how long a *genuinely* failing test takes
-    /// to give up: the probe returns the moment Winsock answers, so a healthy
-    /// shutdown still resolves in one refusal latency whatever this says.
-    const REFUSAL_PROBE_CEILING: Duration = Duration::from_secs(10);
+    /// An ordinary liveness budget, not a threshold anything is inferred
+    /// from: each probe is decisive on its own, so this only bounds how long
+    /// a genuine leak takes to be reported. `drop` -> oneshot ->
+    /// `serve_with_incoming_shutdown` returns -> listener closed is normally
+    /// well under a millisecond.
+    const LISTENER_CLOSE_BUDGET: Duration = Duration::from_secs(10);
 
-    /// Three probes at the ceiling, so one starved answer is not the verdict.
-    /// Kept next to the ceiling it derives from: as independent literals the
-    /// two drifted apart twice, each time breaking the assertion below.
-    const LISTENER_CLOSE_BUDGET: Duration = Duration::from_secs(30);
-
-    async fn probe_port(port: u16) -> Probe {
-        match tokio::time::timeout(
-            REFUSAL_PROBE_CEILING,
-            tokio::net::TcpStream::connect(("127.0.0.1", port)),
-        )
-        .await
-        {
-            Ok(Ok(_)) => Probe::Accepting,
-            Ok(Err(_)) => Probe::Refused,
-            Err(_) => Probe::Silent,
-        }
-    }
-
-    /// Poll until `port` refuses. `Silent` never counts as closed: `timeout`
-    /// measures wall clock, so on these current-thread tests a probe starved by
-    /// the server task it is shutting down would report a live listener as gone
-    /// — the `serve_with_shutdown` regression these tests exist to catch.
-    /// Returns the last outcome seen, so a failure says which one it was.
-    async fn wait_for_close(port: u16) -> Result<(), Probe> {
+    /// Poll until `port` can be bound again, i.e. the listener is gone.
+    async fn wait_for_close(port: u16) -> Result<(), ()> {
         let deadline = Instant::now() + LISTENER_CLOSE_BUDGET;
         loop {
-            let seen = probe_port(port).await;
-            if seen == Probe::Refused {
+            if port_is_free(port) {
                 return Ok(());
             }
             if Instant::now() >= deadline {
-                return Err(seen);
+                return Err(());
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
@@ -2535,9 +2524,9 @@ mod tests {
         // tonic's serve_with_shutdown returns -> listener is closed.
         drop(handle);
 
-        wait_for_close(port).await.unwrap_or_else(|last| {
+        wait_for_close(port).await.unwrap_or_else(|()| {
             panic!(
-                "TCP listener on 127.0.0.1:{port} still {last:?} {LISTENER_CLOSE_BUDGET:?} after dropping the handle"
+                "127.0.0.1:{port} still not bindable {LISTENER_CLOSE_BUDGET:?} after dropping the handle"
             )
         });
 
@@ -2619,8 +2608,8 @@ mod tests {
         drop(handle);
         // Wait for the listener to actually go away before the next test
         // tries to bind the same port.
-        wait_for_close(port).await.unwrap_or_else(|last| {
-            panic!("TCP listener still {last:?} {LISTENER_CLOSE_BUDGET:?} after handle drop")
+        wait_for_close(port).await.unwrap_or_else(|()| {
+            panic!("port still not bindable {LISTENER_CLOSE_BUDGET:?} after handle drop")
         });
     }
 

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -2411,23 +2411,30 @@ mod tests {
     /// assert the listener is gone after shutdown).
     async fn tcp_refused(port: u16) -> bool {
         // ConnectionRefused is the happy-path answer; any other Err (e.g.
-        // network unreachable) we also treat as "not accepting". We bound
-        // the dial with a short timeout so a slow stack can't lie to us.
+        // network unreachable) we also treat as "not accepting".
         //
-        // Silence counts as "not accepting" too: Winsock retries a RST'd
-        // connect in-stack and reports WSAECONNREFUSED only after ~1s, so on
-        // Windows a closed port looks like a timeout from inside this window.
-        // The reverse cannot mislead us — a live loopback listener completes
-        // the handshake in-kernel (backlog) long before 250ms, without the
-        // server ever calling accept.
+        // Silence must NOT count as "not accepting". Winsock retries a RST'd
+        // connect in-stack and reports WSAECONNREFUSED only after ~1s, so the
+        // budget has to clear that — but treating a timeout as "closed" would
+        // make the assertion unfalsifiable from the other direction. These are
+        // current-thread `#[tokio::test]`s and `timeout` measures wall clock,
+        // including time the inner future is not polled; the probe runs while
+        // the server task, its connection drain and the client channel are all
+        // still scheduled on this one thread. A starved runtime would then
+        // report a live listener as closed, which is precisely the
+        // serve_with_shutdown regression these tests exist to catch.
+        //
+        // So: wait long enough for Winsock to answer, and keep silence
+        // meaning "still up".
         match tokio::time::timeout(
-            Duration::from_millis(250),
+            Duration::from_millis(1500),
             tokio::net::TcpStream::connect(("127.0.0.1", port)),
         )
         .await
         {
             Ok(Ok(_)) => false, // still accepting
-            _ => true,          // refused, unreachable, or silence
+            Ok(Err(_)) => true, // refused / unreachable
+            Err(_) => false,    // timed out — something is listening but not answering yet
         }
     }
 
@@ -2490,10 +2497,10 @@ mod tests {
         // tonic's serve_with_shutdown returns -> listener is closed.
         drop(handle);
 
-        let down = wait_for(Duration::from_secs(2), || tcp_refused(port)).await;
+        let down = wait_for(Duration::from_secs(10), || tcp_refused(port)).await;
         assert!(
             down,
-            "TCP listener on 127.0.0.1:{port} did not close within 2s of dropping the handle"
+            "TCP listener on 127.0.0.1:{port} did not close within 10s of dropping the handle"
         );
 
         #[cfg(unix)]
@@ -2574,7 +2581,7 @@ mod tests {
         drop(handle);
         // Wait for the listener to actually go away before the next test
         // tries to bind the same port.
-        let down = wait_for(Duration::from_secs(2), || tcp_refused(port)).await;
+        let down = wait_for(Duration::from_secs(10), || tcp_refused(port)).await;
         assert!(down, "TCP listener did not close after handle drop");
     }
 

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -974,7 +974,14 @@ mod tests {
         // against an announce path that was broken outright.
         let home = tempfile::tempdir().expect("tmpdir");
         let config = seed_like_config(true, home.path());
+        // `control_socket_addr` wraps a path in `/unix/…` only on POSIX; on
+        // Windows the variable must already be a multiaddr, and a Unix one
+        // cannot bind there. Port 0 keeps parallel test binaries from
+        // colliding.
+        #[cfg(unix)]
         std::env::set_var("KWAAINET_SOCKET", home.path().join("node.sock"));
+        #[cfg(not(unix))]
+        std::env::set_var("KWAAINET_SOCKET", "/ip4/127.0.0.1/tcp/0");
         kwaai_p2p::identity::generate_keypair(config.identity_key.as_ref().unwrap())
             .expect("the fixture key must generate");
 

--- a/core/crates/kwaai-p2p-daemon/tests/control_server.rs
+++ b/core/crates/kwaai-p2p-daemon/tests/control_server.rs
@@ -73,10 +73,21 @@ impl TestNode {
         .expect("the swarm must report a listen address");
 
         let tmpdir = TempDir::new().expect("tmpdir");
-        let socket = format!("/unix/{}", tmpdir.path().join("kwaai.sock").display());
-        let server = ControlServer::bind(&socket, handle.clone())
+
+        // Windows has no Unix sockets, and `bind` refuses `/unix/` there. The
+        // control protocol is transport-independent — the server speaks both —
+        // so Windows runs the same suite over loopback TCP rather than skipping
+        // it, which is the platform with the least coverage elsewhere.
+        #[cfg(unix)]
+        let bind = format!("/unix/{}", tmpdir.path().join("kwaai.sock").display());
+        #[cfg(not(unix))]
+        let bind = "/ip4/127.0.0.1/tcp/0".to_string();
+
+        let server = ControlServer::bind(&bind, handle.clone())
             .await
             .expect("control socket binds");
+        // Port 0 only resolves once bound, so take the address from the server.
+        let socket = server.local_addr().expect("the bound control address");
         let server_task = tokio::spawn(server.run());
 
         Self {


### PR DESCRIPTION
## What

`Test (windows-latest)` has failed on every push to main since #84. Three layers, because `cargo test` stops at the first failing target — each fix exposed the next:

1. **`kwaai-p2p-daemon/tests/control_server.rs`** — all 19 tests bound `/unix/<tmpdir>/kwaai.sock`, which `ControlServer::bind` refuses on Windows. The suite is about the control protocol, not its transport, so Windows now runs the same 19 tests over loopback TCP (`/ip4/127.0.0.1/tcp/0`, resolved via `local_addr()`) instead of skipping them. Everything past this target had **never been compiled-and-run on Windows** — which is how layer 2 stayed invisible.

2. **`grpc_server::tests` shutdown probes** — these assert that dropping the handle closes the TCP listener. They did it by connecting to the port and deciding, from how long the connect stayed silent, whether anything was still there. On Windows that question has no cheap answer: a refused loopback connect is reported only after an in-stack SYN retry. **The probe no longer asks it.** It tries to `bind` the port instead, which is immediate and unambiguous on every platform. Detail below, because getting here took three wrong answers.

3. **`node_native` fixture** — set `KWAAINET_SOCKET` to a bare filesystem path, which `control_socket_addr()` wraps in `/unix/…` only on POSIX; on Windows the variable must already be a multiaddr. The fixture now uses `/ip4/127.0.0.1/tcp/0` there.

No production code changes — test harnesses and one test-only probe.

## Layer 2, and why it took four commits

Every version before the last tuned the same number: how long to wait before calling a silent port closed. Each was wrong, and the two failure modes are not symmetric — a test that *cannot pass* is loud, a test that *cannot fail* is silent.

| | probe | verdict |
|---|---|---|
| original | 250 ms ceiling, timeout ⇒ still listening | fails on Windows always: Winsock never answers that fast |
| `8514a0bf` | timeout ⇒ closed | **unfalsifiable** — a starved runtime reads a live listener as gone, which is the exact regression the test exists to catch |
| `0cfb47db` | 1500 ms ceiling, timeout ⇒ still listening | unfalsifiable the other way: below Winsock's ~2.04 s floor, so no probe could ever observe a close |
| `d97b8dec` | 10 s ceiling | correct, but still a threshold guessing at a machine |
| `e307da64` | **`bind` the port** | no threshold at all |

The floor is not a constant. Measured on two boxes, both stock (`MaxSynRetransmissions = 4`, no registry overrides):

| box | mean | worst |
|---|---|---|
| Win 11 Pro Workstations, 64 cores | ~2.04 s | 2.12 s |
| Win 10 22H2, i7-3667U 2c/4t | ~2.30 s | 2.43 s |

Same retry count, different per-retry latency — it scales with the hardware, in the direction CI runners sit. Any ceiling is a guess about a machine.

`bind` needs no guess. Modelling the server's own listener (`std::net::TcpListener::bind`, no socket options — std sets `SO_REUSEADDR` on Unix only), measured on Windows 10 22H2:

- against a live listener, fails in **under a millisecond** with `WSAEADDRINUSE`; on Unix `SO_REUSEADDR` permits `TIME_WAIT` but never an active listener;
- after a connection closed **server-side**, stranding `TIME_WAIT` on that very port, succeeds in **~0.3 ms** with the entry still present in `netstat`.

The second was the failure mode worth fearing — it would report a correctly closed listener as still up. It does not occur, and it was tested in the close order that produces it: closing the client first puts `TIME_WAIT` on the client's ephemeral port and exercises nothing.

One deliberate trade: the probe asks "is this port bindable", not "did *our* listener close", so something else taking the port would report a leak that isn't there. That is a spurious **failure**, never a silent pass — a leaked listener still holds the port. For a test guarding a shutdown regression that is the right direction, and the opposite of what the connect-probe had.

`LISTENER_CLOSE_BUDGET` survives at 10 s but is now an ordinary liveness budget: it bounds how long a genuine leak takes to be reported, and nothing is inferred from it.

## Evidence

Verified on a temporary branch-CI trigger (dropped before this PR; the Windows *test* job only runs on pushes to main, so a fix could otherwise never be verified pre-merge):

- Before: 19 failures in `control_server`, run aborted there — [33414217706](https://github.com/Kwaai-AI-Lab/KwaaiNet/actions/runs/33414217706) (main, same failures)
- Layer 2 surfaced: `control_server` 19/19, then 3 failures in the `kwaainet` bin — [33417416472](https://github.com/Kwaai-AI-Lab/KwaaiNet/actions/runs/33417416472)
- Fully green including `Test (windows-latest)` — [33419106106](https://github.com/Kwaai-AI-Lab/KwaaiNet/actions/runs/33419106106)

**Falsifiability is checked, not argued** — a test that cannot fail is the defect this branch twice reintroduced. `mem::forget` on the handle fails with `127.0.0.1:53796 still not bindable 10s after dropping the handle`. Unmodified: 219 tests pass, `clippy --all-targets -D warnings` and `fmt` clean.

Windows hardware runs on `e307da64` are in progress on a second box; the socket-level measurements above are already from real Windows, not inference from macOS.

## Follow-up

Making the Windows *test* job part of the PR gate. This PR's own job list checks only ubuntu plus the Windows *type* check, which is exactly why this went unseen for six weeks — and "Windows is green" on a PR has been cited as evidence elsewhere when it meant only that the code type-checks. Worth doing alongside #144 the moment this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
