### PR TITLE
fix(p2p): stop three bootstrap-reseed tests panicking on a fresh Windows runner

### DIFF
--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -2347,6 +2347,20 @@ mod tests {
 
     const TICK: Duration = Duration::from_secs(300);
 
+    /// A base instant far enough ahead of the process start that a test can
+    /// subtract from it.
+    ///
+    /// `Instant` is monotonic from an arbitrary epoch, and on Windows that
+    /// epoch is close enough to boot that `Instant::now() - TICK * 10` (50
+    /// minutes) underflows on a runner that booted more recently than that.
+    /// `Instant`'s `Sub` impl `expect`s on the overflow, so the test panics
+    /// rather than failing an assertion — and only on Windows, and only when
+    /// the runner happens to be fresh. Shifting the base forward keeps the
+    /// arithmetic identical and cannot underflow.
+    fn base_instant() -> Instant {
+        Instant::now() + TICK * 100
+    }
+
     fn addr_of(peer: PeerId) -> Multiaddr {
         format!("/ip4/198.51.100.1/tcp/8000/p2p/{peer}")
             .parse()
@@ -2356,7 +2370,7 @@ mod tests {
     #[test]
     fn a_bootstrap_we_are_connected_to_is_left_alone() {
         let peer = PeerId::random();
-        let now = Instant::now();
+        let now = base_instant();
         let connected = HashSet::from([peer]);
         // Stale `last_connected` on purpose: a long-lived connection is not
         // re-established, so recency alone would misread it as lost.
@@ -2367,7 +2381,7 @@ mod tests {
     #[test]
     fn a_bootstrap_seen_within_the_window_is_left_alone() {
         let peer = PeerId::random();
-        let now = Instant::now();
+        let now = base_instant();
         let last = HashMap::from([(peer, now - TICK / 2)]);
         let addrs = [addr_of(peer)];
         let selected = bootstraps_to_reseed(&addrs, &HashSet::new(), &last, now, TICK);
@@ -2401,7 +2415,7 @@ mod tests {
     #[test]
     fn a_bootstrap_last_seen_before_the_window_is_redialled() {
         let peer = PeerId::random();
-        let now = Instant::now();
+        let now = base_instant();
         let last = HashMap::from([(peer, now - TICK * 2)]);
         let addrs = [addr_of(peer)];
         let selected = bootstraps_to_reseed(&addrs, &HashSet::new(), &last, now, TICK);


### PR DESCRIPTION
## What

`main` has been red on `Test (windows-latest)` since #168. This fixes it.

`a_bootstrap_we_are_connected_to_is_left_alone` computes `Instant::now() - TICK * 10` — 50 minutes. `Instant` is monotonic from an arbitrary epoch, and on Windows that epoch is close enough to boot that the subtraction underflows on a runner which booted more recently than that. `Instant`'s `Sub` impl `expect`s on the overflow, so it panics inside `std::time` rather than failing an assertion:

```
core::option::expect_failed
std::time::impl$3::sub
kwaai_p2p::service::tests::a_bootstrap_we_are_connected_to_is_left_alone
  at .\\src\\service.rs:2363
test result: FAILED. 103 passed; 1 failed
```

Two sibling tests subtract `TICK * 2` and `TICK / 2` from the same base — the same latent bug with a shorter fuse, so all three are moved.

The tests are correct; the *base* is wrong. `base_instant()` shifts it forward by `TICK * 100`, leaving the arithmetic identical and making underflow impossible.

## Why it went unnoticed

Platform-specific and timing-dependent, so it only became visible once #163 made Windows actually run the suite. Since then every push to `main` has failed, while every `pull_request` run stayed green — because the Windows **test** job does not run on PRs, only `Windows check`, which compiles without testing.

That gap is worth a separate look: it is why #181 and #182 both merged onto an already-red `main` today with green PR checks. Either run the Windows test job on PRs, or make the red main visible enough that it blocks.

Confirmed *not* related to the recent merges — `git log -L` puts the line at a9901f69 (#168), and the libp2p-kad patch compiles fine on Windows in the same run (my first hypothesis, that #181's untracking broke the Windows patch fetch, was wrong).

## Checks

`cargo test -p kwaai-p2p --lib` (all three tests pass), `cargo fmt --all --check`, `cargo clippy -p kwaai-p2p --all-targets -D warnings` — clean. The real verification is this PR's own CI, and note the caveat above: if the Windows *test* job does not run on PRs, a green check here does not prove the fix. I would confirm on `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxjE2xfQzk11pqyrwgSLZu