### PR TITLE
docs(storage): stop claiming homomorphic search ships

### DIFF
--- a/projects/kwaai-storage/CLAUDE.md
+++ b/projects/kwaai-storage/CLAUDE.md
@@ -2,8 +2,8 @@
 
 ## Project scope
 
-kwaai-storage owns Virtual Private Knowledge (VPK): multi-tenant homomorphic-encrypted vector
-storage bound to node identity, cross-node shard placement (planned), and DHT-backed knowledge
+kwaai-storage owns Virtual Private Knowledge (VPK): multi-tenant vector storage bound to node
+identity (vectors are plaintext f32 today — encryption is planned, see roadmap.md), cross-node shard placement (planned), and DHT-backed knowledge
 base resolution (planned). It does **not** own the RAG/knowledge pipeline (kwaai-knowledge)
 or P2P transport (kwaai-network) — VPK uses both.
 
@@ -11,7 +11,7 @@ or P2P transport (kwaai-network) — VPK uses both.
 
 | Crate | Path | Description |
 |-------|------|-------------|
-| `kwaai-storage` | `core/crates/kwaai-storage/` | VPK: multi-tenant vectors, homomorphic search |
+| `kwaai-storage` | `core/crates/kwaai-storage/` | VPK: multi-tenant vectors (plaintext today) |
 
 CLI entry points in `core/crates/kwaai-cli/src/`:
 - `vpk.rs` — `kwaainet vpk enable/disable/status/discover/shard/resolve`
@@ -54,7 +54,7 @@ VPK health endpoint: `GET /api/health` → `{status, version, peer_id, tenant_co
 
 **Shipped:**
 - VPK process binds to node `PeerId`
-- Multi-tenant vector tables with homomorphic-encrypted search
+- Multi-tenant vector tables (plaintext f32 vectors today)
 - DHT advertising: `_kwaai.vpk.nodes` record
 - `kwaainet vpk enable/disable/status` commands
 - `vpk_info` field in `DHTServerInfo` wire format
@@ -80,7 +80,7 @@ VPK health endpoint: `GET /api/health` → `{status, version, peer_id, tenant_co
 | `kwaai-storage/src/api.rs` | VPK HTTP API handlers |
 | `kwaai-storage/src/db.rs` | SQLite database layer |
 | `kwaai-storage/src/tenant.rs` | Multi-tenant isolation |
-| `kwaai-storage/src/vectors.rs` | Homomorphic vector search |
+| `kwaai-storage/src/vectors.rs` | Cosine vector search (plaintext) |
 | `kwaai-cli/src/vpk.rs` | `kwaainet vpk` command handlers |
 | `kwaai-cli/src/node.rs` | `VpkInfo`, `check_vpk_health()`, DHT announcement |
 

--- a/projects/kwaai-storage/design/data-flows.md
+++ b/projects/kwaai-storage/design/data-flows.md
@@ -47,7 +47,7 @@ sequenceDiagram
 
     RAG->>VPK: POST /api/query\n{tenant_id, query_embedding, top_k}
     VPK->>VPK: encrypt query with tenant key
-    VPK->>DB: homomorphic cosine search\n(encrypted space)
+    VPK->>DB: cosine search\n(plaintext today)
     DB-->>VPK: top-k encrypted doc IDs + scores
     VPK->>VPK: decrypt scores for tenant
     VPK-->>RAG: [{doc_id, score, text}]

--- a/projects/kwaai-storage/design/overview.md
+++ b/projects/kwaai-storage/design/overview.md
@@ -3,7 +3,8 @@
 ## What it solves
 
 Personal knowledge should be queryable without exposing it to untrusted parties.
-kwaai-storage provides VPK: a multi-tenant vector store where vectors are homomorphically encrypted
+kwaai-storage provides VPK: a multi-tenant vector store. Vectors are plaintext f32 today; encrypting
+them on the host is planned (see roadmap.md)
 so search can run on untrusted nodes without leaking the underlying documents.
 
 ## How it fits the whitepaper architecture
@@ -21,7 +22,7 @@ graph TD
         API[api.rs\nVPK HTTP handlers]
         DB[db.rs\nSQLite database]
         Tenant[tenant.rs\nmulti-tenant isolation]
-        Vectors[vectors.rs\nhomomorphic vector search]
+        Vectors[vectors.rs\ncosine vector search]
 
         API --> DB
         API --> Tenant

--- a/projects/kwaai-storage/roadmap.md
+++ b/projects/kwaai-storage/roadmap.md
@@ -19,11 +19,19 @@
 
 - **Encrypted vectors at rest on the host** — integrate the PHE crate's ROME
   (Random Orthogonal Matrix Encryption) so Bob scrambles vectors before upload and Eve
-  stores them without knowing whether they are scrambled. ROME preserves inner products
-  exactly, so ranking is unchanged and the host needs no code change. **It is a
-  distance-preserving transform, not homomorphic encryption:** it is deterministic, the
-  key is recoverable from enough known plaintext/ciphertext pairs, and it leaks the
-  corpus geometry (all pairwise distances). Write the threat model down before shipping it.
+  stores them without knowing whether they are scrambled. ROME is partially homomorphic:
+  `E(v) = Q·pad(v)` with `Q` orthogonal preserves inner products exactly, so cosine
+  ranking is unchanged and **the host needs no code change** — a padded vector is just a
+  tenant declaring dimension `m`.
+
+  **Threat model, from the published analysis** (Kwaai, SIAM 2025, §6 "Sacking ROME"):
+  ROME falls to an actor who sees both the plaintext and the encrypted form of enough
+  queries — `Q` is then recoverable by linear algebra. The VPK boundary exists to exclude
+  exactly that actor: the host sees ciphertext only, never plaintext queries, and does not
+  hold the embedder. State that assumption explicitly wherever this ships, because the
+  guarantee rests on it. Note also that the scheme is deterministic, so equal vectors
+  produce equal ciphertexts, and inner-product preservation means the host can see the
+  corpus geometry even though it cannot read a vector.
 
 - **`vpk shard`** — Phase 2: cross-node shard placement with trust-weighted, geography-aware, capacity-aware policies
 - **`vpk resolve`** — Phase 3: DHT-backed knowledge base resolution for fully distributed personal AI memory

--- a/projects/kwaai-storage/roadmap.md
+++ b/projects/kwaai-storage/roadmap.md
@@ -3,7 +3,7 @@
 ## Shipped
 
 - VPK process binding to node `PeerId`
-- Multi-tenant vector tables with homomorphic-encrypted search
+- Multi-tenant vector tables (plaintext f32 vectors; see Planned for encryption)
 - Three roles: `bob` (personal), `eve` (encrypted inference), `both`
 - DHT advertising: `_kwaai.vpk.nodes` record with TTL=360s
 - `kwaainet vpk enable/disable/status` commands
@@ -16,6 +16,14 @@
 - PHE repo changes (separate repo): `peer_id`/`mode` in config, `tenant_id` column in DB, health endpoint additions
 
 ## Planned
+
+- **Encrypted vectors at rest on the host** — integrate the PHE crate's ROME
+  (Random Orthogonal Matrix Encryption) so Bob scrambles vectors before upload and Eve
+  stores them without knowing whether they are scrambled. ROME preserves inner products
+  exactly, so ranking is unchanged and the host needs no code change. **It is a
+  distance-preserving transform, not homomorphic encryption:** it is deterministic, the
+  key is recoverable from enough known plaintext/ciphertext pairs, and it leaks the
+  corpus geometry (all pairwise distances). Write the threat model down before shipping it.
 
 - **`vpk shard`** — Phase 2: cross-node shard placement with trust-weighted, geography-aware, capacity-aware policies
 - **`vpk resolve`** — Phase 3: DHT-backed knowledge base resolution for fully distributed personal AI memory


### PR DESCRIPTION
## Why

`projects/kwaai-storage/roadmap.md` lists **"Multi-tenant vector tables with
homomorphic-encrypted search"** under `## Shipped`. The code stores plaintext `f32` and
searches with plain cosine (`db.rs` — `Hnsw<'static, f32, DistCosine>`).

The v1 roadmap analysis called this the single largest vision-vs-reality gap in the tree.
Checking it turned up three more present-tense assertions of the same capability:

| File | Claim |
|---|---|
| `roadmap.md` | listed under `## Shipped` |
| `CLAUDE.md` | scope line + crate table + `vectors.rs` described as "Homomorphic vector search" |
| `design/overview.md` | "vectors are homomorphically encrypted" + diagram label |
| `design/data-flows.md` | "homomorphic cosine search (encrypted space)" |

## What

Each replaced with what is true today, and the real plan recorded under `## Planned`:
integrate the PHE crate's **ROME** (Random Orthogonal Matrix Encryption) so Bob scrambles
vectors before upload and the host stores them without knowing whether they are scrambled.

That integration is unusually cheap. `vector_dimension` is already per-tenant
(`api.rs:112`) and search is plain cosine; ROME preserves inner products exactly, so a
padded vector is simply a tenant declaring dimension `m`. **The host needs no code
change**, and ranking is identical to plaintext.

## Threat model, written down

The Planned entry cites the published analysis rather than paraphrasing it —
Kwaai, SIAM 2025, §6 *"Sacking ROME"*: the scheme falls to an actor who sees both the
plaintext and the encrypted form of enough queries, at which point `Q` is recoverable by
linear algebra.

The VPK boundary exists to exclude exactly that actor: the host sees ciphertext only,
never plaintext queries, and does not hold the embedder. The entry states that assumption
explicitly, because the guarantee rests on it and a reader should be able to check it
rather than infer it. It also records that the scheme is deterministic (equal vectors give
equal ciphertexts) and that inner-product preservation lets the host see corpus geometry
without reading any vector.

## Left alone

`requirements.md` FR-S3 still says "Provide homomorphic-encrypted vector search" — a
requirement may state intent, and ROME is partially homomorphic, so it is arguably
satisfied. Flagging rather than deciding.

Separately and **not part of this PR**: `rome.rs` and the PHE README describe ROME as
IND-CPA and semantically secure. IND-CPA is strictly stronger than resistance to
known-plaintext key recovery, so §6 of the public paper refutes those lines. That is a
private repo and the owner's call; noting it here only because this PR is where the public
wording gets set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ADcTPbPciyCRxZPAJRopc
