### PR TITLE
fix(announce): tell the truth about a node that is up but not serving

### DIFF
--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -110,9 +110,10 @@ impl VpkInfo {
 /// trust model (e.g., map.kwaai.ai v2) display trust badges; legacy clients
 /// ignore the field.
 ///
-/// `state` is a **deliberate KwaaiNet divergence** from upstream petals'
-/// `ServerState` enum: `0` joining, `2` ready, `-1` offline. The map decodes
-/// these values directly — preserve them verbatim.
+/// `state` follows petals' `ServerState` — `0` offline, `1` joining, `2`
+/// online — with one KwaaiNet extension: `-1`, an explicit departure tombstone
+/// (a shutdown cannot shorten a record's expiration, so leaving has to be said
+/// in the value). The map decodes these directly; preserve them verbatim.
 pub struct DHTServerInfo {
     pub state: i32,
     pub throughput: f64,

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -153,6 +153,11 @@ pub struct DHTServerInfo {
     /// attempt-and-fallback probe; absence of this key entirely (a legacy
     /// pre-Capacity-Lease peer) is itself the "false" signal on decode.
     pub lease_v1: bool,
+
+    /// A block shard is loading right now, as opposed to this node having
+    /// nothing to load. Only meaningful while `state` is JOINING; encoded only
+    /// when true, so a node that is merely idle says nothing extra.
+    pub shard_loading: bool,
 }
 
 impl DHTServerInfo {
@@ -183,6 +188,7 @@ impl DHTServerInfo {
             vpk_info,
             peer_id_b58,
             lease_v1: true,
+            shard_loading: KwaaiNetConfig::announce_shard_loading(),
         }
     }
 
@@ -244,6 +250,10 @@ impl DHTServerInfo {
                 rmpv::Value::from("trust_attestations"),
                 rmpv::Value::Array(ta_values),
             ));
+        }
+
+        if self.shard_loading {
+            fields.push((rmpv::Value::from("shard_loading"), rmpv::Value::from(true)));
         }
 
         // Include VPK capability when enabled and reachable.
@@ -445,6 +455,7 @@ pub fn build_unannounce_records(
         vpk_info: None,
         peer_id_b58: server_info.peer_id_b58.clone(),
         lease_v1: server_info.lease_v1,
+        shard_loading: false,
     };
 
     let info_bytes = offline_info.to_msgpack()?;
@@ -841,6 +852,7 @@ mod tests {
             vpk_info: vpk,
             peer_id_b58: peer().to_base58(),
             lease_v1: true,
+            shard_loading: false,
         }
     }
 

--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -299,6 +299,7 @@ pub enum ConfigAction {
     ///   model, blocks, start_block, port, use_gpu, log_level,
     ///   public_name, public_ip, announce_addr, no_relay, native_p2p,
     ///   announce_self, enable_upnp, max_connections,
+    ///   announce_online_without_shard,
     ///   decentralized_dht, dht_replication,
     ///   vpk_enabled, vpk_mode, vpk_local_port,
     ///   auto_rebalance, rebalance_interval_secs, rebalance_min_redundancy

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -298,7 +298,7 @@ pub struct KwaaiNetConfig {
     pub dht_replication: usize,
     /// Announce `state=2` (ONLINE) even when no shard server is running.
     ///
-    /// Off by default, and deliberately so. A node announces `state=0`
+    /// Off by default, and deliberately so. A node announces `state=1`
     /// (JOINING) until `shard serve` reports its model loaded, because
     /// `shard run` filters on `state==2`: a node claiming ONLINE without an
     /// `/kwaai/inference/1.0.0` handler gets dialled and fails the session
@@ -1024,7 +1024,12 @@ impl KwaaiNetConfig {
         self.native_p2p == Some(false)
     }
 
-    /// The `state` field for a DHT announcement: `2` ONLINE, `0` JOINING.
+    /// The `state` field for a DHT announcement: `2` ONLINE, `1` JOINING.
+    ///
+    /// Not-serving is `1`, not `0`: petals' enum is `OFFLINE = 0, JOINING = 1,
+    /// ONLINE = 2`, and a node reaching this code is up and announcing, so `0`
+    /// (which the map rendered as "offline", indistinguishable from the `-1`
+    /// departure tombstone) was a lie about a healthy node.
     ///
     /// ONLINE means "this node will serve inference", not merely "this node is
     /// up" — `shard run` filters on `state == 2`, so a node that claims it
@@ -1051,7 +1056,7 @@ impl KwaaiNetConfig {
         }
         match Self::load_or_create() {
             Ok(cfg) if cfg.announce_online_without_shard => 2,
-            _ => 0,
+            _ => 1,
         }
     }
 

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -1509,18 +1509,19 @@ mod native_p2p_tri_state {
     }
 }
 
+/// Serialises the tests that drive `KWAAINET_HOME`, crate-wide.
+///
+/// The var is process-global. These tests each point it at their own tempdir
+/// and some remove it when done, so run concurrently one test reads another's
+/// directory — or none at all — and sees the wrong config back. One lock for
+/// the whole crate, not one per module: the racing tests live in different
+/// files (`config`, `daemon`), and per-module mutexes never serialise those.
+#[cfg(test)]
+pub(crate) static HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Serialises the tests that drive `KWAAINET_HOME`.
-    ///
-    /// The var is process-global. These tests each point it at their own
-    /// tempdir and some remove it when done, so run concurrently one test
-    /// reads another's directory — or none at all — and sees the wrong
-    /// config back. Identical block on every branch that adds such a test,
-    /// so the copies merge as a duplicate rather than a conflict.
-    static HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn cfg(start: u32, blocks: u32, total_hint: &str) -> KwaaiNetConfig {
         KwaaiNetConfig {

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -1031,6 +1031,12 @@ impl KwaaiNetConfig {
     /// (which the map rendered as "offline", indistinguishable from the `-1`
     /// departure tombstone) was a lie about a healthy node.
     ///
+    /// Every consumer that survives the native migration filters on `== 2`. The
+    /// one that read this as a threshold — a python petals server's
+    /// `block_selection`, counting everything `>= JOINING` — would weigh a node
+    /// that may never load a shard; it matters again only if a
+    /// `petals.cli.run_server` ever rejoins the swarm.
+    ///
     /// ONLINE means "this node will serve inference", not merely "this node is
     /// up" — `shard run` filters on `state == 2`, so a node that claims it
     /// without anything to serve gets dialled and fails the session with

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -296,6 +296,21 @@ pub struct KwaaiNetConfig {
     /// when `decentralized_dht` is false.
     #[serde(default = "default_dht_replication")]
     pub dht_replication: usize,
+    /// Announce `state=2` (ONLINE) even when no shard server is running.
+    ///
+    /// Off by default, and deliberately so. A node announces `state=0`
+    /// (JOINING) until `shard serve` reports its model loaded, because
+    /// `shard run` filters on `state==2`: a node claiming ONLINE without an
+    /// `/kwaai/inference/1.0.0` handler gets dialled and fails the session
+    /// with "protocols not supported".
+    ///
+    /// Turn it on only where that cannot happen — a topology test exercising
+    /// NAT traversal, relays and hole punching, where no inference is served
+    /// and no client will route to these nodes. It exists because such a
+    /// topology otherwise shows every node as offline on the map, which
+    /// obscures the connectivity it is there to test.
+    #[serde(default)]
+    pub announce_online_without_shard: bool,
 
     #[serde(default)]
     pub health_monitoring: HealthConfig,
@@ -902,6 +917,7 @@ impl Default for KwaaiNetConfig {
             announce_self: true,
             decentralized_dht: false,
             dht_replication: default_dht_replication(),
+            announce_online_without_shard: false,
             health_monitoring: HealthConfig::default(),
             model_dht_prefix: None,
             model_repository: None,
@@ -1239,6 +1255,9 @@ impl KwaaiNetConfig {
                 }
                 self.dht_replication = k;
             }
+            "announce_online_without_shard" => {
+                self.announce_online_without_shard = parse_bool(value)?
+            }
             "start_block" => {
                 self.start_block =
                     Some(value.parse().map_err(|_| {
@@ -1492,6 +1511,24 @@ mod tests {
             blocks,
             ..KwaaiNetConfig::default()
         }
+    }
+
+    #[test]
+    fn announce_online_without_shard_defaults_off() {
+        // The default has to stay false. Announcing ONLINE without a loaded
+        // shard is what `shard run` filters on, so a node that does it gets
+        // dialled and fails the session with "protocols not supported" — the
+        // exact bug the state gate was introduced to fix.
+        assert!(!KwaaiNetConfig::default().announce_online_without_shard);
+    }
+
+    #[test]
+    fn announce_online_without_shard_round_trips() {
+        let mut c = KwaaiNetConfig::default();
+        c.set_key("announce_online_without_shard", "true").unwrap();
+        assert!(c.announce_online_without_shard);
+        c.set_key("announce_online_without_shard", "false").unwrap();
+        assert!(!c.announce_online_without_shard);
     }
 
     #[test]

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -1038,11 +1038,20 @@ impl KwaaiNetConfig {
     /// nodes announced JOINING for as long as they ran, which put them off the
     /// map and, worse, out of `shard run`'s candidate set while they were
     /// serving perfectly well.
+    ///
+    /// `announce_online_without_shard` overrides the gate entirely for topology
+    /// tests, which serve no inference and would otherwise show every node as
+    /// offline on the map — hiding the connectivity they exist to exercise.
+    ///
+    /// Lives beside the flag it reads, and reachable from both the p2pd and the
+    /// native announce paths, so the two cannot drift on what ONLINE means.
     pub fn announce_state() -> i32 {
         if ShardManager::shard_is_ready() || ShardManager::whole_model_is_ready() {
-            2
-        } else {
-            0
+            return 2;
+        }
+        match Self::load_or_create() {
+            Ok(cfg) if cfg.announce_online_without_shard => 2,
+            _ => 0,
         }
     }
 

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -1066,6 +1066,14 @@ impl KwaaiNetConfig {
         }
     }
 
+    /// Whether a block shard is mid-load: `shard serve` is alive but has not
+    /// written its ready sentinel. Both this and "up, serving nothing" announce
+    /// JOINING, and only the node can tell them apart — so it says which, and
+    /// the map stops implying progress that may never come.
+    pub fn announce_shard_loading() -> bool {
+        !ShardManager::shard_is_ready() && ShardManager::new().is_running()
+    }
+
     /// Re-read config.yaml before a save so writes by other processes are kept;
     /// falls back to `self` if the file cannot be read.
     pub fn reloaded(&self) -> Self {

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -1513,6 +1513,15 @@ mod native_p2p_tri_state {
 mod tests {
     use super::*;
 
+    /// Serialises the tests that drive `KWAAINET_HOME`.
+    ///
+    /// The var is process-global. These tests each point it at their own
+    /// tempdir and some remove it when done, so run concurrently one test
+    /// reads another's directory — or none at all — and sees the wrong
+    /// config back. Identical block on every branch that adds such a test,
+    /// so the copies merge as a duplicate rather than a conflict.
+    static HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     fn cfg(start: u32, blocks: u32, total_hint: &str) -> KwaaiNetConfig {
         KwaaiNetConfig {
             model: total_hint.to_string(), // name heuristic drives model_total_blocks()
@@ -1533,6 +1542,15 @@ mod tests {
 
     #[test]
     fn announce_online_without_shard_round_trips() {
+        let _env_lock = HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // `set_key` persists to $KWAAINET_HOME. Without our own tempdir this
+        // writes into whichever directory another test has pointed the var
+        // at — and fails with ENOENT when that test's TempDir drops mid-run.
+        // Harmless on this branch alone; a ~1-in-6 flake once `combined` puts
+        // it alongside the bootstrap-serve tests that drive the same var.
+        let home = tempfile::tempdir().expect("tmpdir");
+        std::env::set_var("KWAAINET_HOME", home.path());
+
         let mut c = KwaaiNetConfig::default();
         c.set_key("announce_online_without_shard", "true").unwrap();
         assert!(c.announce_online_without_shard);

--- a/core/crates/kwaai-cli/src/daemon.rs
+++ b/core/crates/kwaai-cli/src/daemon.rs
@@ -745,6 +745,43 @@ mod whole_model_readiness_tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
+    /// JOINING covers two different situations and the map has to tell them
+    /// apart: a shard part-way through loading, and a node that will never load
+    /// one. The live pid is this test process, which is certainly running.
+    #[test]
+    fn shard_loading_is_only_true_while_a_shard_process_loads() {
+        let _env_lock = crate::config::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = std::env::temp_dir().join(format!("kwaai-loading-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("KWAAINET_HOME", &tmp);
+
+        let shard = ShardManager::new();
+        let _ = std::fs::remove_file(ShardManager::ready_file());
+        shard.remove_pid();
+        assert!(
+            !KwaaiNetConfig::announce_shard_loading(),
+            "no shard process means nothing is loading"
+        );
+
+        shard.write_pid(std::process::id());
+        assert!(
+            KwaaiNetConfig::announce_shard_loading(),
+            "a live shard process with no ready sentinel is loading"
+        );
+
+        std::fs::write(ShardManager::ready_file(), "").unwrap();
+        assert!(
+            !KwaaiNetConfig::announce_shard_loading(),
+            "a loaded shard is serving, not loading"
+        );
+        assert_eq!(KwaaiNetConfig::announce_state(), 2);
+
+        std::env::remove_var("KWAAINET_HOME");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
     /// Live check against this machine's actual Ollama, following the
     /// `live_*` convention: `#[ignore]` alone, because it is read-only against
     /// the network (localhost only) and writes its sentinel into an isolated

--- a/core/crates/kwaai-cli/src/daemon.rs
+++ b/core/crates/kwaai-cli/src/daemon.rs
@@ -759,6 +759,9 @@ mod whole_model_readiness_tests {
     /// Ollama retracts the claim rather than leaving a dead path advertised.
     #[tokio::test]
     #[ignore = "probes the local Ollama on 11434"]
+    // The guard is held across awaits deliberately: it serialises `KWAAINET_HOME`
+    // for the whole test, and a single-threaded test runtime cannot deadlock on it.
+    #[allow(clippy::await_holding_lock)]
     async fn live_whole_model_readiness_tracks_real_ollama() {
         let _env_lock = crate::config::HOME_ENV_LOCK
             .lock()

--- a/core/crates/kwaai-cli/src/daemon.rs
+++ b/core/crates/kwaai-cli/src/daemon.rs
@@ -695,7 +695,7 @@ mod whole_model_readiness_tests {
     use crate::config::KwaaiNetConfig;
 
     /// Regression for #175: a node serving whole models over the Ollama proxy
-    /// must announce ONLINE (2), not JOINING (0).
+    /// must announce ONLINE (2), not JOINING (1).
     ///
     /// `announce_state` gated only on `shard.ready`, which the block-sharding
     /// path writes and the macOS whole-model path deliberately does not — so a
@@ -720,7 +720,7 @@ mod whole_model_readiness_tests {
         assert!(!ShardManager::whole_model_is_ready());
         assert_eq!(
             KwaaiNetConfig::announce_state(),
-            0,
+            1,
             "nothing to serve must stay JOINING"
         );
 
@@ -737,7 +737,7 @@ mod whole_model_readiness_tests {
         ShardManager::clear_whole_model_ready();
         assert_eq!(
             KwaaiNetConfig::announce_state(),
-            0,
+            1,
             "clearing the sentinel must drop back to JOINING"
         );
 
@@ -803,10 +803,10 @@ mod whole_model_readiness_tests {
         );
         assert_eq!(
             KwaaiNetConfig::announce_state(),
-            0,
+            1,
             "with Ollama gone, the node must stop claiming it can serve"
         );
-        eprintln!("announce_state() = 0 (JOINING) with Ollama unreachable");
+        eprintln!("announce_state() = 1 (JOINING) with Ollama unreachable");
 
         std::env::remove_var("KWAAINET_HOME");
         let _ = std::fs::remove_dir_all(&tmp);

--- a/core/crates/kwaai-cli/src/daemon.rs
+++ b/core/crates/kwaai-cli/src/daemon.rs
@@ -707,6 +707,9 @@ mod whole_model_readiness_tests {
     /// `KWAAINET_HOME`, so they must not run against a live node's run dir.
     #[test]
     fn whole_model_serving_announces_online() {
+        let _env_lock = crate::config::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!("kwaai-wm-ready-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
         std::env::set_var("KWAAINET_HOME", &tmp);
@@ -757,6 +760,9 @@ mod whole_model_readiness_tests {
     #[tokio::test]
     #[ignore = "probes the local Ollama on 11434"]
     async fn live_whole_model_readiness_tracks_real_ollama() {
+        let _env_lock = crate::config::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!("kwaai-wm-live-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
         std::env::set_var("KWAAINET_HOME", &tmp);
@@ -811,6 +817,9 @@ mod whole_model_readiness_tests {
     /// implies, and a whole-model node has none.
     #[test]
     fn whole_model_readiness_does_not_imply_a_block_shard() {
+        let _env_lock = crate::config::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!("kwaai-wm-distinct-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
         std::env::set_var("KWAAINET_HOME", &tmp);

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -2244,10 +2244,17 @@ mod tests {
     struct EnvGuard {
         prev_home: Option<std::ffi::OsString>,
         prev_kwaainet_home: Option<std::ffi::OsString>,
+        /// `TEST_LOCK` above serialises these tests against each other only.
+        /// `KWAAINET_HOME` is process-global, so the guard also holds the
+        /// crate-wide lock the tests in other modules take.
+        _home_env: std::sync::MutexGuard<'static, ()>,
     }
 
     impl EnvGuard {
         fn set(dir: &std::path::Path) -> Self {
+            let _home_env = crate::config::HOME_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             let prev_home = std::env::var_os("HOME");
             let prev_kwaainet_home = std::env::var_os("KWAAINET_HOME");
             std::env::set_var("HOME", dir);
@@ -2255,6 +2262,7 @@ mod tests {
             Self {
                 prev_home,
                 prev_kwaainet_home,
+                _home_env,
             }
         }
     }

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -1154,7 +1154,7 @@ async fn announce(
     let node_info = NodeInfo::from_peer_id(peer_id);
 
     // Build block STORE request — always announce configured blocks so the node
-    // appears on the map. State=0 (joining) when shard is not yet loaded.
+    // appears on the map. State=1 (joining) when shard is not yet loaded.
     {
         let mut keys = Vec::new();
         let mut subkeys = Vec::new();

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -37,6 +37,28 @@ type SharedStorage = Arc<RwLock<DHTStorage>>;
 
 use crate::announce::{dht_id, DHTServerInfo, ModelInfo, VpkInfo};
 
+/// The `state` field for a DHT announcement: `2` ONLINE, `0` JOINING.
+///
+/// ONLINE means "this node will serve inference", not merely "this node is
+/// up" — `shard run` filters on `state == 2`, so a node that claims it
+/// without a loaded shard gets dialled and fails the session with "protocols
+/// not supported". Hence the gate on `shard_is_ready()`.
+///
+/// `announce_online_without_shard` overrides that for topology tests, which
+/// serve no inference and would otherwise show every node as offline on the
+/// map — hiding the connectivity they exist to exercise. Reading the config
+/// here rather than threading a flag through every call site keeps the rule
+/// in one place.
+fn announce_state() -> i32 {
+    if ShardManager::shard_is_ready() {
+        return 2;
+    }
+    match KwaaiNetConfig::load_or_create() {
+        Ok(cfg) if cfg.announce_online_without_shard => 2,
+        _ => 0,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -699,6 +699,7 @@ pub async fn run_node(config: &KwaaiNetConfig, grpc_port: Option<u16>) -> Result
                 server_info.start_block = sb;
                 server_info.end_block = eb;
                 server_info.state = KwaaiNetConfig::announce_state();
+                server_info.shard_loading = KwaaiNetConfig::announce_shard_loading();
                 if let Err(e) = announce(
                     &mut client, peer_id, &storage, &bootstrap_peers,
                     &prefix, &repository, config.model_total_blocks(),
@@ -829,6 +830,7 @@ pub async fn run_node(config: &KwaaiNetConfig, grpc_port: Option<u16>) -> Result
                 // come and go under a long-running node.
                 crate::ollama::refresh_whole_model_ready(config.ollama_port).await;
                 server_info.state = KwaaiNetConfig::announce_state();
+                server_info.shard_loading = KwaaiNetConfig::announce_shard_loading();
                 info!(
                     "Re-announcing to DHT (shard_ready={}, whole_model_ready={})...",
                     ShardManager::shard_is_ready(),
@@ -1054,6 +1056,7 @@ async fn unannounce(
         vpk_info: None,
         peer_id_b58: server_info.peer_id_b58.clone(),
         lease_v1: server_info.lease_v1,
+        shard_loading: false,
     };
     // Use the same 360 s TTL as a regular announcement — Hivemind bootstrap
     // peers reject updates with a shorter TTL than the existing record.

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -37,28 +37,6 @@ type SharedStorage = Arc<RwLock<DHTStorage>>;
 
 use crate::announce::{dht_id, DHTServerInfo, ModelInfo, VpkInfo};
 
-/// The `state` field for a DHT announcement: `2` ONLINE, `0` JOINING.
-///
-/// ONLINE means "this node will serve inference", not merely "this node is
-/// up" — `shard run` filters on `state == 2`, so a node that claims it
-/// without a loaded shard gets dialled and fails the session with "protocols
-/// not supported". Hence the gate on `shard_is_ready()`.
-///
-/// `announce_online_without_shard` overrides that for topology tests, which
-/// serve no inference and would otherwise show every node as offline on the
-/// map — hiding the connectivity they exist to exercise. Reading the config
-/// here rather than threading a flag through every call site keeps the rule
-/// in one place.
-fn announce_state() -> i32 {
-    if ShardManager::shard_is_ready() {
-        return 2;
-    }
-    match KwaaiNetConfig::load_or_create() {
-        Ok(cfg) if cfg.announce_online_without_shard => 2,
-        _ => 0,
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -792,6 +792,7 @@ fn refresh_server_info(server_info: &mut DHTServerInfo, config: &KwaaiNetConfig)
     server_info.start_block = config.start_block() as i32;
     server_info.end_block = config.effective_end_block() as i32;
     server_info.state = KwaaiNetConfig::announce_state();
+    server_info.shard_loading = KwaaiNetConfig::announce_shard_loading();
 }
 
 /// Fold one announce round's per-bootstrap timings into the reputation store.

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -329,8 +329,8 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
     //
     // So a Mac does not register as a block server. It serves whole-model
     // inference over `/kwaai/ollama-proxy/1.0.0`, which every node already
-    // registers, and stays at announce state 0 ("online, no shard") because no
-    // shard ever loads — no announce change needed.
+    // registers, and stays at announce state 1 (JOINING) because no shard ever
+    // loads — no announce change needed.
     //
     // Stopgap. Delete this branch when an Apple fast path lands: MLX
     // (`mlx_shard.rs`) already implements sharding and failed only on graph
@@ -660,7 +660,7 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
             // The PID file normally comes from the supervised launch path, but
             // `shard_is_ready()` requires it (ready sentinel AND live process),
             // so a standalone `kwaainet shard serve` must write its own or the
-            // node announces state 0 (map: "offline") forever.
+            // node announces state 1 (JOINING) forever.
             crate::daemon::ShardManager::new().write_pid(std::process::id());
             let ready_file = crate::daemon::ShardManager::ready_file();
             let _ = std::fs::write(&ready_file, "");
@@ -2551,7 +2551,7 @@ async fn pick_gap_blocks(
 fn decode_server_info_regular(bytes: &[u8]) -> Option<(String, BlockServerEntry)> {
     let (state, start_block, end_block, public_name, peer_id_b58, version, throughput, lease_v1) =
         decode_server_info_ext(bytes)?;
-    // Only include ONLINE nodes (state=2); skip JOINING (0) and OFFLINE (-1).
+    // Only include ONLINE nodes (state=2); skip JOINING (1) and OFFLINE (0/-1).
     if state != 2 {
         return None;
     }


### PR DESCRIPTION
## What

`KwaaiNetConfig::announce_state()` decides the `state` field every node writes into its DHT records. Two things were wrong with it, and this branch fixes both:

1. **A node serving whole models announced JOINING forever.** An Apple-silicon node serves over `/kwaai/ollama-proxy/1.0.0` and deliberately loads no block shard, but the gate only looked at the block-shard sentinel. Those nodes were off the map and out of `shard run`'s candidate set while serving perfectly well. `announce_state()` now also accepts whole-model readiness, and `refresh_whole_model_ready` retracts the claim when Ollama goes away.

2. **"Not serving" was announced as `0`, which is petals' OFFLINE.** Petals' enum is `OFFLINE = 0, JOINING = 1, ONLINE = 2`, and petals itself uses `OFFLINE` as its *shutdown* announcement (`server.py:542`, `:650`) — so a node that was up, reachable and re-announcing on a timer published the same value as one that had gone away. The map rendered it "offline", indistinguishable from KwaaiNet's own `-1` departure tombstone. It now announces `1` (JOINING), which is what the doc comment already claimed it did.

Also here: `announce_online_without_shard`, an off-by-default config key that forces ONLINE for topology tests, which serve no inference and would otherwise show every node as dead on the map; `announce_state()` moved onto `KwaaiNetConfig` so the p2pd and native announce paths cannot drift on what ONLINE means; and test serialisation for the `KWAAINET_HOME` env var these tests move around.

## Behaviour

No routing or selection behaviour changes with `0` -> `1`. Every consumer in the stack filters on `state == 2`: `shard run`'s candidate sets and chain decoder, the rebalancer, both map generations' block coverage, the node health monitors. The GUI never sees the field (`BlockPeer` carries no state).

One consumer read it as a *threshold* rather than an equality — a python petals server's `block_selection`, which counts everything `>= JOINING` — so a non-serving node would be weighed when such a server places its own blocks. No `petals.cli.run_server` is deployed since the native migration of the bootstraps and maps, so this costs nothing today; it is recorded in the doc comment so a future one does not surprise anyone.

Consumers reading the *map's* JSON are unaffected — `/api/v1/state` still carries `online|joining|offline`. The KwaaiNetMap side of this (rendering those as Sharding / Ready / Departed, and fixing `reachability_issues` to mean failed dials rather than non-ONLINE announcements) is a separate change in that repo.

## Checks

`cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, `cargo test -p kwaainet` (251 passed) — all clean on the rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)