### PR TITLE
feat(announce): publish signed dial addresses so NATed peers can be reached

### DIFF
--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -23,12 +23,14 @@ use anyhow::Result;
 use kwaai_hivemind_dht::protocol::{NodeInfo, RequestAuthInfo, StoreRequest, StoreResponse};
 use kwaai_hivemind_dht::value::get_dht_time;
 use kwaai_p2p::{NetworkHandle, PeerId};
+use libp2p::Multiaddr;
 use prost::Message;
 use sha1::{Digest, Sha1};
 use std::collections::{HashMap, HashSet};
 use tracing::{info, warn};
 
 use crate::config::KwaaiNetConfig;
+use crate::shard_cmd::{version_meets_minimum, BlockServerEntry};
 
 /// TTL applied to every announced record, in seconds.
 ///
@@ -201,12 +203,14 @@ pub struct DHTServerInfo {
     /// the attacker to complete a handshake.
     ///
     /// The envelope closes *that*, and only that.
+    /// [`kwaai_p2p::peer_record::verified_addrs`] is the reader:
     /// `PeerRecord::from_signed_envelope_interop` verifies the signature and
-    /// binds the record's peer id to the signing key, so an address list the
-    /// announced peer did not sign is one the reader drops. The interop format
-    /// (`libp2p-peer-record`) is used rather than rust-libp2p's legacy domain
-    /// because this record is a published wire format that a Go or JS reader
-    /// may one day verify.
+    /// binds the record's peer id to the signing key, and the caller's
+    /// comparison against the announced peer ties it to the peer being dialed
+    /// — so an address list the announced peer did not sign is one the reader
+    /// drops. The interop format (`libp2p-peer-record`) is used rather than
+    /// rust-libp2p's legacy domain because this record is a published wire
+    /// format that a Go or JS reader may one day verify.
     ///
     /// What it does **not** close, because the signature covers the address
     /// list rather than the record: an attacker can still overwrite a peer's
@@ -352,6 +356,227 @@ impl DHTServerInfo {
         let mut out = Vec::new();
         rmpv::encode::write_value(&mut out, &ext)?;
         Ok(out)
+    }
+}
+
+// ── Reading one back ─────────────────────────────────────────────────────────
+//
+// The decoder sits beside `DHTServerInfo::to_msgpack` deliberately. The two
+// halves are one published wire format, and every bug this code has had was a
+// disagreement between them — a key spelled differently, a field the encoder
+// gained and the reader never learned. Side by side they can be tested by
+// round trip through the real producer rather than against a hand-built map,
+// and a field added to one is visibly missing from the other.
+
+/// One decoded announcement, as a struct rather than the positional tuple this
+/// used to return: nine fields where three call sites want different subsets is
+/// exactly the shape where `_`-holes drift out of alignment with the producer.
+pub struct ServerInfoFields {
+    pub state: i32,
+    pub start_block: usize,
+    pub end_block: usize,
+    pub public_name: String,
+    pub peer_id_b58: String,
+    pub version: String,
+    pub throughput: f64,
+    pub lease_v1: bool,
+    /// Verified multiaddrs the peer can be dialed on, **bare** — the
+    /// destination `/p2p/<peer>` stripped and a circuit's relay hop kept,
+    /// exactly as [`kwaai_p2p::peer_record::verified_addrs`] returns them.
+    /// Empty for a peer that published none, and for one whose record did not
+    /// verify.
+    pub dial_addrs: Vec<Multiaddr>,
+}
+
+pub fn decode_server_info_ext(bytes: &[u8]) -> Option<ServerInfoFields> {
+    let val = rmpv::decode::read_value(&mut &bytes[..]).ok()?;
+    let inner_bytes = match &val {
+        rmpv::Value::Ext(64, b) => b.as_slice(),
+        _ => return None,
+    };
+    let inner = rmpv::decode::read_value(&mut &inner_bytes[..]).ok()?;
+    let arr = inner.as_array()?;
+    if arr.len() < 3 {
+        return None;
+    }
+    let map = arr[2].as_map()?;
+
+    let get_i = |k: &str| -> Option<i64> {
+        map.iter()
+            .find(|(ky, _)| ky.as_str() == Some(k))
+            .and_then(|(_, v)| v.as_i64())
+    };
+    let get_s = |k: &str| -> String {
+        map.iter()
+            .find(|(ky, _)| ky.as_str() == Some(k))
+            .and_then(|(_, v)| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+
+    let state = arr[0].as_i64().unwrap_or(0) as i32;
+    let throughput = arr[1].as_f64().unwrap_or(0.0);
+    let start_block = get_i("start_block")? as usize;
+    let end_block = get_i("end_block")? as usize;
+    let public_name = get_s("public_name");
+    let peer_id_b58 = get_s("peer_id");
+    let version = get_s("version");
+    // Absent key (a peer built before Capacity Lease existed) defaults to
+    // false — the exact "legacy peer" signal a requester falls back on.
+    let lease_v1 = map
+        .iter()
+        .find(|(ky, _)| ky.as_str() == Some("lease_v1"))
+        .and_then(|(_, v)| v.as_bool())
+        .unwrap_or(false);
+
+    // The record is only worth reading against the peer it claims to be, and
+    // that binding is the whole of the check — see `verified_addrs`. A record
+    // whose `peer_id` does not parse has nothing to bind to, so it yields no
+    // addresses rather than unverified ones.
+    let dial_addrs = map
+        .iter()
+        .find(|(ky, _)| ky.as_str() == Some("addrs_signed"))
+        .and_then(|(_, v)| v.as_slice())
+        .zip(peer_id_b58.parse::<PeerId>().ok())
+        .map(|(envelope, claimed)| kwaai_p2p::peer_record::verified_addrs(envelope, claimed))
+        .unwrap_or_default();
+
+    Some(ServerInfoFields {
+        state,
+        start_block,
+        end_block,
+        public_name,
+        peer_id_b58,
+        version,
+        throughput,
+        lease_v1,
+        dial_addrs,
+    })
+}
+
+/// Parse `Ext(64, [state, throughput, {start_block, end_block, peer_id, …}])`
+/// from a FoundRegular value.
+///
+/// Returns `(dedup_key, entry)`.  Legacy nodes (pre-v0.3.3) omit `peer_id`; we
+/// synthesise a stable key from `public_name:start_block` so they still count
+/// for gap detection even though they cannot be routed to directly.
+pub fn decode_server_info_regular(bytes: &[u8]) -> Option<(String, BlockServerEntry)> {
+    let info = decode_server_info_ext(bytes)?;
+    // Only include ONLINE nodes (state=2); skip JOINING (1) and OFFLINE (0/-1).
+    if info.state != 2 {
+        return None;
+    }
+    if !version_meets_minimum(&info.version) {
+        return None;
+    }
+    let (dedup_key, peer_id) = match info.peer_id_b58.parse::<PeerId>() {
+        Ok(pid) => (pid.to_base58(), pid),
+        Err(_) => {
+            let key = format!("legacy:{}:{}", info.public_name, info.start_block);
+            (key, PeerId::random())
+        }
+    };
+    Some((
+        dedup_key,
+        BlockServerEntry {
+            peer_id,
+            start_block: info.start_block,
+            end_block: info.end_block,
+            public_name: info.public_name,
+            throughput: info.throughput,
+            trust_score: None,
+            lease_v1: info.lease_v1,
+            dial_addrs: info.dial_addrs,
+        },
+    ))
+}
+
+/// Parse `Ext(80, [expiry, created, [[subkey_bytes, value_bytes, expiry], …]])`
+/// from a FoundDictionary value. Appends into `out` (deduplicates by peer_id).
+pub fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockServerEntry>) {
+    let outer = match rmpv::decode::read_value(&mut &bytes[..]) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let inner_bytes = match &outer {
+        rmpv::Value::Ext(80, b) => b.as_slice(),
+        _ => return,
+    };
+    let inner = match rmpv::decode::read_value(&mut &inner_bytes[..]) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let outer_arr = match inner.as_array() {
+        Some(a) if a.len() >= 3 => a,
+        _ => return,
+    };
+    let entries = match outer_arr[2].as_array() {
+        Some(e) => e,
+        None => return,
+    };
+
+    for entry in entries {
+        let arr = match entry.as_array() {
+            Some(a) if a.len() >= 2 => a,
+            _ => continue,
+        };
+
+        // Subkey is rmp_serde::to_vec(&peer_id_base58) = msgpack(string)
+        let peer_id_b58 = match &arr[0] {
+            rmpv::Value::String(s) => s.as_str().unwrap_or("").to_string(),
+            rmpv::Value::Binary(b) => {
+                // Decode as msgpack string
+                match rmpv::decode::read_value(&mut b.as_slice()) {
+                    Ok(rmpv::Value::String(s)) => s.as_str().unwrap_or("").to_string(),
+                    _ => continue,
+                }
+            }
+            _ => continue,
+        };
+
+        let value_bytes = match &arr[1] {
+            rmpv::Value::Binary(b) => b.as_slice(),
+            _ => continue,
+        };
+
+        if peer_id_b58.is_empty() {
+            continue;
+        }
+
+        let peer_id = match peer_id_b58.parse::<PeerId>() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        if let Some(info) = decode_server_info_ext(value_bytes) {
+            if info.state != 2 {
+                continue;
+            }
+            if !version_meets_minimum(&info.version) {
+                continue;
+            }
+            // The entry is identified by its *subkey*, but the signature was
+            // checked against the `peer_id` inside the value — and one writer
+            // controls both. A value naming a different peer than the subkey
+            // it sits under would hand this entry `peer_id` from the subkey
+            // and addresses belonging to whoever the value names. Legacy
+            // records omit `peer_id` entirely, so only a present-and-different
+            // one is a contradiction.
+            if !info.peer_id_b58.is_empty() && info.peer_id_b58 != peer_id_b58 {
+                continue;
+            }
+            let key = peer_id_b58.clone();
+            out.entry(key).or_insert(BlockServerEntry {
+                peer_id,
+                start_block: info.start_block,
+                end_block: info.end_block,
+                public_name: info.public_name,
+                throughput: info.throughput,
+                trust_score: None,
+                lease_v1: info.lease_v1,
+                dial_addrs: info.dial_addrs,
+            });
+        }
     }
 }
 
@@ -1673,5 +1898,285 @@ mod tests {
 
         let _ = handle.shutdown().await;
         let _ = task.await;
+    }
+
+    /// Build a minimal `Ext(64, [state, throughput, {fields}])` blob matching
+    /// `DHTServerInfo::to_msgpack()`'s shape, with `lease_v1` present or
+    /// absent — mirrors what a real (or legacy, pre-Capacity-Lease) peer's
+    /// DHT announcement decodes from.
+    fn make_server_info_ext_bytes(lease_v1: Option<bool>) -> Vec<u8> {
+        let mut fields = vec![
+            (rmpv::Value::from("start_block"), rmpv::Value::from(0i64)),
+            (rmpv::Value::from("end_block"), rmpv::Value::from(32i64)),
+            (
+                rmpv::Value::from("public_name"),
+                rmpv::Value::from("test-node"),
+            ),
+            (
+                rmpv::Value::from("peer_id"),
+                rmpv::Value::from(PeerId::random().to_base58().as_str()),
+            ),
+            (
+                rmpv::Value::from("version"),
+                rmpv::Value::from("kwaai-0.5.4"),
+            ),
+        ];
+        if let Some(v) = lease_v1 {
+            fields.push((rmpv::Value::from("lease_v1"), rmpv::Value::from(v)));
+        }
+        let inner = rmpv::Value::Array(vec![
+            rmpv::Value::from(2i32), // state = ONLINE
+            rmpv::Value::from(10.0), // throughput
+            rmpv::Value::Map(fields),
+        ]);
+        let mut inner_bytes = Vec::new();
+        rmpv::encode::write_value(&mut inner_bytes, &inner).unwrap();
+        let ext = rmpv::Value::Ext(64, inner_bytes);
+        let mut out = Vec::new();
+        rmpv::encode::write_value(&mut out, &ext).unwrap();
+        out
+    }
+
+    #[test]
+    fn decode_server_info_ext_reads_lease_v1_when_present() {
+        let bytes = make_server_info_ext_bytes(Some(true));
+        let info = decode_server_info_ext(&bytes).expect("decodes");
+        assert!(info.lease_v1);
+    }
+
+    /// Helper: one entry wrapped in the `Ext(80, [expiry, created, [[subkey,
+    /// value, expiry]]])` shape a FoundDictionary response carries.
+    fn dictionary_bytes(subkey_peer_b58: &str, value: &[u8]) -> Vec<u8> {
+        let subkey = rmp_serde::to_vec(&subkey_peer_b58).expect("msgpack subkey");
+        let entry = rmpv::Value::Array(vec![
+            rmpv::Value::Binary(subkey),
+            rmpv::Value::Binary(value.to_vec()),
+            rmpv::Value::from(0.0),
+        ]);
+        let inner = rmpv::Value::Array(vec![
+            rmpv::Value::from(0.0),
+            rmpv::Value::from(0.0),
+            rmpv::Value::Array(vec![entry]),
+        ]);
+        let mut inner_bytes = Vec::new();
+        rmpv::encode::write_value(&mut inner_bytes, &inner).expect("encodes");
+        let mut out = Vec::new();
+        rmpv::encode::write_value(&mut out, &rmpv::Value::Ext(80, inner_bytes)).expect("encodes");
+        out
+    }
+
+    /// Helper: a signed envelope for `key` naming `addrs`, exactly as the
+    /// publisher emits one.
+    fn signed_envelope(key: &libp2p::identity::Keypair, addrs: &[&str]) -> Vec<u8> {
+        let addrs = addrs
+            .iter()
+            .map(|a| a.parse().expect("a valid addr"))
+            .collect();
+        libp2p::core::PeerRecord::new_interop(key, addrs)
+            .expect("signs")
+            .into_signed_envelope()
+            .into_protobuf_encoding()
+    }
+
+    /// The publisher's own encoder is the producer of record, so the decoder is
+    /// tested against what it emits rather than against a hand-built map. The
+    /// address comes back bare, the form the daemon takes and keeps in its
+    /// learned-address map.
+    #[test]
+    fn decode_server_info_ext_round_trips_a_signed_address() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let mut published = DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            peer.to_base58(),
+        );
+        published.signed_addrs = signed_envelope(&key, &["/ip4/203.0.113.7/tcp/4001"]);
+
+        let info =
+            decode_server_info_ext(&published.to_msgpack().expect("encodes")).expect("decodes");
+        assert_eq!(
+            info.dial_addrs,
+            vec!["/ip4/203.0.113.7/tcp/4001".parse::<Multiaddr>().unwrap()]
+        );
+    }
+
+    /// The attack the signature exists to stop: anyone may write under any
+    /// subkey, so a record whose addresses were signed by a different key must
+    /// yield nothing — the peer falls back to a bare-PeerId dial rather than
+    /// being steered at an address its own key never vouched for.
+    #[test]
+    fn decode_server_info_ext_rejects_addresses_signed_by_another_key() {
+        let victim = libp2p::identity::Keypair::generate_ed25519()
+            .public()
+            .to_peer_id();
+        let attacker = libp2p::identity::Keypair::generate_ed25519();
+        let mut forged = DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            victim.to_base58(),
+        );
+        forged.signed_addrs = signed_envelope(&attacker, &["/ip4/198.51.100.9/tcp/4001"]);
+
+        let info = decode_server_info_ext(&forged.to_msgpack().expect("encodes")).expect("decodes");
+        assert!(
+            info.dial_addrs.is_empty(),
+            "an address list the announced peer did not sign must not be dialed"
+        );
+        assert_eq!(
+            info.public_name, "test-node",
+            "the rest of the record still decodes"
+        );
+    }
+
+    /// Garbage in the field costs the addresses, not the record.
+    #[test]
+    fn decode_server_info_ext_ignores_an_unparseable_envelope() {
+        let peer = PeerId::random();
+        let mut info = DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            peer.to_base58(),
+        );
+        info.signed_addrs = vec![0xde, 0xad, 0xbe, 0xef];
+
+        let decoded =
+            decode_server_info_ext(&info.to_msgpack().expect("encodes")).expect("decodes");
+        assert!(decoded.dial_addrs.is_empty());
+        assert_eq!(
+            decoded.end_block, 32,
+            "the rest of the record still decodes"
+        );
+    }
+
+    /// The dictionary path keys an entry by its *subkey* but verified the
+    /// signature against the value's `peer_id`, and one writer controls both.
+    /// A value naming a different peer must be dropped, or the entry would
+    /// carry the victim's peer id beside a stranger's addresses.
+    #[test]
+    fn decode_server_info_dictionary_drops_a_value_naming_another_peer() {
+        let victim = PeerId::random();
+        let attacker = libp2p::identity::Keypair::generate_ed25519();
+        let mut forged = DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            attacker.public().to_peer_id().to_base58(),
+        );
+        forged.state = 2;
+        forged.signed_addrs = signed_envelope(&attacker, &["/ip4/198.51.100.9/tcp/4001"]);
+
+        let mut out = HashMap::new();
+        decode_server_info_dictionary(
+            &dictionary_bytes(&victim.to_base58(), &forged.to_msgpack().expect("encodes")),
+            &mut out,
+        );
+        assert!(
+            out.is_empty(),
+            "an entry whose value names a peer other than its subkey must not be used"
+        );
+    }
+
+    /// The same shape, honestly published, still decodes — so the check above
+    /// rejects the contradiction rather than the dictionary path itself.
+    #[test]
+    fn decode_server_info_dictionary_keeps_a_value_matching_its_subkey() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let mut honest = DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            peer.to_base58(),
+        );
+        honest.state = 2;
+        honest.signed_addrs = signed_envelope(&key, &["/ip4/203.0.113.7/tcp/4001"]);
+
+        let mut out = HashMap::new();
+        decode_server_info_dictionary(
+            &dictionary_bytes(&peer.to_base58(), &honest.to_msgpack().expect("encodes")),
+            &mut out,
+        );
+        let entry = out.get(&peer.to_base58()).expect("the entry decodes");
+        assert_eq!(
+            entry.dial_addrs,
+            vec!["/ip4/203.0.113.7/tcp/4001".parse::<Multiaddr>().unwrap()]
+        );
+    }
+
+    /// Circuits are the whole motivation, and their shape is the one a dialer
+    /// cannot reconstruct: the relay hop must survive the round trip, and only
+    /// the destination `/p2p` is stripped.
+    #[test]
+    fn decode_server_info_ext_round_trips_a_circuit_address() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let relay = PeerId::random();
+        let circuit = format!("/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit", relay);
+
+        let mut published = DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            peer.to_base58(),
+        );
+        published.signed_addrs = signed_envelope(&key, &[&circuit]);
+
+        let info =
+            decode_server_info_ext(&published.to_msgpack().expect("encodes")).expect("decodes");
+        assert_eq!(info.dial_addrs, vec![circuit.parse::<Multiaddr>().unwrap()]);
+    }
+
+    /// A peer on a binary that predates the field decodes to an empty list,
+    /// not a dropped record — it is still dialable by PeerId if it happens to
+    /// be in the routing table.
+    #[test]
+    fn decode_server_info_ext_defaults_addrs_empty_for_legacy_bytes() {
+        let bytes = make_server_info_ext_bytes(None);
+        let info = decode_server_info_ext(&bytes).expect("decodes");
+        assert_eq!(info.state, 2, "the rest of the record must still decode");
+        assert!(info.dial_addrs.is_empty());
+    }
+
+    #[test]
+    fn decode_server_info_ext_defaults_lease_v1_false_for_legacy_bytes() {
+        // No lease_v1 key at all — exactly what a pre-Capacity-Lease peer's
+        // announcement looks like. Must decode successfully (not error) and
+        // default to false, not panic or silently drop the record.
+        let bytes = make_server_info_ext_bytes(None);
+        let info = decode_server_info_ext(&bytes).expect("decodes");
+        let (state, lease_v1) = (info.state, info.lease_v1);
+        assert_eq!(
+            state, 2,
+            "pre-existing fields must still decode alongside the new one"
+        );
+        assert!(!lease_v1);
     }
 }

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -1263,7 +1263,7 @@ mod tests {
     #[test]
     fn select_dial_addrs_reserves_room_for_a_circuit() {
         let mut listeners: Vec<String> = (1..=MAX_DIAL_ADDRS + 2)
-            .map(|i| format!("/ip6/2001:db8::{i}/tcp/4001"))
+            .map(|i| format!("/ip6/2606:4700::{i}/tcp/4001"))
             .collect();
         listeners.push(format!(
             "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit/p2p/{}",

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -479,7 +479,8 @@ pub const MAX_DIAL_ADDRS: usize = 4;
 /// of the form `<relay-addr>/p2p/<relay>/p2p-circuit/p2p/<us>`, already carrying
 /// both hops a dialer needs. Three filters apply:
 ///
-/// - [`is_announceable`](kwaai_p2p::is_announceable) drops the loopback and
+/// - [`is_announceable_with`](kwaai_p2p::is_announceable_with) under the
+///   node's policy (`strict` is `require_global_ips`) drops the loopback and
 ///   RFC1918 listeners that every node has and no remote peer can use, while
 ///   passing circuits unconditionally (the relay's address is the routable
 ///   half).
@@ -509,10 +510,15 @@ pub async fn signed_dial_addrs(
     handle: &NetworkHandle,
     keypair: &libp2p::identity::Keypair,
     declared: Option<&str>,
+    strict: bool,
 ) -> Vec<u8> {
     let external = handle.external_addrs().await.unwrap_or_default();
     let listeners = handle.listen_addrs().await.unwrap_or_default();
-    let addrs = select_dial_addrs(external.into_iter().chain(listeners).collect(), declared);
+    let addrs = select_dial_addrs(
+        external.into_iter().chain(listeners).collect(),
+        declared,
+        strict,
+    );
     if addrs.is_empty() {
         return Vec::new();
     }
@@ -538,15 +544,16 @@ pub async fn signed_dial_addrs(
 fn select_dial_addrs(
     listeners: Vec<libp2p::Multiaddr>,
     declared: Option<&str>,
+    strict: bool,
 ) -> Vec<libp2p::Multiaddr> {
-    use kwaai_p2p::addresses::{peer_id_from_multiaddr, strip_dest_p2p};
-    use kwaai_p2p::{is_announceable, is_circuit, uses_dialable_transport};
+    use kwaai_p2p::addresses::{is_announceable_with, peer_id_from_multiaddr, strip_dest_p2p};
+    use kwaai_p2p::{is_circuit, uses_dialable_transport};
 
     let mut sorted: Vec<libp2p::Multiaddr> = declared
         .and_then(|d| d.parse().ok())
         .into_iter()
         .chain(listeners)
-        .filter(|a| is_announceable(a) && uses_dialable_transport(a))
+        .filter(|a| is_announceable_with(a, strict) && uses_dialable_transport(a))
         .collect();
     // Direct before circuit (`false` sorts before `true`), stably, so the
     // declared address stays ahead of the listeners it was chained onto.
@@ -1196,7 +1203,10 @@ mod tests {
             "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit",
             relay().to_base58()
         );
-        assert_eq!(select_dial_addrs(listeners, None), addrs(&[expected]));
+        assert_eq!(
+            select_dial_addrs(listeners, None, false),
+            addrs(&[expected])
+        );
     }
 
     /// Both circuits cross the same relay, so publishing both spends two of
@@ -1214,7 +1224,7 @@ mod tests {
             peer().to_base58()
         );
 
-        let out = select_dial_addrs(addrs(&[tcp, quic]), None);
+        let out = select_dial_addrs(addrs(&[tcp, quic]), None, false);
         let expected = format!(
             "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit",
             relay().to_base58()
@@ -1231,14 +1241,18 @@ mod tests {
             relay().to_base58(),
             peer().to_base58()
         );
-        assert!(select_dial_addrs(addrs(&[wt]), None).is_empty());
+        assert!(select_dial_addrs(addrs(&[wt]), None, false).is_empty());
     }
 
     /// The peer id belongs in the record, under the signature, not repeated on
     /// every address — a reader re-attaches it when it dials.
     #[test]
     fn select_dial_addrs_leaves_the_peer_id_to_the_record() {
-        let out = select_dial_addrs(addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]), None);
+        let out = select_dial_addrs(
+            addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]),
+            None,
+            false,
+        );
         assert_eq!(out, addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]));
     }
 
@@ -1252,7 +1266,7 @@ mod tests {
             relay().to_base58(),
             peer().to_base58()
         );
-        let out = select_dial_addrs(addrs(&[circuit]), Some("/ip4/203.0.113.7/tcp/4001"));
+        let out = select_dial_addrs(addrs(&[circuit]), Some("/ip4/203.0.113.7/tcp/4001"), false);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].to_string(), "/ip4/203.0.113.7/tcp/4001");
     }
@@ -1271,13 +1285,22 @@ mod tests {
             peer().to_base58()
         ));
 
-        let out = select_dial_addrs(addrs(&listeners), None);
+        let out = select_dial_addrs(addrs(&listeners), None, false);
         assert_eq!(out.len(), MAX_DIAL_ADDRS);
         assert!(
             kwaai_p2p::is_circuit(out.last().expect("non-empty")),
             "the circuit survives, last because direct is cheaper to try"
         );
         assert!(!kwaai_p2p::is_circuit(&out[0]));
+    }
+
+    /// The record follows the node's policy: a reserved-range listener is
+    /// published only by a node whose operator declared that range routable.
+    #[test]
+    fn select_dial_addrs_follows_the_address_policy() {
+        let reserved = addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]);
+        assert_eq!(select_dial_addrs(reserved.clone(), None, false), reserved);
+        assert!(select_dial_addrs(reserved, None, true).is_empty());
     }
 
     /// The same value is stored under every block key, so the list is capped.
@@ -1287,7 +1310,7 @@ mod tests {
             .map(|i| format!("/ip4/203.0.113.{i}/tcp/4001"))
             .collect();
         assert_eq!(
-            select_dial_addrs(addrs(&listeners), None).len(),
+            select_dial_addrs(addrs(&listeners), None, false).len(),
             MAX_DIAL_ADDRS
         );
     }

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -25,7 +25,7 @@ use kwaai_hivemind_dht::value::get_dht_time;
 use kwaai_p2p::{NetworkHandle, PeerId};
 use prost::Message;
 use sha1::{Digest, Sha1};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tracing::{info, warn};
 
 use crate::config::KwaaiNetConfig;
@@ -158,6 +158,38 @@ pub struct DHTServerInfo {
     /// nothing to load. Only meaningful while `state` is JOINING; encoded only
     /// when true, so a node that is merely idle says nothing extra.
     pub shard_loading: bool,
+
+    /// Multiaddrs a peer can actually dial us on, each ending in
+    /// `/p2p/<our-peer-id>`. Empty for a node that has no reachable address
+    /// yet, and for every path that does not fill it in — see
+    /// [`crate::node_native::NativeNode::announce`], which is what populates it.
+    ///
+    /// # Why the record has to carry this
+    ///
+    /// Discovery hands dispatch a bare PeerId, and dialing by PeerId resolves
+    /// through kad — which cannot answer. rust-libp2p serves `FIND_NODE` from
+    /// its k-buckets alone (`find_closest_local_peers`), where the kad-DHT spec
+    /// §6.1.1 says a server MUST answer for a requested peer it holds in its
+    /// *peerstore* "even if the target node isn't a DHT Server or only
+    /// advertises private addresses", and where go-libp2p's `handleFindPeer`
+    /// does exactly that. So a peer is findable only while it occupies one of
+    /// the twenty slots in the right bucket on a peer the walk happens to
+    /// reach, and a disconnected entry is the first one replaced. That is the
+    /// half the Go p2pd bootstrap used to supply; on the native stack it made
+    /// dispatch fail fleet-wide with `peer not found in DHT (no addresses)` —
+    /// ~2000 of them in one node's log.
+    ///
+    /// Note this is *not* about kad's mode: `dht_server` is true on every
+    /// native node (`node_native.rs`), so kad is pinned to `Mode::Server`
+    /// whether the node is reachable or not.
+    ///
+    /// The relay path works fine once the address is known; what is missing is
+    /// only the address. Nothing else carries it — a circuit address names the
+    /// relay a node happens to hold a reservation on, reservations rotate
+    /// (`kwaai_p2p::relay_manager`), and a dialer cannot guess which relay that
+    /// is: dialing a peer through a bootstrap it has not reserved on returns
+    /// `Relay has no reservation for destination`.
+    pub dial_addrs: Vec<String>,
 }
 
 impl DHTServerInfo {
@@ -189,6 +221,10 @@ impl DHTServerInfo {
             peer_id_b58,
             lease_v1: true,
             shard_loading: KwaaiNetConfig::announce_shard_loading(),
+            // Filled in per-announce from the live swarm rather than here: the
+            // set changes as reservations rotate, and a value captured at
+            // startup would be wrong by the first re-announce.
+            dial_addrs: Vec::new(),
         }
     }
 
@@ -256,6 +292,19 @@ impl DHTServerInfo {
             fields.push((rmpv::Value::from("shard_loading"), rmpv::Value::from(true)));
         }
 
+        // Dial addresses, omitted entirely when empty so a node with nothing
+        // reachable to say adds no bytes. Same unknown-key tolerance as the
+        // fields above: a legacy client ignores `addrs` and keeps dialing by
+        // PeerId exactly as it does today.
+        if !self.dial_addrs.is_empty() {
+            let addrs: Vec<rmpv::Value> = self
+                .dial_addrs
+                .iter()
+                .map(|a| rmpv::Value::String(rmpv::Utf8String::from(a.as_str())))
+                .collect();
+            fields.push((rmpv::Value::from("addrs"), rmpv::Value::Array(addrs)));
+        }
+
         // Include VPK capability when enabled and reachable.
         // Unknown map keys are silently ignored by legacy Hivemind clients
         // and old map viewers — no backward-compatibility risk.
@@ -278,6 +327,99 @@ impl DHTServerInfo {
         rmpv::encode::write_value(&mut out, &ext)?;
         Ok(out)
     }
+}
+
+/// How many dial addresses one announcement may carry.
+///
+/// The same value is stored under every block key the node serves — 32 keys
+/// for an 8B model — so an address costs its own length times the block count
+/// in DHT bytes. Four is enough for the shapes that occur: a direct address
+/// plus the circuits from the two or three reservations `relay_manager` holds
+/// at once, or one address per transport on a public node.
+pub const MAX_DIAL_ADDRS: usize = 4;
+
+/// The addresses to publish so other peers can dial this node, most useful
+/// first, at most [`MAX_DIAL_ADDRS`] of them.
+///
+/// Sourced from the swarm's live listeners, which is where a relay reservation
+/// shows up: `libp2p-relay` turns an accepted reservation into a listen address
+/// of the form `<relay-addr>/p2p/<relay>/p2p-circuit/p2p/<us>`, already carrying
+/// both hops a dialer needs. Three filters apply:
+///
+/// - [`is_announceable`](kwaai_p2p::is_announceable) drops the loopback and
+///   RFC1918 listeners that every node has and no remote peer can use, while
+///   passing circuits unconditionally (the relay's address is the routable
+///   half).
+/// - [`uses_dialable_transport`](kwaai_p2p::uses_dialable_transport) drops
+///   webtransport/websocket forms this build has no transport for.
+/// - One address per relay. A relay that offers TCP *and* QUIC produces a
+///   circuit on each, and both traverse the same hop: keeping the second
+///   spends a scarce slot on a path that fails with the first.
+///
+/// Direct addresses sort ahead of circuits so a dialer that can reach one
+/// never pays for a relay, and a `declared` announce address — an operator
+/// saying "I forwarded this port" — sorts ahead of everything, since it is the
+/// one address the swarm cannot observe for itself.
+pub async fn publishable_dial_addrs(
+    handle: &NetworkHandle,
+    peer_id: PeerId,
+    declared: Option<&str>,
+) -> Vec<String> {
+    let listeners = handle.listen_addrs().await.unwrap_or_default();
+    select_dial_addrs(listeners, peer_id, declared)
+}
+
+/// The selection itself, split from the swarm call so it can be tested against
+/// a fixed address list rather than a live node.
+fn select_dial_addrs(
+    listeners: Vec<libp2p::Multiaddr>,
+    peer_id: PeerId,
+    declared: Option<&str>,
+) -> Vec<String> {
+    use kwaai_p2p::addresses::{peer_id_from_multiaddr, strip_dest_p2p};
+    use kwaai_p2p::{is_announceable, is_circuit, uses_dialable_transport};
+    use libp2p::multiaddr::Protocol;
+
+    let mut sorted: Vec<libp2p::Multiaddr> = declared
+        .and_then(|d| d.parse().ok())
+        .into_iter()
+        .chain(listeners)
+        .filter(|a| is_announceable(a) && uses_dialable_transport(a))
+        .collect();
+    // Direct before circuit (`false` sorts before `true`), stably, so the
+    // declared address stays ahead of the listeners it was chained onto.
+    sorted.sort_by_key(is_circuit);
+
+    let mut out: Vec<String> = Vec::new();
+    let mut seen_hops: HashSet<String> = HashSet::new();
+    for addr in sorted {
+        // A circuit is keyed on the relay itself, so its TCP and QUIC forms
+        // collapse to one entry — both cross the same hop, and if that hop is
+        // down neither works. A direct address is keyed on the address, where
+        // TCP and QUIC are genuinely separate chances.
+        let key = match (is_circuit(&addr), peer_id_from_multiaddr(&addr)) {
+            (true, Some(relay)) => relay.to_base58(),
+            _ => strip_dest_p2p(&addr).to_string(),
+        };
+        if !seen_hops.insert(key) {
+            continue;
+        }
+        // A circuit listener already names us; a direct one does not, and a
+        // dialer needs the destination to know who it expects to answer.
+        let addr = if addr
+            .iter()
+            .any(|p| matches!(p, Protocol::P2p(id) if id == peer_id))
+        {
+            addr
+        } else {
+            addr.with(Protocol::P2p(peer_id))
+        };
+        out.push(addr.to_string());
+        if out.len() == MAX_DIAL_ADDRS {
+            break;
+        }
+    }
+    out
 }
 
 /// Model info stored in the `_petals.models` DHT registry.
@@ -456,6 +598,9 @@ pub fn build_unannounce_records(
         peer_id_b58: server_info.peer_id_b58.clone(),
         lease_v1: server_info.lease_v1,
         shard_loading: false,
+        // A tombstone says "stop using me"; where to reach the node is
+        // exactly the thing it is withdrawing.
+        dial_addrs: Vec::new(),
     };
 
     let info_bytes = offline_info.to_msgpack()?;
@@ -853,7 +998,136 @@ mod tests {
             peer_id_b58: peer().to_base58(),
             lease_v1: true,
             shard_loading: false,
+            dial_addrs: vec![],
         }
+    }
+
+    /// A relay's peer id, distinct from [`peer`] — the node being announced.
+    fn relay() -> PeerId {
+        "12D3KooWF7ckKo2HQojbtueQNuLYRT2XC2yzbvBbh4NK2rbi2Azg"
+            .parse()
+            .expect("a valid peer id")
+    }
+
+    fn addrs(list: &[String]) -> Vec<libp2p::Multiaddr> {
+        list.iter()
+            .map(|a| a.parse().expect("a valid addr"))
+            .collect()
+    }
+
+    /// The listener set a NATed node actually has: loopback, two LAN
+    /// interfaces, and the circuit its reservation produced.
+    #[test]
+    fn select_dial_addrs_keeps_only_the_circuit_for_a_natted_node() {
+        let circuit = format!(
+            "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit/p2p/{}",
+            relay().to_base58(),
+            peer().to_base58()
+        );
+        let listeners = addrs(&[
+            "/ip4/127.0.0.1/tcp/54428".to_string(),
+            "/ip4/192.168.68.135/tcp/54428".to_string(),
+            "/ip6/::1/udp/54428/quic-v1".to_string(),
+            circuit.clone(),
+        ]);
+
+        assert_eq!(select_dial_addrs(listeners, peer(), None), vec![circuit]);
+    }
+
+    /// Both circuits cross the same relay, so publishing both spends two of
+    /// four slots on one hop.
+    #[test]
+    fn select_dial_addrs_collapses_two_transports_on_one_relay() {
+        let tcp = format!(
+            "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit/p2p/{}",
+            relay().to_base58(),
+            peer().to_base58()
+        );
+        let quic = format!(
+            "/ip4/76.13.5.74/udp/4001/quic-v1/p2p/{}/p2p-circuit/p2p/{}",
+            relay().to_base58(),
+            peer().to_base58()
+        );
+
+        let out = select_dial_addrs(addrs(&[tcp.clone(), quic]), peer(), None);
+        assert_eq!(out, vec![tcp], "one address per relay, first one wins");
+    }
+
+    /// This build has no webtransport transport, and the certhash form is the
+    /// longest address a relay offers — publishing it is pure cost.
+    #[test]
+    fn select_dial_addrs_drops_transports_this_build_cannot_dial() {
+        let wt = format!(
+            "/ip4/76.13.5.74/udp/4001/quic-v1/webtransport/certhash/uEiBIeyYi7BYMq_u71nPi3WJna-9kL5yAURJ5HYy0qXW3YQ/p2p/{}/p2p-circuit/p2p/{}",
+            relay().to_base58(),
+            peer().to_base58()
+        );
+        assert!(select_dial_addrs(addrs(&[wt]), peer(), None).is_empty());
+    }
+
+    /// A dialer needs to know who it expects to answer; a direct listener does
+    /// not carry that, a circuit already does and must not be given a second.
+    #[test]
+    fn select_dial_addrs_ends_every_address_at_this_node() {
+        let out = select_dial_addrs(
+            addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]),
+            peer(),
+            None,
+        );
+        assert_eq!(
+            out,
+            vec![format!(
+                "/ip4/198.18.0.40/tcp/8080/p2p/{}",
+                peer().to_base58()
+            )]
+        );
+    }
+
+    /// A declared address is the operator saying "I forwarded this port" — the
+    /// one address the swarm cannot observe for itself, and the cheapest hop
+    /// for a dialer, so it leads.
+    #[test]
+    fn select_dial_addrs_puts_a_declared_address_first() {
+        let circuit = format!(
+            "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit/p2p/{}",
+            relay().to_base58(),
+            peer().to_base58()
+        );
+        let out = select_dial_addrs(addrs(&[circuit]), peer(), Some("/ip4/203.0.113.7/tcp/4001"));
+        assert_eq!(out.len(), 2);
+        assert!(out[0].starts_with("/ip4/203.0.113.7/tcp/4001/p2p/"));
+    }
+
+    /// The same value is stored under every block key, so the list is capped.
+    #[test]
+    fn select_dial_addrs_stops_at_the_cap() {
+        let listeners: Vec<String> = (1..=MAX_DIAL_ADDRS + 3)
+            .map(|i| format!("/ip4/203.0.113.{i}/tcp/4001"))
+            .collect();
+        assert_eq!(
+            select_dial_addrs(addrs(&listeners), peer(), None).len(),
+            MAX_DIAL_ADDRS
+        );
+    }
+
+    /// A node with nothing reachable to say must add no bytes to the record,
+    /// so that `addrs` is absent rather than an empty array.
+    #[test]
+    fn to_msgpack_omits_addrs_when_there_are_none() {
+        let bytes = server_info(None).to_msgpack().expect("encodes");
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(!text.contains("addrs"));
+    }
+
+    #[test]
+    fn to_msgpack_carries_addrs_when_present() {
+        let mut info = server_info(None);
+        let addr = format!("/ip4/203.0.113.7/tcp/4001/p2p/{}", peer().to_base58());
+        info.dial_addrs = vec![addr.clone()];
+        let bytes = info.to_msgpack().expect("encodes");
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(text.contains("addrs"));
+        assert!(text.contains(&addr));
     }
 
     fn vpk_info() -> VpkInfo {

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -30,7 +30,6 @@ use std::collections::{HashMap, HashSet};
 use tracing::{info, warn};
 
 use crate::config::KwaaiNetConfig;
-use crate::shard_cmd::{version_meets_minimum, BlockServerEntry};
 
 /// TTL applied to every announced record, in seconds.
 ///
@@ -367,6 +366,13 @@ impl DHTServerInfo {
 // gained and the reader never learned. Side by side they can be tested by
 // round trip through the real producer rather than against a hand-built map,
 // and a field added to one is visibly missing from the other.
+//
+// Bytes to fields is all that lives here. What a reader then *does* with those
+// fields — which states count as usable, which versions are too old to trust,
+// what struct they become — is the consumer's policy, and putting it here
+// would make the wire format depend on the sharding layer that reads it. So
+// `decode_server_info_regular` / `_dictionary` sit in `shard_cmd.rs` instead,
+// on top of `decode_server_info_ext`.
 
 /// One decoded announcement, as a struct rather than the positional tuple this
 /// used to return: nine fields where three call sites want different subsets is
@@ -452,132 +458,6 @@ pub fn decode_server_info_ext(bytes: &[u8]) -> Option<ServerInfoFields> {
         lease_v1,
         dial_addrs,
     })
-}
-
-/// Parse `Ext(64, [state, throughput, {start_block, end_block, peer_id, …}])`
-/// from a FoundRegular value.
-///
-/// Returns `(dedup_key, entry)`.  Legacy nodes (pre-v0.3.3) omit `peer_id`; we
-/// synthesise a stable key from `public_name:start_block` so they still count
-/// for gap detection even though they cannot be routed to directly.
-pub fn decode_server_info_regular(bytes: &[u8]) -> Option<(String, BlockServerEntry)> {
-    let info = decode_server_info_ext(bytes)?;
-    // Only include ONLINE nodes (state=2); skip JOINING (1) and OFFLINE (0/-1).
-    if info.state != 2 {
-        return None;
-    }
-    if !version_meets_minimum(&info.version) {
-        return None;
-    }
-    let (dedup_key, peer_id) = match info.peer_id_b58.parse::<PeerId>() {
-        Ok(pid) => (pid.to_base58(), pid),
-        Err(_) => {
-            let key = format!("legacy:{}:{}", info.public_name, info.start_block);
-            (key, PeerId::random())
-        }
-    };
-    Some((
-        dedup_key,
-        BlockServerEntry {
-            peer_id,
-            start_block: info.start_block,
-            end_block: info.end_block,
-            public_name: info.public_name,
-            throughput: info.throughput,
-            trust_score: None,
-            lease_v1: info.lease_v1,
-            dial_addrs: info.dial_addrs,
-        },
-    ))
-}
-
-/// Parse `Ext(80, [expiry, created, [[subkey_bytes, value_bytes, expiry], …]])`
-/// from a FoundDictionary value. Appends into `out` (deduplicates by peer_id).
-pub fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockServerEntry>) {
-    let outer = match rmpv::decode::read_value(&mut &bytes[..]) {
-        Ok(v) => v,
-        Err(_) => return,
-    };
-    let inner_bytes = match &outer {
-        rmpv::Value::Ext(80, b) => b.as_slice(),
-        _ => return,
-    };
-    let inner = match rmpv::decode::read_value(&mut &inner_bytes[..]) {
-        Ok(v) => v,
-        Err(_) => return,
-    };
-    let outer_arr = match inner.as_array() {
-        Some(a) if a.len() >= 3 => a,
-        _ => return,
-    };
-    let entries = match outer_arr[2].as_array() {
-        Some(e) => e,
-        None => return,
-    };
-
-    for entry in entries {
-        let arr = match entry.as_array() {
-            Some(a) if a.len() >= 2 => a,
-            _ => continue,
-        };
-
-        // Subkey is rmp_serde::to_vec(&peer_id_base58) = msgpack(string)
-        let peer_id_b58 = match &arr[0] {
-            rmpv::Value::String(s) => s.as_str().unwrap_or("").to_string(),
-            rmpv::Value::Binary(b) => {
-                // Decode as msgpack string
-                match rmpv::decode::read_value(&mut b.as_slice()) {
-                    Ok(rmpv::Value::String(s)) => s.as_str().unwrap_or("").to_string(),
-                    _ => continue,
-                }
-            }
-            _ => continue,
-        };
-
-        let value_bytes = match &arr[1] {
-            rmpv::Value::Binary(b) => b.as_slice(),
-            _ => continue,
-        };
-
-        if peer_id_b58.is_empty() {
-            continue;
-        }
-
-        let peer_id = match peer_id_b58.parse::<PeerId>() {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        if let Some(info) = decode_server_info_ext(value_bytes) {
-            if info.state != 2 {
-                continue;
-            }
-            if !version_meets_minimum(&info.version) {
-                continue;
-            }
-            // The entry is identified by its *subkey*, but the signature was
-            // checked against the `peer_id` inside the value — and one writer
-            // controls both. A value naming a different peer than the subkey
-            // it sits under would hand this entry `peer_id` from the subkey
-            // and addresses belonging to whoever the value names. Legacy
-            // records omit `peer_id` entirely, so only a present-and-different
-            // one is a contradiction.
-            if !info.peer_id_b58.is_empty() && info.peer_id_b58 != peer_id_b58 {
-                continue;
-            }
-            let key = peer_id_b58.clone();
-            out.entry(key).or_insert(BlockServerEntry {
-                peer_id,
-                start_block: info.start_block,
-                end_block: info.end_block,
-                public_name: info.public_name,
-                throughput: info.throughput,
-                trust_score: None,
-                lease_v1: info.lease_v1,
-                dial_addrs: info.dial_addrs,
-            });
-        }
-    }
 }
 
 /// How many dial addresses one announcement may carry.
@@ -1944,27 +1824,6 @@ mod tests {
         assert!(info.lease_v1);
     }
 
-    /// Helper: one entry wrapped in the `Ext(80, [expiry, created, [[subkey,
-    /// value, expiry]]])` shape a FoundDictionary response carries.
-    fn dictionary_bytes(subkey_peer_b58: &str, value: &[u8]) -> Vec<u8> {
-        let subkey = rmp_serde::to_vec(&subkey_peer_b58).expect("msgpack subkey");
-        let entry = rmpv::Value::Array(vec![
-            rmpv::Value::Binary(subkey),
-            rmpv::Value::Binary(value.to_vec()),
-            rmpv::Value::from(0.0),
-        ]);
-        let inner = rmpv::Value::Array(vec![
-            rmpv::Value::from(0.0),
-            rmpv::Value::from(0.0),
-            rmpv::Value::Array(vec![entry]),
-        ]);
-        let mut inner_bytes = Vec::new();
-        rmpv::encode::write_value(&mut inner_bytes, &inner).expect("encodes");
-        let mut out = Vec::new();
-        rmpv::encode::write_value(&mut out, &rmpv::Value::Ext(80, inner_bytes)).expect("encodes");
-        out
-    }
-
     /// Helper: a signed envelope for `key` naming `addrs`, exactly as the
     /// publisher emits one.
     fn signed_envelope(key: &libp2p::identity::Keypair, addrs: &[&str]) -> Vec<u8> {
@@ -2061,69 +1920,6 @@ mod tests {
         assert_eq!(
             decoded.end_block, 32,
             "the rest of the record still decodes"
-        );
-    }
-
-    /// The dictionary path keys an entry by its *subkey* but verified the
-    /// signature against the value's `peer_id`, and one writer controls both.
-    /// A value naming a different peer must be dropped, or the entry would
-    /// carry the victim's peer id beside a stranger's addresses.
-    #[test]
-    fn decode_server_info_dictionary_drops_a_value_naming_another_peer() {
-        let victim = PeerId::random();
-        let attacker = libp2p::identity::Keypair::generate_ed25519();
-        let mut forged = DHTServerInfo::new(
-            0,
-            32,
-            "test-node",
-            true,
-            10.0,
-            Vec::new(),
-            None,
-            attacker.public().to_peer_id().to_base58(),
-        );
-        forged.state = 2;
-        forged.signed_addrs = signed_envelope(&attacker, &["/ip4/198.51.100.9/tcp/4001"]);
-
-        let mut out = HashMap::new();
-        decode_server_info_dictionary(
-            &dictionary_bytes(&victim.to_base58(), &forged.to_msgpack().expect("encodes")),
-            &mut out,
-        );
-        assert!(
-            out.is_empty(),
-            "an entry whose value names a peer other than its subkey must not be used"
-        );
-    }
-
-    /// The same shape, honestly published, still decodes — so the check above
-    /// rejects the contradiction rather than the dictionary path itself.
-    #[test]
-    fn decode_server_info_dictionary_keeps_a_value_matching_its_subkey() {
-        let key = libp2p::identity::Keypair::generate_ed25519();
-        let peer = key.public().to_peer_id();
-        let mut honest = DHTServerInfo::new(
-            0,
-            32,
-            "test-node",
-            true,
-            10.0,
-            Vec::new(),
-            None,
-            peer.to_base58(),
-        );
-        honest.state = 2;
-        honest.signed_addrs = signed_envelope(&key, &["/ip4/203.0.113.7/tcp/4001"]);
-
-        let mut out = HashMap::new();
-        decode_server_info_dictionary(
-            &dictionary_bytes(&peer.to_base58(), &honest.to_msgpack().expect("encodes")),
-            &mut out,
-        );
-        let entry = out.get(&peer.to_base58()).expect("the entry decodes");
-        assert_eq!(
-            entry.dial_addrs,
-            vec!["/ip4/203.0.113.7/tcp/4001".parse::<Multiaddr>().unwrap()]
         );
     }
 

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -492,7 +492,15 @@ pub const MAX_DIAL_ADDRS: usize = 4;
 /// Direct addresses sort ahead of circuits so a dialer that can reach one
 /// never pays for a relay, and a `declared` announce address — an operator
 /// saying "I forwarded this port" — sorts ahead of everything, since it is the
-/// one address the swarm cannot observe for itself.
+/// one address the swarm cannot observe for itself. Circuits nonetheless
+/// claim their slots first: a NATed host with several global v6 addresses or a
+/// VPN interface would otherwise fill the record with direct addresses that
+/// only work from its own network and lose the one address that works from
+/// anywhere.
+///
+/// Listeners are read alongside the swarm's confirmed external addresses. A
+/// UPnP mapping is not a listener, and a node that got one has released its
+/// relay reservations — without it that node would publish nothing at all.
 ///
 /// The result is signed with the node's own identity key, the same key the
 /// peer id is derived from — see [`DHTServerInfo::signed_addrs`] for why an
@@ -502,8 +510,9 @@ pub async fn signed_dial_addrs(
     keypair: &libp2p::identity::Keypair,
     declared: Option<&str>,
 ) -> Vec<u8> {
+    let external = handle.external_addrs().await.unwrap_or_default();
     let listeners = handle.listen_addrs().await.unwrap_or_default();
-    let addrs = select_dial_addrs(listeners, declared);
+    let addrs = select_dial_addrs(external.into_iter().chain(listeners).collect(), declared);
     if addrs.is_empty() {
         return Vec::new();
     }
@@ -543,7 +552,8 @@ fn select_dial_addrs(
     // declared address stays ahead of the listeners it was chained onto.
     sorted.sort_by_key(is_circuit);
 
-    let mut out: Vec<libp2p::Multiaddr> = Vec::new();
+    let mut direct: Vec<libp2p::Multiaddr> = Vec::new();
+    let mut circuits: Vec<libp2p::Multiaddr> = Vec::new();
     let mut seen_hops: HashSet<String> = HashSet::new();
     for addr in sorted {
         // A circuit is keyed on the relay itself, so its TCP and QUIC forms
@@ -557,12 +567,18 @@ fn select_dial_addrs(
         if !seen_hops.insert(key) {
             continue;
         }
-        out.push(strip_dest_p2p(&addr));
-        if out.len() == MAX_DIAL_ADDRS {
-            break;
+        if is_circuit(&addr) {
+            circuits.push(strip_dest_p2p(&addr));
+        } else {
+            direct.push(strip_dest_p2p(&addr));
         }
     }
-    out
+    // Circuits take their slots first; direct addresses get what is left and
+    // still lead the output. See the function docs for why.
+    circuits.truncate(MAX_DIAL_ADDRS);
+    direct.truncate(MAX_DIAL_ADDRS - circuits.len());
+    direct.extend(circuits);
+    direct
 }
 
 /// Model info stored in the `_petals.models` DHT registry.
@@ -1239,6 +1255,29 @@ mod tests {
         let out = select_dial_addrs(addrs(&[circuit]), Some("/ip4/203.0.113.7/tcp/4001"));
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].to_string(), "/ip4/203.0.113.7/tcp/4001");
+    }
+
+    /// A host with many interfaces — several global v6 addresses, a VPN —
+    /// must not crowd its circuit out of the record: for a NATed node the
+    /// circuit is the only entry that works from outside its own network.
+    #[test]
+    fn select_dial_addrs_reserves_room_for_a_circuit() {
+        let mut listeners: Vec<String> = (1..=MAX_DIAL_ADDRS + 2)
+            .map(|i| format!("/ip6/2001:db8::{i}/tcp/4001"))
+            .collect();
+        listeners.push(format!(
+            "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit/p2p/{}",
+            relay().to_base58(),
+            peer().to_base58()
+        ));
+
+        let out = select_dial_addrs(addrs(&listeners), None);
+        assert_eq!(out.len(), MAX_DIAL_ADDRS);
+        assert!(
+            kwaai_p2p::is_circuit(out.last().expect("non-empty")),
+            "the circuit survives, last because direct is cheaper to try"
+        );
+        assert!(!kwaai_p2p::is_circuit(&out[0]));
     }
 
     /// The same value is stored under every block key, so the list is capped.

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -159,10 +159,10 @@ pub struct DHTServerInfo {
     /// when true, so a node that is merely idle says nothing extra.
     pub shard_loading: bool,
 
-    /// Multiaddrs a peer can actually dial us on, each ending in
-    /// `/p2p/<our-peer-id>`. Empty for a node that has no reachable address
-    /// yet, and for every path that does not fill it in — see
-    /// [`crate::node_native::NativeNode::announce`], which is what populates it.
+    /// A signed RFC 0003 peer record naming the multiaddrs a peer can dial us
+    /// on, protobuf-encoded as a `SignedEnvelope`. Empty for a node with no
+    /// reachable address yet, and for every path that does not fill it in —
+    /// see [`crate::node_native::NativeNode::announce`], which populates it.
     ///
     /// # Why the record has to carry this
     ///
@@ -189,7 +189,33 @@ pub struct DHTServerInfo {
     /// (`kwaai_p2p::relay_manager`), and a dialer cannot guess which relay that
     /// is: dialing a peer through a bootstrap it has not reserved on returns
     /// `Relay has no reservation for destination`.
-    pub dial_addrs: Vec<String>,
+    ///
+    /// # Why it is signed rather than a plain list
+    ///
+    /// `kwaai-hivemind-dht` implements no record validators, so any peer can
+    /// `STORE` under another node's subkey with a later expiration. A plain
+    /// address list would therefore be an instruction, from anyone, about
+    /// where to send a victim's traffic: black-hole a node by pointing its
+    /// addresses at a dead host, or aim dials at a third party. Impersonation
+    /// is already caught at the Noise handshake, but neither of those needs
+    /// the attacker to complete a handshake.
+    ///
+    /// The envelope closes *that*, and only that.
+    /// `PeerRecord::from_signed_envelope_interop` verifies the signature and
+    /// binds the record's peer id to the signing key, so an address list the
+    /// announced peer did not sign is one the reader drops. The interop format
+    /// (`libp2p-peer-record`) is used rather than rust-libp2p's legacy domain
+    /// because this record is a published wire format that a Go or JS reader
+    /// may one day verify.
+    ///
+    /// What it does **not** close, because the signature covers the address
+    /// list rather than the record: an attacker can still overwrite a peer's
+    /// announcement with one that omits this field — dropping it back to the
+    /// bare-PeerId dial that fails — tombstone it with `state = -1`, or replay
+    /// an older genuine list of addresses the peer has since moved off. All
+    /// three are plain overwrites, which is what a record validator in the DHT
+    /// store would answer; none of them need a forged signature.
+    pub signed_addrs: Vec<u8>,
 }
 
 impl DHTServerInfo {
@@ -224,7 +250,7 @@ impl DHTServerInfo {
             // Filled in per-announce from the live swarm rather than here: the
             // set changes as reservations rotate, and a value captured at
             // startup would be wrong by the first re-announce.
-            dial_addrs: Vec::new(),
+            signed_addrs: Vec::new(),
         }
     }
 
@@ -294,15 +320,15 @@ impl DHTServerInfo {
 
         // Dial addresses, omitted entirely when empty so a node with nothing
         // reachable to say adds no bytes. Same unknown-key tolerance as the
-        // fields above: a legacy client ignores `addrs` and keeps dialing by
-        // PeerId exactly as it does today.
-        if !self.dial_addrs.is_empty() {
-            let addrs: Vec<rmpv::Value> = self
-                .dial_addrs
-                .iter()
-                .map(|a| rmpv::Value::String(rmpv::Utf8String::from(a.as_str())))
-                .collect();
-            fields.push((rmpv::Value::from("addrs"), rmpv::Value::Array(addrs)));
+        // fields above: a legacy client ignores `addrs_signed` and keeps
+        // dialing by PeerId exactly as it does today. Binary, not a string
+        // list — the value is the signed envelope, and only what the node's
+        // own key signed is worth publishing.
+        if !self.signed_addrs.is_empty() {
+            fields.push((
+                rmpv::Value::from("addrs_signed"),
+                rmpv::Value::Binary(self.signed_addrs.clone()),
+            ));
         }
 
         // Include VPK capability when enabled and reachable.
@@ -338,8 +364,10 @@ impl DHTServerInfo {
 /// at once, or one address per transport on a public node.
 pub const MAX_DIAL_ADDRS: usize = 4;
 
-/// The addresses to publish so other peers can dial this node, most useful
-/// first, at most [`MAX_DIAL_ADDRS`] of them.
+/// A signed peer record naming the addresses other peers can dial this node
+/// on — most useful first, at most [`MAX_DIAL_ADDRS`] of them — protobuf
+/// encoded and ready to publish. Empty when the node has no address worth
+/// announcing, or when signing fails.
 ///
 /// Sourced from the swarm's live listeners, which is where a relay reservation
 /// shows up: `libp2p-relay` turns an accepted reservation into a listen address
@@ -360,25 +388,45 @@ pub const MAX_DIAL_ADDRS: usize = 4;
 /// never pays for a relay, and a `declared` announce address — an operator
 /// saying "I forwarded this port" — sorts ahead of everything, since it is the
 /// one address the swarm cannot observe for itself.
-pub async fn publishable_dial_addrs(
+///
+/// The result is signed with the node's own identity key, the same key the
+/// peer id is derived from — see [`DHTServerInfo::signed_addrs`] for why an
+/// unsigned list would be a standing invitation to redirect a node's traffic.
+pub async fn signed_dial_addrs(
     handle: &NetworkHandle,
-    peer_id: PeerId,
+    keypair: &libp2p::identity::Keypair,
     declared: Option<&str>,
-) -> Vec<String> {
+) -> Vec<u8> {
     let listeners = handle.listen_addrs().await.unwrap_or_default();
-    select_dial_addrs(listeners, peer_id, declared)
+    let addrs = select_dial_addrs(listeners, declared);
+    if addrs.is_empty() {
+        return Vec::new();
+    }
+    match libp2p::core::PeerRecord::new_interop(keypair, addrs) {
+        Ok(record) => record.into_signed_envelope().into_protobuf_encoding(),
+        Err(e) => {
+            // Signing failing means the identity key is unusable, which the
+            // swarm would already have died on. Publish nothing rather than
+            // an unsigned list a reader would be right to refuse.
+            warn!("could not sign the dial-address record: {e}");
+            Vec::new()
+        }
+    }
 }
 
-/// The selection itself, split from the swarm call so it can be tested against
-/// a fixed address list rather than a live node.
+/// The selection itself, split from the swarm call and the signing so it can
+/// be tested against a fixed address list rather than a live node.
+///
+/// Addresses come back **without** a trailing `/p2p/<us>`: the peer record
+/// names the peer once, in a field the signature covers, and a reader
+/// re-attaches it when it dials. `strip_dest_p2p` is what does that, and it
+/// keeps a circuit's relay hop — the half a dialer cannot reconstruct.
 fn select_dial_addrs(
     listeners: Vec<libp2p::Multiaddr>,
-    peer_id: PeerId,
     declared: Option<&str>,
-) -> Vec<String> {
+) -> Vec<libp2p::Multiaddr> {
     use kwaai_p2p::addresses::{peer_id_from_multiaddr, strip_dest_p2p};
     use kwaai_p2p::{is_announceable, is_circuit, uses_dialable_transport};
-    use libp2p::multiaddr::Protocol;
 
     let mut sorted: Vec<libp2p::Multiaddr> = declared
         .and_then(|d| d.parse().ok())
@@ -390,7 +438,7 @@ fn select_dial_addrs(
     // declared address stays ahead of the listeners it was chained onto.
     sorted.sort_by_key(is_circuit);
 
-    let mut out: Vec<String> = Vec::new();
+    let mut out: Vec<libp2p::Multiaddr> = Vec::new();
     let mut seen_hops: HashSet<String> = HashSet::new();
     for addr in sorted {
         // A circuit is keyed on the relay itself, so its TCP and QUIC forms
@@ -404,17 +452,7 @@ fn select_dial_addrs(
         if !seen_hops.insert(key) {
             continue;
         }
-        // A circuit listener already names us; a direct one does not, and a
-        // dialer needs the destination to know who it expects to answer.
-        let addr = if addr
-            .iter()
-            .any(|p| matches!(p, Protocol::P2p(id) if id == peer_id))
-        {
-            addr
-        } else {
-            addr.with(Protocol::P2p(peer_id))
-        };
-        out.push(addr.to_string());
+        out.push(strip_dest_p2p(&addr));
         if out.len() == MAX_DIAL_ADDRS {
             break;
         }
@@ -600,7 +638,7 @@ pub fn build_unannounce_records(
         shard_loading: false,
         // A tombstone says "stop using me"; where to reach the node is
         // exactly the thing it is withdrawing.
-        dial_addrs: Vec::new(),
+        signed_addrs: Vec::new(),
     };
 
     let info_bytes = offline_info.to_msgpack()?;
@@ -998,7 +1036,7 @@ mod tests {
             peer_id_b58: peer().to_base58(),
             lease_v1: true,
             shard_loading: false,
-            dial_addrs: vec![],
+            signed_addrs: vec![],
         }
     }
 
@@ -1028,10 +1066,16 @@ mod tests {
             "/ip4/127.0.0.1/tcp/54428".to_string(),
             "/ip4/192.168.68.135/tcp/54428".to_string(),
             "/ip6/::1/udp/54428/quic-v1".to_string(),
-            circuit.clone(),
+            circuit,
         ]);
 
-        assert_eq!(select_dial_addrs(listeners, peer(), None), vec![circuit]);
+        // The destination hop is stripped — the record names the peer itself —
+        // but the relay hop, which a dialer cannot reconstruct, is kept.
+        let expected = format!(
+            "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit",
+            relay().to_base58()
+        );
+        assert_eq!(select_dial_addrs(listeners, None), addrs(&[expected]));
     }
 
     /// Both circuits cross the same relay, so publishing both spends two of
@@ -1049,8 +1093,12 @@ mod tests {
             peer().to_base58()
         );
 
-        let out = select_dial_addrs(addrs(&[tcp.clone(), quic]), peer(), None);
-        assert_eq!(out, vec![tcp], "one address per relay, first one wins");
+        let out = select_dial_addrs(addrs(&[tcp, quic]), None);
+        let expected = format!(
+            "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit",
+            relay().to_base58()
+        );
+        assert_eq!(out, addrs(&[expected]), "one address per relay, first wins");
     }
 
     /// This build has no webtransport transport, and the certhash form is the
@@ -1062,25 +1110,15 @@ mod tests {
             relay().to_base58(),
             peer().to_base58()
         );
-        assert!(select_dial_addrs(addrs(&[wt]), peer(), None).is_empty());
+        assert!(select_dial_addrs(addrs(&[wt]), None).is_empty());
     }
 
-    /// A dialer needs to know who it expects to answer; a direct listener does
-    /// not carry that, a circuit already does and must not be given a second.
+    /// The peer id belongs in the record, under the signature, not repeated on
+    /// every address — a reader re-attaches it when it dials.
     #[test]
-    fn select_dial_addrs_ends_every_address_at_this_node() {
-        let out = select_dial_addrs(
-            addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]),
-            peer(),
-            None,
-        );
-        assert_eq!(
-            out,
-            vec![format!(
-                "/ip4/198.18.0.40/tcp/8080/p2p/{}",
-                peer().to_base58()
-            )]
-        );
+    fn select_dial_addrs_leaves_the_peer_id_to_the_record() {
+        let out = select_dial_addrs(addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]), None);
+        assert_eq!(out, addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]));
     }
 
     /// A declared address is the operator saying "I forwarded this port" — the
@@ -1093,9 +1131,9 @@ mod tests {
             relay().to_base58(),
             peer().to_base58()
         );
-        let out = select_dial_addrs(addrs(&[circuit]), peer(), Some("/ip4/203.0.113.7/tcp/4001"));
+        let out = select_dial_addrs(addrs(&[circuit]), Some("/ip4/203.0.113.7/tcp/4001"));
         assert_eq!(out.len(), 2);
-        assert!(out[0].starts_with("/ip4/203.0.113.7/tcp/4001/p2p/"));
+        assert_eq!(out[0].to_string(), "/ip4/203.0.113.7/tcp/4001");
     }
 
     /// The same value is stored under every block key, so the list is capped.
@@ -1105,7 +1143,7 @@ mod tests {
             .map(|i| format!("/ip4/203.0.113.{i}/tcp/4001"))
             .collect();
         assert_eq!(
-            select_dial_addrs(addrs(&listeners), peer(), None).len(),
+            select_dial_addrs(addrs(&listeners), None).len(),
             MAX_DIAL_ADDRS
         );
     }
@@ -1122,12 +1160,30 @@ mod tests {
     #[test]
     fn to_msgpack_carries_addrs_when_present() {
         let mut info = server_info(None);
-        let addr = format!("/ip4/203.0.113.7/tcp/4001/p2p/{}", peer().to_base58());
-        info.dial_addrs = vec![addr.clone()];
+        info.signed_addrs = vec![1, 2, 3];
         let bytes = info.to_msgpack().expect("encodes");
-        let text = String::from_utf8_lossy(&bytes);
-        assert!(text.contains("addrs"));
-        assert!(text.contains(&addr));
+        assert!(String::from_utf8_lossy(&bytes).contains("addrs_signed"));
+    }
+
+    /// The whole point of the field: what is published is signed by the key
+    /// the peer id is derived from, so a reader can bind the two.
+    #[test]
+    fn a_signed_record_verifies_and_names_the_signer() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let me = key.public().to_peer_id();
+        let addr: libp2p::Multiaddr = "/ip4/203.0.113.7/tcp/4001".parse().expect("parses");
+
+        let bytes = libp2p::core::PeerRecord::new_interop(&key, vec![addr.clone()])
+            .expect("signs")
+            .into_signed_envelope()
+            .into_protobuf_encoding();
+
+        let envelope =
+            libp2p::core::SignedEnvelope::from_protobuf_encoding(&bytes).expect("decodes");
+        let record =
+            libp2p::core::PeerRecord::from_signed_envelope_interop(envelope).expect("verifies");
+        assert_eq!(record.peer_id(), me);
+        assert_eq!(record.addresses(), &[addr]);
     }
 
     fn vpk_info() -> VpkInfo {

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -584,8 +584,14 @@ fn select_dial_addrs(
         }
     }
     // Circuits take their slots first; direct addresses get what is left and
-    // still lead the output. See the function docs for why.
-    circuits.truncate(MAX_DIAL_ADDRS);
+    // still lead the output. See the function docs for why. The declared
+    // address, if it survived the filter, is `direct[0]` and keeps one slot
+    // regardless — it is the one address no circuit can substitute for.
+    let declared_kept = declared
+        .and_then(|d| d.parse::<libp2p::Multiaddr>().ok())
+        .map(|d| strip_dest_p2p(&d))
+        .is_some_and(|d| direct.first() == Some(&d));
+    circuits.truncate(MAX_DIAL_ADDRS - usize::from(declared_kept));
     direct.truncate(MAX_DIAL_ADDRS - circuits.len());
     direct.extend(circuits);
     direct
@@ -1273,6 +1279,31 @@ mod tests {
         let out = select_dial_addrs(addrs(&[circuit]), Some("/ip4/203.0.113.7/tcp/4001"), false, true);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].to_string(), "/ip4/203.0.113.7/tcp/4001");
+    }
+
+    /// Enough reservations to fill the record must not push the declared
+    /// address out: it is the operator's forwarded port, which no circuit
+    /// stands in for.
+    #[test]
+    fn select_dial_addrs_keeps_the_declared_address_beside_full_circuits() {
+        let circuits: Vec<String> = (0..MAX_DIAL_ADDRS + 1)
+            .map(|i| {
+                format!(
+                    "/ip4/76.13.5.{i}/tcp/4001/p2p/{}/p2p-circuit/p2p/{}",
+                    PeerId::random().to_base58(),
+                    peer().to_base58()
+                )
+            })
+            .collect();
+        let out = select_dial_addrs(
+            addrs(&circuits),
+            Some("/ip4/203.0.113.7/tcp/4001"),
+            false,
+            true,
+        );
+        assert_eq!(out.len(), MAX_DIAL_ADDRS);
+        assert_eq!(out[0].to_string(), "/ip4/203.0.113.7/tcp/4001");
+        assert!(out[1..].iter().all(kwaai_p2p::is_circuit));
     }
 
     /// A host with many interfaces — several global v6 addresses, a VPN —

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -511,6 +511,7 @@ pub async fn signed_dial_addrs(
     keypair: &libp2p::identity::Keypair,
     declared: Option<&str>,
     strict: bool,
+    quic: bool,
 ) -> Vec<u8> {
     let external = handle.external_addrs().await.unwrap_or_default();
     let listeners = handle.listen_addrs().await.unwrap_or_default();
@@ -518,6 +519,7 @@ pub async fn signed_dial_addrs(
         external.into_iter().chain(listeners).collect(),
         declared,
         strict,
+        quic,
     );
     if addrs.is_empty() {
         return Vec::new();
@@ -545,6 +547,7 @@ fn select_dial_addrs(
     listeners: Vec<libp2p::Multiaddr>,
     declared: Option<&str>,
     strict: bool,
+    quic: bool,
 ) -> Vec<libp2p::Multiaddr> {
     use kwaai_p2p::addresses::{is_announceable_with, peer_id_from_multiaddr, strip_dest_p2p};
     use kwaai_p2p::{is_circuit, uses_dialable_transport};
@@ -553,7 +556,7 @@ fn select_dial_addrs(
         .and_then(|d| d.parse().ok())
         .into_iter()
         .chain(listeners)
-        .filter(|a| is_announceable_with(a, strict) && uses_dialable_transport(a))
+        .filter(|a| is_announceable_with(a, strict) && uses_dialable_transport(a, quic))
         .collect();
     // Direct before circuit (`false` sorts before `true`), stably, so the
     // declared address stays ahead of the listeners it was chained onto.
@@ -1204,7 +1207,7 @@ mod tests {
             relay().to_base58()
         );
         assert_eq!(
-            select_dial_addrs(listeners, None, false),
+            select_dial_addrs(listeners, None, false, true),
             addrs(&[expected])
         );
     }
@@ -1224,7 +1227,7 @@ mod tests {
             peer().to_base58()
         );
 
-        let out = select_dial_addrs(addrs(&[tcp, quic]), None, false);
+        let out = select_dial_addrs(addrs(&[tcp, quic]), None, false, true);
         let expected = format!(
             "/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit",
             relay().to_base58()
@@ -1241,7 +1244,7 @@ mod tests {
             relay().to_base58(),
             peer().to_base58()
         );
-        assert!(select_dial_addrs(addrs(&[wt]), None, false).is_empty());
+        assert!(select_dial_addrs(addrs(&[wt]), None, false, true).is_empty());
     }
 
     /// The peer id belongs in the record, under the signature, not repeated on
@@ -1252,6 +1255,7 @@ mod tests {
             addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]),
             None,
             false,
+            true,
         );
         assert_eq!(out, addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]));
     }
@@ -1266,7 +1270,7 @@ mod tests {
             relay().to_base58(),
             peer().to_base58()
         );
-        let out = select_dial_addrs(addrs(&[circuit]), Some("/ip4/203.0.113.7/tcp/4001"), false);
+        let out = select_dial_addrs(addrs(&[circuit]), Some("/ip4/203.0.113.7/tcp/4001"), false, true);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].to_string(), "/ip4/203.0.113.7/tcp/4001");
     }
@@ -1285,7 +1289,7 @@ mod tests {
             peer().to_base58()
         ));
 
-        let out = select_dial_addrs(addrs(&listeners), None, false);
+        let out = select_dial_addrs(addrs(&listeners), None, false, true);
         assert_eq!(out.len(), MAX_DIAL_ADDRS);
         assert!(
             kwaai_p2p::is_circuit(out.last().expect("non-empty")),
@@ -1299,8 +1303,8 @@ mod tests {
     #[test]
     fn select_dial_addrs_follows_the_address_policy() {
         let reserved = addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]);
-        assert_eq!(select_dial_addrs(reserved.clone(), None, false), reserved);
-        assert!(select_dial_addrs(reserved, None, true).is_empty());
+        assert_eq!(select_dial_addrs(reserved.clone(), None, false, true), reserved);
+        assert!(select_dial_addrs(reserved, None, true, true).is_empty());
     }
 
     /// The same value is stored under every block key, so the list is capped.
@@ -1310,7 +1314,7 @@ mod tests {
             .map(|i| format!("/ip4/203.0.113.{i}/tcp/4001"))
             .collect();
         assert_eq!(
-            select_dial_addrs(addrs(&listeners), None, false).len(),
+            select_dial_addrs(addrs(&listeners), None, false, true).len(),
             MAX_DIAL_ADDRS
         );
     }

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -1276,7 +1276,12 @@ mod tests {
             relay().to_base58(),
             peer().to_base58()
         );
-        let out = select_dial_addrs(addrs(&[circuit]), Some("/ip4/203.0.113.7/tcp/4001"), false, true);
+        let out = select_dial_addrs(
+            addrs(&[circuit]),
+            Some("/ip4/203.0.113.7/tcp/4001"),
+            false,
+            true,
+        );
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].to_string(), "/ip4/203.0.113.7/tcp/4001");
     }
@@ -1334,7 +1339,10 @@ mod tests {
     #[test]
     fn select_dial_addrs_follows_the_address_policy() {
         let reserved = addrs(&["/ip4/198.18.0.40/tcp/8080".to_string()]);
-        assert_eq!(select_dial_addrs(reserved.clone(), None, false, true), reserved);
+        assert_eq!(
+            select_dial_addrs(reserved.clone(), None, false, true),
+            reserved
+        );
         assert!(select_dial_addrs(reserved, None, true, true).is_empty());
     }
 

--- a/core/crates/kwaai-cli/src/grpc_server.rs
+++ b/core/crates/kwaai-cli/src/grpc_server.rs
@@ -2615,6 +2615,7 @@ mod tests {
             throughput: 1.0,
             trust_score: None,
             lease_v1: false,
+            dial_addrs: Vec::new(),
         };
 
         // Gap at block 3: [0,3) + [4,8).

--- a/core/crates/kwaai-cli/src/node.rs
+++ b/core/crates/kwaai-cli/src/node.rs
@@ -631,7 +631,7 @@ mod capacity_lease_dht_tests {
     use super::*;
 
     /// Decode `to_msgpack()`'s `Ext(64, ...)` wrapper down to the inner
-    /// fields map, mirroring what `shard_cmd.rs`'s `decode_server_info_ext`
+    /// fields map, mirroring what `announce.rs`'s `decode_server_info_ext`
     /// does on the read side.
     fn decode_fields_map(bytes: &[u8]) -> rmpv::Value {
         let ext = rmpv::decode::read_value(&mut &bytes[..]).expect("valid outer msgpack");

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -95,6 +95,10 @@ pub struct NativeNode {
     /// Replica target for decentralized placement; meaningless when
     /// `decentralized` is false.
     replication: usize,
+    /// The operator's declared reachable address, if any. Copied here for the
+    /// same reason as the two fields above: it is an announce input, and
+    /// `announce` should not need a config reference to publish it.
+    announce_addr: Option<String>,
 }
 
 impl NativeNode {
@@ -275,6 +279,7 @@ impl NativeNode {
             tasks,
             decentralized: config.decentralized_dht,
             replication: config.dht_replication,
+            announce_addr: configured_announce_addr(config),
         })
     }
 
@@ -316,9 +321,18 @@ impl NativeNode {
     pub async fn announce(
         &self,
         ctx: &AnnounceContext<'_>,
-        server_info: &DHTServerInfo,
+        server_info: &mut DHTServerInfo,
         bootstrap_peers: &[String],
     ) -> Result<Vec<crate::announce::StoreTiming>> {
+        // Refreshed here, not by the caller, so no announce path can forget —
+        // a reservation rotating is what makes a published address wrong, and
+        // it lands between ticks.
+        server_info.dial_addrs = crate::announce::publishable_dial_addrs(
+            &self.handle,
+            self.peer_id,
+            self.announce_addr.as_deref(),
+        )
+        .await;
         let records = build_announce_records(ctx, server_info)?;
         for record in &records {
             self.storage.handle_store(record.clone());
@@ -479,7 +493,7 @@ pub async fn run_native_node(
     // ── Initial announcement ───────────────────────────────────────────────
     if config.announce_self {
         info!("[3/4] Announcing to DHT...");
-        if let Err(e) = node.announce(&ctx, &server_info, bootstrap_peers).await {
+        if let Err(e) = node.announce(&ctx, &mut server_info, bootstrap_peers).await {
             warn!("Initial announce failed: {e:#} — will retry at the 300 s tick");
         }
     }
@@ -536,7 +550,7 @@ pub async fn run_native_node(
                 reload_block_range(&mut config);
                 refresh_server_info(&mut server_info, &config);
                 if config.announce_self {
-                    if let Err(e) = node.announce(&ctx, &server_info, bootstrap_peers).await {
+                    if let Err(e) = node.announce(&ctx, &mut server_info, bootstrap_peers).await {
                         warn!("Re-announce after SIGHUP failed: {e:#}");
                     }
                 }
@@ -588,7 +602,7 @@ pub async fn run_native_node(
                         ShardManager::shard_is_ready(),
                         ShardManager::whole_model_is_ready()
                     );
-                    match node.announce(&ctx, &server_info, bootstrap_peers).await {
+                    match node.announce(&ctx, &mut server_info, bootstrap_peers).await {
                         Ok(timings) => {
                             record_reputation(&mut rep_store, timings);
                             if tick_state.announceable {
@@ -650,7 +664,7 @@ pub async fn run_native_node(
                 crate::node::refresh_throughput(&mut server_info, &config.model, dl_bps, using_relay);
                 server_info.using_relay = using_relay;
                 refresh_server_info(&mut server_info, &config);
-                match node.announce(&ctx, &server_info, bootstrap_peers).await {
+                match node.announce(&ctx, &mut server_info, bootstrap_peers).await {
                     // Only a successful publish consumes the epoch; on failure
                     // the next settle window or the 300 s tick retries it.
                     Ok(_) => last_announced_epoch = state.epoch,
@@ -663,7 +677,7 @@ pub async fn run_native_node(
             Some(()) = ollama_recovery_rx.recv(), if config.announce_self => {
                 info!("Ollama recovered — triggering immediate re-announce");
                 refresh_server_info(&mut server_info, &config);
-                if let Err(e) = node.announce(&ctx, &server_info, bootstrap_peers).await {
+                if let Err(e) = node.announce(&ctx, &mut server_info, bootstrap_peers).await {
                     warn!("Re-announce after Ollama recovery failed: {e:#}");
                 }
             }
@@ -994,7 +1008,7 @@ mod tests {
             repository: "https://huggingface.co/Qwen/Qwen3-8B",
             total_blocks: 32,
         };
-        let server_info = DHTServerInfo::new(
+        let mut server_info = DHTServerInfo::new(
             config.start_block() as i32,
             config.effective_end_block() as i32,
             "node-under-test",
@@ -1005,7 +1019,7 @@ mod tests {
             node.peer_id.to_base58(),
         );
 
-        node.announce(&ctx, &server_info, &[])
+        node.announce(&ctx, &mut server_info, &[])
             .await
             .expect("an ordinary announce must build its records");
         assert!(

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -103,9 +103,10 @@ pub struct NativeNode {
     /// announce carries. The same key the swarm authenticates connections
     /// with, which is what makes the signature checkable against the peer id.
     identity: libp2p::identity::Keypair,
-    /// `require_global_ips`, as handed to the swarm: the dial-address record
-    /// is selected under the same policy the daemon dials by.
+    /// `require_global_ips` and `enable_quic`, as handed to the swarm: the
+    /// dial-address record is selected under the policy the daemon dials by.
     require_global_ips: bool,
+    dials_quic: bool,
 }
 
 impl NativeNode {
@@ -181,6 +182,7 @@ impl NativeNode {
         };
 
         let require_global_ips = net_config.require_global_ips;
+        let dials_quic = net_config.enable_quic;
         // Cloned, not moved: the same key signs the dial-address record on
         // every announce, which is what lets a reader bind those addresses to
         // this peer id.
@@ -293,6 +295,7 @@ impl NativeNode {
             announce_addr: configured_announce_addr(config),
             identity: keypair,
             require_global_ips,
+            dials_quic,
         })
     }
 
@@ -345,6 +348,7 @@ impl NativeNode {
             &self.identity,
             self.announce_addr.as_deref(),
             self.require_global_ips,
+            self.dials_quic,
         )
         .await;
         let records = build_announce_records(ctx, server_info)?;

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -103,6 +103,9 @@ pub struct NativeNode {
     /// announce carries. The same key the swarm authenticates connections
     /// with, which is what makes the signature checkable against the peer id.
     identity: libp2p::identity::Keypair,
+    /// `require_global_ips`, as handed to the swarm: the dial-address record
+    /// is selected under the same policy the daemon dials by.
+    require_global_ips: bool,
 }
 
 impl NativeNode {
@@ -177,6 +180,7 @@ impl NativeNode {
             ..NetworkConfig::default()
         };
 
+        let require_global_ips = net_config.require_global_ips;
         // Cloned, not moved: the same key signs the dial-address record on
         // every announce, which is what lets a reader bind those addresses to
         // this peer id.
@@ -288,6 +292,7 @@ impl NativeNode {
             replication: config.dht_replication,
             announce_addr: configured_announce_addr(config),
             identity: keypair,
+            require_global_ips,
         })
     }
 
@@ -339,6 +344,7 @@ impl NativeNode {
             &self.handle,
             &self.identity,
             self.announce_addr.as_deref(),
+            self.require_global_ips,
         )
         .await;
         let records = build_announce_records(ctx, server_info)?;

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -99,6 +99,10 @@ pub struct NativeNode {
     /// same reason as the two fields above: it is an announce input, and
     /// `announce` should not need a config reference to publish it.
     announce_addr: Option<String>,
+    /// The node's identity key, kept to sign the dial-address record every
+    /// announce carries. The same key the swarm authenticates connections
+    /// with, which is what makes the signature checkable against the peer id.
+    identity: libp2p::identity::Keypair,
 }
 
 impl NativeNode {
@@ -173,8 +177,11 @@ impl NativeNode {
             ..NetworkConfig::default()
         };
 
-        let (handle, swarm_task) =
-            NetworkService::spawn(net_config, keypair).context("starting the libp2p swarm")?;
+        // Cloned, not moved: the same key signs the dial-address record on
+        // every announce, which is what lets a reader bind those addresses to
+        // this peer id.
+        let (handle, swarm_task) = NetworkService::spawn(net_config, keypair.clone())
+            .context("starting the libp2p swarm")?;
         info!("Peer ID: {}", peer_id.to_base58());
 
         let mut tasks = vec![swarm_task];
@@ -280,6 +287,7 @@ impl NativeNode {
             decentralized: config.decentralized_dht,
             replication: config.dht_replication,
             announce_addr: configured_announce_addr(config),
+            identity: keypair,
         })
     }
 
@@ -327,9 +335,9 @@ impl NativeNode {
         // Refreshed here, not by the caller, so no announce path can forget —
         // a reservation rotating is what makes a published address wrong, and
         // it lands between ticks.
-        server_info.dial_addrs = crate::announce::publishable_dial_addrs(
+        server_info.signed_addrs = crate::announce::signed_dial_addrs(
             &self.handle,
-            self.peer_id,
+            &self.identity,
             self.announce_addr.as_deref(),
         )
         .await;

--- a/core/crates/kwaai-cli/src/rebalancer.rs
+++ b/core/crates/kwaai-cli/src/rebalancer.rs
@@ -148,6 +148,7 @@ mod tests {
             trust_score: None,
             throughput: 0.0,
             lease_v1: false,
+            dial_addrs: Vec::new(),
         }
     }
 

--- a/core/crates/kwaai-cli/src/shard_api.rs
+++ b/core/crates/kwaai-cli/src/shard_api.rs
@@ -873,7 +873,18 @@ pub async fn run(args: ShardApiArgs) -> Result<()> {
 
     // Pre-connect to all block-server peers
     for entry in &chain {
-        let _ = crate::shard_cmd::connect_chain_entry(&mut client, entry).await;
+        // A peer whose binary predates `addrs_signed` publishes none, and the
+        // daemon rejects a connect carrying no addresses — that one case keeps
+        // the bare-PeerId dial.
+        let _ = if entry.dial_addrs.is_empty() {
+            client
+                .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
+                .await
+        } else {
+            client
+                .connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)
+                .await
+        };
     }
 
     // Detect llama.cpp fast path (full model on this node + GGUF available)

--- a/core/crates/kwaai-cli/src/shard_api.rs
+++ b/core/crates/kwaai-cli/src/shard_api.rs
@@ -873,18 +873,9 @@ pub async fn run(args: ShardApiArgs) -> Result<()> {
 
     // Pre-connect to all block-server peers
     for entry in &chain {
-        // A peer whose binary predates `addrs_signed` publishes none, and the
-        // daemon rejects a connect carrying no addresses — that one case keeps
-        // the bare-PeerId dial.
-        let _ = if entry.dial_addrs.is_empty() {
-            client
-                .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
-                .await
-        } else {
-            client
-                .connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)
-                .await
-        };
+        let _ = client
+            .connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)
+            .await;
     }
 
     // Detect llama.cpp fast path (full model on this node + GGUF available)

--- a/core/crates/kwaai-cli/src/shard_api.rs
+++ b/core/crates/kwaai-cli/src/shard_api.rs
@@ -873,8 +873,7 @@ pub async fn run(args: ShardApiArgs) -> Result<()> {
 
     // Pre-connect to all block-server peers
     for entry in &chain {
-        let hint = format!("/p2p/{}", entry.peer_id.to_base58());
-        let _ = client.connect_peer(&hint).await;
+        let _ = crate::shard_cmd::connect_chain_entry(&mut client, entry).await;
     }
 
     // Detect llama.cpp fast path (full model on this node + GGUF available)

--- a/core/crates/kwaai-cli/src/shard_api.rs
+++ b/core/crates/kwaai-cli/src/shard_api.rs
@@ -32,8 +32,8 @@ use crate::config::KwaaiNetConfig;
 use crate::display::*;
 use crate::hf;
 use crate::shard_cmd::{
-    daemon_socket, discover_chain, forward_through_chain, load_circuit_by_id, sample_token,
-    BlockServerEntry,
+    daemon_socket, discover_chain, forward_through_chain, load_circuit_by_id,
+    refresh_circuit_addrs, sample_token, BlockServerEntry,
 };
 
 // ── llama.cpp fast path (macOS Metal acceleration) ──────────────────────────
@@ -787,8 +787,17 @@ pub async fn run(args: ShardApiArgs) -> Result<()> {
     // Acquire chain: from a saved circuit (skips DHT) or fresh discovery.
     let chain = if let Some(ref circuit_id) = args.circuit {
         let circuit = load_circuit_by_id(circuit_id)?;
-        let entries: Vec<BlockServerEntry> =
+        let mut entries: Vec<BlockServerEntry> =
             circuit.chain.iter().filter_map(|e| e.to_entry()).collect();
+        refresh_circuit_addrs(
+            &mut entries,
+            &mut client,
+            &our_peer_id,
+            &dht_prefix,
+            total_blocks,
+            &bootstrap_peers,
+        )
+        .await;
         if entries.is_empty() {
             return Err(anyhow::anyhow!(
                 "Circuit '{}' loaded but contains no usable entries",

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -2385,7 +2385,8 @@ pub async fn discover_inference_peer(
     let mut req_bytes = Vec::new();
     find_req.encode(&mut req_bytes).ok()?;
 
-    let mut candidates: Vec<(f64, PeerId, String)> = Vec::new(); // (throughput, peer_id, name)
+    // (throughput, peer_id, name, the addresses the peer signed for itself)
+    let mut candidates: Vec<(f64, PeerId, String, Vec<libp2p::Multiaddr>)> = Vec::new();
 
     let query_peers = resolve_query_peers(client, bootstrap_peers).await;
 
@@ -2421,7 +2422,12 @@ pub async fn discover_inference_peer(
                 if let Some(info) = decode_server_info_ext(&result.value) {
                     if info.state == 2 && version_meets_minimum(&info.version) {
                         if let Ok(pid) = info.peer_id_b58.parse::<PeerId>() {
-                            candidates.push((info.throughput, pid, info.public_name));
+                            candidates.push((
+                                info.throughput,
+                                pid,
+                                info.public_name,
+                                info.dial_addrs,
+                            ));
                         }
                     }
                 }
@@ -2429,7 +2435,7 @@ pub async fn discover_inference_peer(
                 let mut tmp: HashMap<String, BlockServerEntry> = HashMap::new();
                 decode_server_info_dictionary(&result.value, &mut tmp);
                 for (_, e) in tmp {
-                    candidates.push((e.throughput, e.peer_id, e.public_name));
+                    candidates.push((e.throughput, e.peer_id, e.public_name, e.dial_addrs));
                 }
             }
         }
@@ -2440,14 +2446,14 @@ pub async fn discover_inference_peer(
         if let (Some(prefix), Some(total)) = (dht_prefix, total_blocks) {
             let chain = discover_chain(client, our_peer_id, prefix, total, bootstrap_peers).await;
             for e in chain {
-                candidates.push((e.throughput, e.peer_id, e.public_name));
+                candidates.push((e.throughput, e.peer_id, e.public_name, e.dial_addrs));
             }
         }
     }
 
     // Remove ourselves — dialling self via p2p proxy always fails.
     let our_b58 = our_peer_id.to_base58();
-    candidates.retain(|(_, pid, _)| pid.to_base58() != our_b58);
+    candidates.retain(|(_, pid, _, _)| pid.to_base58() != our_b58);
 
     if candidates.is_empty() {
         return None;
@@ -2459,13 +2465,18 @@ pub async fn discover_inference_peer(
             .unwrap_or(std::cmp::Ordering::Equal)
             .then_with(|| a.2.cmp(&b.2))
     });
-    let (tps, best_peer, name) = &candidates[0];
+    let (tps, best_peer, name, dial_addrs) = &candidates[0];
     tracing::info!(
         "p2p://auto → {} ({}, {:.1} tok/s)",
         best_peer.to_base58(),
         name,
         tps
     );
+    // The URL names the peer alone; the daemon keeps the addresses so the dial
+    // it leads to is seeded, not bare. Best effort — the URL is still good.
+    if !dial_addrs.is_empty() {
+        let _ = client.connect_peer_with_addrs(best_peer, dial_addrs).await;
+    }
     Some(format!("p2p://{}", best_peer.to_base58()))
 }
 

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -1406,11 +1406,10 @@ pub async fn cmd_shard_run(args: ShardRunArgs) -> Result<()> {
     println!("  Max tokens:   {}", max_tokens);
     print_separator();
 
-    // Connect to all block-server peers
+    // Connect to all block-server peers — best effort, and over the addresses
+    // each one published rather than by bare PeerId.
     for entry in &chain {
-        let multiaddr_hint = format!("/p2p/{}", entry.peer_id.to_base58());
-        let _ = client.connect_peer(&multiaddr_hint).await;
-        // best effort — may already be connected
+        let _ = connect_chain_entry(&mut client, entry).await;
     }
 
     // ── Inference loop ────────────────────────────────────────────────────────
@@ -1881,9 +1880,7 @@ async fn run_streaming_inner(
 
     // Best-effort dial of every server in the chain (matches CLI).
     for entry in &chain {
-        let _ = client
-            .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
-            .await;
+        let _ = connect_chain_entry(&mut client, entry).await;
     }
 
     // Pin the path for this session.
@@ -2155,6 +2152,11 @@ pub struct BlockServerEntry {
     /// the shard-chain integration phase without another decoder pass.
     #[allow(dead_code)]
     pub lease_v1: bool,
+    /// Multiaddrs the peer published for itself, each already ending in
+    /// `/p2p/<its-peer-id>`. Empty for a peer running a binary that predates
+    /// the `addrs` field — the case [`connect_chain_entry`] falls back to a
+    /// bare-PeerId dial for.
+    pub dial_addrs: Vec<String>,
 }
 
 /// The peers a DHT read should query, given the configured list.
@@ -2223,6 +2225,39 @@ async fn resolve_query_peers(client: &mut P2PClient, configured: &[String]) -> V
         crate::peer_cache::PeerCache::load_default().dial_addrs(&out.iter().cloned().collect());
     out.extend(cached);
     out
+}
+
+/// Best-effort pre-connect to one chain entry, over the addresses it published.
+///
+/// Returns whether a connection exists afterwards — every caller treats this as
+/// advisory (dispatch retries the peer anyway and falls back to another), so a
+/// failure here is not an error.
+///
+/// # Why this is not just `connect_peer("/p2p/<id>")`
+///
+/// That form asks the daemon to resolve the peer through kad, which usually
+/// cannot: rust-libp2p answers `FIND_NODE` from its k-buckets alone, so a peer
+/// is findable only while it holds a slot in the right bucket on a peer the
+/// walk reaches — see [`crate::announce::DHTServerInfo::dial_addrs`]. When it
+/// does not, the lookup returns nothing after spending a full query timeout.
+/// Dialing a published address needs no lookup at all.
+///
+/// The bare-PeerId form is still tried last, and still matters: it is the only
+/// path for a peer whose binary predates `addrs`, and it succeeds immediately
+/// when the peer is already connected or already in our routing table. It is
+/// kept even when published addresses were tried and failed — a reservation
+/// that rotated since the announce leaves stale addresses and a peer that may
+/// still be in the table — at the cost of one lookup timeout when it is not.
+pub async fn connect_chain_entry(client: &mut P2PClient, entry: &BlockServerEntry) -> bool {
+    for addr in &entry.dial_addrs {
+        if client.connect_peer(addr).await.is_ok() {
+            return true;
+        }
+    }
+    client
+        .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
+        .await
+        .is_ok()
 }
 
 /// Query bootstrap peers for all block keys of `dht_prefix` and return a
@@ -2406,12 +2441,10 @@ pub async fn discover_inference_peer(
             // Values stored under _kwaai.inference.nodes use the same
             // DHTServerInfo msgpack encoding as block records.
             if result.result_type == 1 {
-                if let Some((state, _, _, name, peer_id_b58, version, tps, _lease_v1)) =
-                    decode_server_info_ext(&result.value)
-                {
-                    if state == 2 && version_meets_minimum(&version) {
-                        if let Ok(pid) = peer_id_b58.parse::<PeerId>() {
-                            candidates.push((tps, pid, name));
+                if let Some(info) = decode_server_info_ext(&result.value) {
+                    if info.state == 2 && version_meets_minimum(&info.version) {
+                        if let Ok(pid) = info.peer_id_b58.parse::<PeerId>() {
+                            candidates.push((info.throughput, pid, info.public_name));
                         }
                     }
                 }
@@ -2549,19 +2582,18 @@ async fn pick_gap_blocks(
 /// synthesise a stable key from `public_name:start_block` so they still count
 /// for gap detection even though they cannot be routed to directly.
 fn decode_server_info_regular(bytes: &[u8]) -> Option<(String, BlockServerEntry)> {
-    let (state, start_block, end_block, public_name, peer_id_b58, version, throughput, lease_v1) =
-        decode_server_info_ext(bytes)?;
+    let info = decode_server_info_ext(bytes)?;
     // Only include ONLINE nodes (state=2); skip JOINING (1) and OFFLINE (0/-1).
-    if state != 2 {
+    if info.state != 2 {
         return None;
     }
-    if !version_meets_minimum(&version) {
+    if !version_meets_minimum(&info.version) {
         return None;
     }
-    let (dedup_key, peer_id) = match peer_id_b58.parse::<PeerId>() {
+    let (dedup_key, peer_id) = match info.peer_id_b58.parse::<PeerId>() {
         Ok(pid) => (pid.to_base58(), pid),
         Err(_) => {
-            let key = format!("legacy:{}:{}", public_name, start_block);
+            let key = format!("legacy:{}:{}", info.public_name, info.start_block);
             (key, PeerId::random())
         }
     };
@@ -2569,12 +2601,13 @@ fn decode_server_info_regular(bytes: &[u8]) -> Option<(String, BlockServerEntry)
         dedup_key,
         BlockServerEntry {
             peer_id,
-            start_block,
-            end_block,
-            public_name,
-            throughput,
+            start_block: info.start_block,
+            end_block: info.end_block,
+            public_name: info.public_name,
+            throughput: info.throughput,
             trust_score: None,
-            lease_v1,
+            lease_v1: info.lease_v1,
+            dial_addrs: info.dial_addrs,
         },
     ))
 }
@@ -2636,32 +2669,23 @@ fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockSe
             Err(_) => continue,
         };
 
-        if let Some((
-            state,
-            start_block,
-            end_block,
-            public_name,
-            _,
-            version,
-            throughput,
-            lease_v1,
-        )) = decode_server_info_ext(value_bytes)
-        {
-            if state != 2 {
+        if let Some(info) = decode_server_info_ext(value_bytes) {
+            if info.state != 2 {
                 continue;
             }
-            if !version_meets_minimum(&version) {
+            if !version_meets_minimum(&info.version) {
                 continue;
             }
             let key = peer_id_b58.clone();
             out.entry(key).or_insert(BlockServerEntry {
                 peer_id,
-                start_block,
-                end_block,
-                public_name,
-                throughput,
+                start_block: info.start_block,
+                end_block: info.end_block,
+                public_name: info.public_name,
+                throughput: info.throughput,
                 trust_score: None,
-                lease_v1,
+                lease_v1: info.lease_v1,
+                dial_addrs: info.dial_addrs,
             });
         }
     }
@@ -2722,9 +2746,24 @@ pub fn snap_to_valid_blocks(n: usize) -> usize {
 /// Core decoder: `Ext(64, msgpack([state, throughput, {start_block, end_block, …}]))`
 /// Returns `(state, start_block, end_block, public_name, peer_id_b58, version, throughput, lease_v1)`.
 #[allow(clippy::type_complexity)]
-fn decode_server_info_ext(
-    bytes: &[u8],
-) -> Option<(i32, usize, usize, String, String, String, f64, bool)> {
+/// One decoded announcement, as a struct rather than the positional tuple this
+/// used to return: nine fields where three call sites want different subsets is
+/// exactly the shape where `_`-holes drift out of alignment with the producer.
+struct ServerInfoFields {
+    state: i32,
+    start_block: usize,
+    end_block: usize,
+    public_name: String,
+    peer_id_b58: String,
+    version: String,
+    throughput: f64,
+    lease_v1: bool,
+    /// Multiaddrs the peer says it can be dialed on (`addrs`), empty for a peer
+    /// that published none — see [`crate::announce::DHTServerInfo::dial_addrs`].
+    dial_addrs: Vec<String>,
+}
+
+fn decode_server_info_ext(bytes: &[u8]) -> Option<ServerInfoFields> {
     let val = rmpv::decode::read_value(&mut &bytes[..]).ok()?;
     let inner_bytes = match &val {
         rmpv::Value::Ext(64, b) => b.as_slice(),
@@ -2765,7 +2804,22 @@ fn decode_server_info_ext(
         .and_then(|(_, v)| v.as_bool())
         .unwrap_or(false);
 
-    Some((
+    // Anything that is not a string is dropped rather than failing the whole
+    // record: an address list is an optimisation, and a peer that garbles one
+    // entry is still worth reaching on the others.
+    let dial_addrs = map
+        .iter()
+        .find(|(ky, _)| ky.as_str() == Some("addrs"))
+        .and_then(|(_, v)| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .take(crate::announce::MAX_DIAL_ADDRS)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(ServerInfoFields {
         state,
         start_block,
         end_block,
@@ -2774,7 +2828,8 @@ fn decode_server_info_ext(
         version,
         throughput,
         lease_v1,
-    ))
+        dial_addrs,
+    })
 }
 
 // ── Pinned path ──────────────────────────────────────────────────────────────
@@ -2862,6 +2917,10 @@ impl SerializableEntry {
             // Capacity Lease — conservatively unknown/false, same as any
             // other legacy-shaped record with the key absent.
             lease_v1: false,
+            // Likewise no addresses: a saved circuit is a list of peers, and
+            // where they were reachable months ago is not worth replaying.
+            // Rediscovery refills these from the live record.
+            dial_addrs: Vec::new(),
         })
     }
 }
@@ -3839,8 +3898,86 @@ mod tests {
     #[test]
     fn decode_server_info_ext_reads_lease_v1_when_present() {
         let bytes = make_server_info_ext_bytes(Some(true));
-        let (_, _, _, _, _, _, _, lease_v1) = decode_server_info_ext(&bytes).expect("decodes");
-        assert!(lease_v1);
+        let info = decode_server_info_ext(&bytes).expect("decodes");
+        assert!(info.lease_v1);
+    }
+
+    /// The publisher's own encoder is the producer of record, so the decoder is
+    /// tested against what it emits rather than against a hand-built map.
+    #[test]
+    fn decode_server_info_ext_round_trips_the_published_addrs() {
+        let peer = PeerId::random();
+        let addr = format!("/ip4/203.0.113.7/tcp/4001/p2p/{}", peer.to_base58());
+        let mut published = crate::announce::DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            peer.to_base58(),
+        );
+        published.dial_addrs = vec![addr.clone()];
+
+        let info =
+            decode_server_info_ext(&published.to_msgpack().expect("encodes")).expect("decodes");
+        assert_eq!(info.dial_addrs, vec![addr]);
+    }
+
+    /// A peer on a binary that predates `addrs` decodes to an empty list, not a
+    /// dropped record — it is still dialable by PeerId if it happens to be in
+    /// the routing table.
+    #[test]
+    fn decode_server_info_ext_defaults_addrs_empty_for_legacy_bytes() {
+        let bytes = make_server_info_ext_bytes(None);
+        let info = decode_server_info_ext(&bytes).expect("decodes");
+        assert_eq!(info.state, 2, "the rest of the record must still decode");
+        assert!(info.dial_addrs.is_empty());
+    }
+
+    /// A malformed entry costs that entry, not the record: the peer is still
+    /// worth reaching on whatever else it published.
+    #[test]
+    fn decode_server_info_ext_skips_non_string_addrs() {
+        let mut bytes_fields = vec![
+            (rmpv::Value::from("start_block"), rmpv::Value::from(0i64)),
+            (rmpv::Value::from("end_block"), rmpv::Value::from(32i64)),
+            (
+                rmpv::Value::from("public_name"),
+                rmpv::Value::from("test-node"),
+            ),
+            (
+                rmpv::Value::from("peer_id"),
+                rmpv::Value::from(PeerId::random().to_base58().as_str()),
+            ),
+            (
+                rmpv::Value::from("version"),
+                rmpv::Value::from("kwaai-0.5.4"),
+            ),
+        ];
+        bytes_fields.push((
+            rmpv::Value::from("addrs"),
+            rmpv::Value::Array(vec![
+                rmpv::Value::from(7i64),
+                rmpv::Value::from("/ip4/203.0.113.7/tcp/4001"),
+            ]),
+        ));
+        let inner = rmpv::Value::Array(vec![
+            rmpv::Value::from(2i32),
+            rmpv::Value::from(10.0),
+            rmpv::Value::Map(bytes_fields),
+        ]);
+        let mut inner_bytes = Vec::new();
+        rmpv::encode::write_value(&mut inner_bytes, &inner).unwrap();
+        let mut bytes = Vec::new();
+        rmpv::encode::write_value(&mut bytes, &rmpv::Value::Ext(64, inner_bytes)).unwrap();
+
+        let info = decode_server_info_ext(&bytes).expect("decodes");
+        assert_eq!(
+            info.dial_addrs,
+            vec!["/ip4/203.0.113.7/tcp/4001".to_string()]
+        );
     }
 
     #[test]
@@ -3849,7 +3986,8 @@ mod tests {
         // announcement looks like. Must decode successfully (not error) and
         // default to false, not panic or silently drop the record.
         let bytes = make_server_info_ext_bytes(None);
-        let (state, _, _, _, _, _, _, lease_v1) = decode_server_info_ext(&bytes).expect("decodes");
+        let info = decode_server_info_ext(&bytes).expect("decodes");
+        let (state, lease_v1) = (info.state, info.lease_v1);
         assert_eq!(
             state, 2,
             "pre-existing fields must still decode alongside the new one"

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -30,6 +30,9 @@ use std::{
 };
 use tokio::sync::RwLock;
 
+use crate::announce::{
+    decode_server_info_dictionary, decode_server_info_ext, decode_server_info_regular,
+};
 use crate::block_rpc::{
     call_block_forward, f16_bytes_to_tensor, make_block_rpc_handler, token_ids_to_bytes,
     InferenceRequest, PayloadType, ShardCell,
@@ -1406,10 +1409,21 @@ pub async fn cmd_shard_run(args: ShardRunArgs) -> Result<()> {
     println!("  Max tokens:   {}", max_tokens);
     print_separator();
 
-    // Connect to all block-server peers — best effort, and over the addresses
-    // each one published rather than by bare PeerId.
+    // Connect to all block-server peers — best effort, handing the daemon the
+    // addresses each one published so that later dials can reuse them too.
     for entry in &chain {
-        let _ = connect_chain_entry(&mut client, entry).await;
+        // A peer whose binary predates `addrs_signed` publishes none, and the
+        // daemon rejects a connect carrying no addresses — that one case keeps
+        // the bare-PeerId dial.
+        let _ = if entry.dial_addrs.is_empty() {
+            client
+                .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
+                .await
+        } else {
+            client
+                .connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)
+                .await
+        };
     }
 
     // ── Inference loop ────────────────────────────────────────────────────────
@@ -1880,7 +1894,18 @@ async fn run_streaming_inner(
 
     // Best-effort dial of every server in the chain (matches CLI).
     for entry in &chain {
-        let _ = connect_chain_entry(&mut client, entry).await;
+        // A peer whose binary predates `addrs_signed` publishes none, and the
+        // daemon rejects a connect carrying no addresses — that one case keeps
+        // the bare-PeerId dial.
+        let _ = if entry.dial_addrs.is_empty() {
+            client
+                .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
+                .await
+        } else {
+            client
+                .connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)
+                .await
+        };
     }
 
     // Pin the path for this session.
@@ -2152,12 +2177,16 @@ pub struct BlockServerEntry {
     /// the shard-chain integration phase without another decoder pass.
     #[allow(dead_code)]
     pub lease_v1: bool,
-    /// Multiaddrs the peer published for itself and signed, each ending in
-    /// `/p2p/<its-peer-id>` — see [`verified_dial_addrs`], which is the only
-    /// thing that fills this in. Empty for a peer running a binary that
-    /// predates the field, and for one whose record failed verification: both
-    /// are cases [`connect_chain_entry`] falls back to a bare-PeerId dial for.
-    pub dial_addrs: Vec<String>,
+    /// Bare multiaddrs from the peer's own signed record — the destination
+    /// `/p2p/<its-peer-id>` stripped, a circuit's relay hop kept — as
+    /// [`kwaai_p2p::peer_record::verified_addrs`] returns them.
+    ///
+    /// They are handed straight to the daemon, which keeps them in its
+    /// learned-address map, so every later dial to the peer benefits and not
+    /// just the pre-connect that supplied them. Empty for a peer running a
+    /// binary that predates the field, and for one whose record failed
+    /// verification.
+    pub dial_addrs: Vec<libp2p::Multiaddr>,
 }
 
 /// The peers a DHT read should query, given the configured list.
@@ -2226,47 +2255,6 @@ async fn resolve_query_peers(client: &mut P2PClient, configured: &[String]) -> V
         crate::peer_cache::PeerCache::load_default().dial_addrs(&out.iter().cloned().collect());
     out.extend(cached);
     out
-}
-
-/// Best-effort pre-connect to one chain entry, over the addresses it published.
-///
-/// Returns whether a connection exists afterwards — every caller treats this as
-/// advisory (dispatch retries the peer anyway and falls back to another), so a
-/// failure here is not an error.
-///
-/// # Why this is not just `connect_peer("/p2p/<id>")`
-///
-/// That form asks the daemon to resolve the peer through kad, which usually
-/// cannot: rust-libp2p answers `FIND_NODE` from its k-buckets alone, so a peer
-/// is findable only while it holds a slot in the right bucket on a peer the
-/// walk reaches — see [`crate::announce::DHTServerInfo::signed_addrs`]. When it
-/// does not, the lookup returns nothing after spending a full query timeout.
-/// Dialing a published address needs no lookup at all.
-///
-/// The bare-PeerId form is still tried last, and still matters: it is the only
-/// path for a peer whose binary predates `addrs`, and it succeeds immediately
-/// when the peer is already connected or already in our routing table. It is
-/// kept even when published addresses were tried and failed — a reservation
-/// that rotated since the announce leaves stale addresses and a peer that may
-/// still be in the table — at the cost of one lookup timeout when it is not.
-pub async fn connect_chain_entry(client: &mut P2PClient, entry: &BlockServerEntry) -> bool {
-    for addr in &entry.dial_addrs {
-        if client.connect_peer(addr).await.is_ok() {
-            tracing::debug!(peer = %entry.peer_id, %addr, "pre-connected via published address");
-            return true;
-        }
-    }
-    // Which path a pre-connect took is the one fact worth having when a chain
-    // fails to form, so the fallback is logged even though it is routine.
-    tracing::debug!(
-        peer = %entry.peer_id,
-        published = entry.dial_addrs.len(),
-        "no published address connected — falling back to a bare-PeerId dial"
-    );
-    client
-        .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
-        .await
-        .is_ok()
 }
 
 /// Query bootstrap peers for all block keys of `dht_prefix` and return a
@@ -2582,134 +2570,6 @@ async fn pick_gap_blocks(
     Ok((start, end))
 }
 
-// ── Server info decoding ──────────────────────────────────────────────────────
-
-/// Parse `Ext(64, [state, throughput, {start_block, end_block, peer_id, …}])`
-/// from a FoundRegular value.
-///
-/// Returns `(dedup_key, entry)`.  Legacy nodes (pre-v0.3.3) omit `peer_id`; we
-/// synthesise a stable key from `public_name:start_block` so they still count
-/// for gap detection even though they cannot be routed to directly.
-fn decode_server_info_regular(bytes: &[u8]) -> Option<(String, BlockServerEntry)> {
-    let info = decode_server_info_ext(bytes)?;
-    // Only include ONLINE nodes (state=2); skip JOINING (1) and OFFLINE (0/-1).
-    if info.state != 2 {
-        return None;
-    }
-    if !version_meets_minimum(&info.version) {
-        return None;
-    }
-    let (dedup_key, peer_id) = match info.peer_id_b58.parse::<PeerId>() {
-        Ok(pid) => (pid.to_base58(), pid),
-        Err(_) => {
-            let key = format!("legacy:{}:{}", info.public_name, info.start_block);
-            (key, PeerId::random())
-        }
-    };
-    Some((
-        dedup_key,
-        BlockServerEntry {
-            peer_id,
-            start_block: info.start_block,
-            end_block: info.end_block,
-            public_name: info.public_name,
-            throughput: info.throughput,
-            trust_score: None,
-            lease_v1: info.lease_v1,
-            dial_addrs: info.dial_addrs,
-        },
-    ))
-}
-
-/// Parse `Ext(80, [expiry, created, [[subkey_bytes, value_bytes, expiry], …]])`
-/// from a FoundDictionary value. Appends into `out` (deduplicates by peer_id).
-fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockServerEntry>) {
-    let outer = match rmpv::decode::read_value(&mut &bytes[..]) {
-        Ok(v) => v,
-        Err(_) => return,
-    };
-    let inner_bytes = match &outer {
-        rmpv::Value::Ext(80, b) => b.as_slice(),
-        _ => return,
-    };
-    let inner = match rmpv::decode::read_value(&mut &inner_bytes[..]) {
-        Ok(v) => v,
-        Err(_) => return,
-    };
-    let outer_arr = match inner.as_array() {
-        Some(a) if a.len() >= 3 => a,
-        _ => return,
-    };
-    let entries = match outer_arr[2].as_array() {
-        Some(e) => e,
-        None => return,
-    };
-
-    for entry in entries {
-        let arr = match entry.as_array() {
-            Some(a) if a.len() >= 2 => a,
-            _ => continue,
-        };
-
-        // Subkey is rmp_serde::to_vec(&peer_id_base58) = msgpack(string)
-        let peer_id_b58 = match &arr[0] {
-            rmpv::Value::String(s) => s.as_str().unwrap_or("").to_string(),
-            rmpv::Value::Binary(b) => {
-                // Decode as msgpack string
-                match rmpv::decode::read_value(&mut b.as_slice()) {
-                    Ok(rmpv::Value::String(s)) => s.as_str().unwrap_or("").to_string(),
-                    _ => continue,
-                }
-            }
-            _ => continue,
-        };
-
-        let value_bytes = match &arr[1] {
-            rmpv::Value::Binary(b) => b.as_slice(),
-            _ => continue,
-        };
-
-        if peer_id_b58.is_empty() {
-            continue;
-        }
-
-        let peer_id = match peer_id_b58.parse::<PeerId>() {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        if let Some(info) = decode_server_info_ext(value_bytes) {
-            if info.state != 2 {
-                continue;
-            }
-            if !version_meets_minimum(&info.version) {
-                continue;
-            }
-            // The entry is identified by its *subkey*, but the signature was
-            // checked against the `peer_id` inside the value — and one writer
-            // controls both. A value naming a different peer than the subkey
-            // it sits under would hand this entry `peer_id` from the subkey
-            // and addresses belonging to whoever the value names. Legacy
-            // records omit `peer_id` entirely, so only a present-and-different
-            // one is a contradiction.
-            if !info.peer_id_b58.is_empty() && info.peer_id_b58 != peer_id_b58 {
-                continue;
-            }
-            let key = peer_id_b58.clone();
-            out.entry(key).or_insert(BlockServerEntry {
-                peer_id,
-                start_block: info.start_block,
-                end_block: info.end_block,
-                public_name: info.public_name,
-                throughput: info.throughput,
-                trust_score: None,
-                lease_v1: info.lease_v1,
-                dial_addrs: info.dial_addrs,
-            });
-        }
-    }
-}
-
 /// Minimum version required for a node's DHT record to be trusted.
 /// Nodes below this version announced stale block data unconditionally.
 const MIN_VERSION: (u32, u32, u32) = (0, 3, 15);
@@ -2728,7 +2588,7 @@ fn parse_kwaai_version(s: &str) -> Option<(u32, u32, u32)> {
     Some((maj, min, pat))
 }
 
-fn version_meets_minimum(version_str: &str) -> bool {
+pub fn version_meets_minimum(version_str: &str) -> bool {
     match parse_kwaai_version(version_str) {
         Some(v) => v >= MIN_VERSION,
         None => false, // unparseable / missing version → pre-0.3.15, exclude
@@ -2760,104 +2620,6 @@ pub fn snap_to_valid_blocks(n: usize) -> usize {
         .iter()
         .min_by_key(|&&v| (v as i64 - n as i64).unsigned_abs())
         .unwrap_or(&4)
-}
-
-/// [`kwaai_p2p::peer_record::verified_addrs`], as dialable strings.
-///
-/// The verification itself is network-layer work and lives in `kwaai-p2p`; all
-/// this adds is the announcement's string-typed peer id and the `/p2p/<peer>`
-/// the record deliberately omits — a peer record stores its addresses bare,
-/// with the id inside, under the signature, so a reader re-attaches it to dial.
-fn verified_dial_addrs(envelope_bytes: &[u8], peer_id_b58: &str) -> Vec<String> {
-    let Ok(claimed) = peer_id_b58.parse::<PeerId>() else {
-        return Vec::new();
-    };
-    kwaai_p2p::peer_record::verified_addrs(envelope_bytes, claimed)
-        .into_iter()
-        .map(|a| {
-            a.with(libp2p::multiaddr::Protocol::P2p(claimed))
-                .to_string()
-        })
-        .collect()
-}
-
-/// One decoded announcement, as a struct rather than the positional tuple this
-/// used to return: nine fields where three call sites want different subsets is
-/// exactly the shape where `_`-holes drift out of alignment with the producer.
-struct ServerInfoFields {
-    state: i32,
-    start_block: usize,
-    end_block: usize,
-    public_name: String,
-    peer_id_b58: String,
-    version: String,
-    throughput: f64,
-    lease_v1: bool,
-    /// Verified multiaddrs the peer can be dialed on, empty for a peer that
-    /// published none or whose record did not verify — see
-    /// [`verified_dial_addrs`].
-    dial_addrs: Vec<String>,
-}
-
-fn decode_server_info_ext(bytes: &[u8]) -> Option<ServerInfoFields> {
-    let val = rmpv::decode::read_value(&mut &bytes[..]).ok()?;
-    let inner_bytes = match &val {
-        rmpv::Value::Ext(64, b) => b.as_slice(),
-        _ => return None,
-    };
-    let inner = rmpv::decode::read_value(&mut &inner_bytes[..]).ok()?;
-    let arr = inner.as_array()?;
-    if arr.len() < 3 {
-        return None;
-    }
-    let map = arr[2].as_map()?;
-
-    let get_i = |k: &str| -> Option<i64> {
-        map.iter()
-            .find(|(ky, _)| ky.as_str() == Some(k))
-            .and_then(|(_, v)| v.as_i64())
-    };
-    let get_s = |k: &str| -> String {
-        map.iter()
-            .find(|(ky, _)| ky.as_str() == Some(k))
-            .and_then(|(_, v)| v.as_str())
-            .unwrap_or("")
-            .to_string()
-    };
-
-    let state = arr[0].as_i64().unwrap_or(0) as i32;
-    let throughput = arr[1].as_f64().unwrap_or(0.0);
-    let start_block = get_i("start_block")? as usize;
-    let end_block = get_i("end_block")? as usize;
-    let public_name = get_s("public_name");
-    let peer_id_b58 = get_s("peer_id");
-    let version = get_s("version");
-    // Absent key (a peer built before Capacity Lease existed) defaults to
-    // false — the exact "legacy peer" signal a requester falls back on.
-    let lease_v1 = map
-        .iter()
-        .find(|(ky, _)| ky.as_str() == Some("lease_v1"))
-        .and_then(|(_, v)| v.as_bool())
-        .unwrap_or(false);
-
-    let dial_addrs = map
-        .iter()
-        .find(|(ky, _)| ky.as_str() == Some("addrs_signed"))
-        .and_then(|(_, v)| v.as_slice())
-        .map(|bytes| verified_dial_addrs(bytes, &peer_id_b58))
-        .unwrap_or_default();
-
-    Some(ServerInfoFields {
-        state,
-        start_block,
-        end_block,
-        public_name,
-        peer_id_b58,
-        version,
-        throughput,
-        lease_v1,
-        dial_addrs,
-    })
 }
 
 // ── Pinned path ──────────────────────────────────────────────────────────────
@@ -3884,292 +3646,6 @@ mod tests {
         assert!(version_meets_minimum("kwaai-0.3.16"));
         assert!(version_meets_minimum("kwaai-0.4.0"));
         assert!(version_meets_minimum("kwaai-1.0.0"));
-    }
-
-    /// Build a minimal `Ext(64, [state, throughput, {fields}])` blob matching
-    /// `DHTServerInfo::to_msgpack()`'s shape, with `lease_v1` present or
-    /// absent — mirrors what a real (or legacy, pre-Capacity-Lease) peer's
-    /// DHT announcement decodes from.
-    fn make_server_info_ext_bytes(lease_v1: Option<bool>) -> Vec<u8> {
-        let mut fields = vec![
-            (rmpv::Value::from("start_block"), rmpv::Value::from(0i64)),
-            (rmpv::Value::from("end_block"), rmpv::Value::from(32i64)),
-            (
-                rmpv::Value::from("public_name"),
-                rmpv::Value::from("test-node"),
-            ),
-            (
-                rmpv::Value::from("peer_id"),
-                rmpv::Value::from(PeerId::random().to_base58().as_str()),
-            ),
-            (
-                rmpv::Value::from("version"),
-                rmpv::Value::from("kwaai-0.5.4"),
-            ),
-        ];
-        if let Some(v) = lease_v1 {
-            fields.push((rmpv::Value::from("lease_v1"), rmpv::Value::from(v)));
-        }
-        let inner = rmpv::Value::Array(vec![
-            rmpv::Value::from(2i32), // state = ONLINE
-            rmpv::Value::from(10.0), // throughput
-            rmpv::Value::Map(fields),
-        ]);
-        let mut inner_bytes = Vec::new();
-        rmpv::encode::write_value(&mut inner_bytes, &inner).unwrap();
-        let ext = rmpv::Value::Ext(64, inner_bytes);
-        let mut out = Vec::new();
-        rmpv::encode::write_value(&mut out, &ext).unwrap();
-        out
-    }
-
-    #[test]
-    fn decode_server_info_ext_reads_lease_v1_when_present() {
-        let bytes = make_server_info_ext_bytes(Some(true));
-        let info = decode_server_info_ext(&bytes).expect("decodes");
-        assert!(info.lease_v1);
-    }
-
-    /// Helper: one entry wrapped in the `Ext(80, [expiry, created, [[subkey,
-    /// value, expiry]]])` shape a FoundDictionary response carries.
-    fn dictionary_bytes(subkey_peer_b58: &str, value: &[u8]) -> Vec<u8> {
-        let subkey = rmp_serde::to_vec(&subkey_peer_b58).expect("msgpack subkey");
-        let entry = rmpv::Value::Array(vec![
-            rmpv::Value::Binary(subkey),
-            rmpv::Value::Binary(value.to_vec()),
-            rmpv::Value::from(0.0),
-        ]);
-        let inner = rmpv::Value::Array(vec![
-            rmpv::Value::from(0.0),
-            rmpv::Value::from(0.0),
-            rmpv::Value::Array(vec![entry]),
-        ]);
-        let mut inner_bytes = Vec::new();
-        rmpv::encode::write_value(&mut inner_bytes, &inner).expect("encodes");
-        let mut out = Vec::new();
-        rmpv::encode::write_value(&mut out, &rmpv::Value::Ext(80, inner_bytes)).expect("encodes");
-        out
-    }
-
-    /// Helper: a signed envelope for `key` naming `addrs`, exactly as the
-    /// publisher emits one.
-    fn signed_envelope(key: &libp2p::identity::Keypair, addrs: &[&str]) -> Vec<u8> {
-        let addrs = addrs
-            .iter()
-            .map(|a| a.parse().expect("a valid addr"))
-            .collect();
-        libp2p::core::PeerRecord::new_interop(key, addrs)
-            .expect("signs")
-            .into_signed_envelope()
-            .into_protobuf_encoding()
-    }
-
-    /// The publisher's own encoder is the producer of record, so the decoder is
-    /// tested against what it emits rather than against a hand-built map. The
-    /// bare address the record carries comes back with `/p2p/<peer>` on it,
-    /// which is the form `connect_peer` needs.
-    #[test]
-    fn decode_server_info_ext_round_trips_a_signed_address() {
-        let key = libp2p::identity::Keypair::generate_ed25519();
-        let peer = key.public().to_peer_id();
-        let mut published = crate::announce::DHTServerInfo::new(
-            0,
-            32,
-            "test-node",
-            true,
-            10.0,
-            Vec::new(),
-            None,
-            peer.to_base58(),
-        );
-        published.signed_addrs = signed_envelope(&key, &["/ip4/203.0.113.7/tcp/4001"]);
-
-        let info =
-            decode_server_info_ext(&published.to_msgpack().expect("encodes")).expect("decodes");
-        assert_eq!(
-            info.dial_addrs,
-            vec![format!(
-                "/ip4/203.0.113.7/tcp/4001/p2p/{}",
-                peer.to_base58()
-            )]
-        );
-    }
-
-    /// The attack the signature exists to stop: anyone may write under any
-    /// subkey, so a record whose addresses were signed by a different key must
-    /// yield nothing — the peer falls back to a bare-PeerId dial rather than
-    /// being steered at an address its own key never vouched for.
-    #[test]
-    fn decode_server_info_ext_rejects_addresses_signed_by_another_key() {
-        let victim = libp2p::identity::Keypair::generate_ed25519()
-            .public()
-            .to_peer_id();
-        let attacker = libp2p::identity::Keypair::generate_ed25519();
-        let mut forged = crate::announce::DHTServerInfo::new(
-            0,
-            32,
-            "test-node",
-            true,
-            10.0,
-            Vec::new(),
-            None,
-            victim.to_base58(),
-        );
-        forged.signed_addrs = signed_envelope(&attacker, &["/ip4/198.51.100.9/tcp/4001"]);
-
-        let info = decode_server_info_ext(&forged.to_msgpack().expect("encodes")).expect("decodes");
-        assert!(
-            info.dial_addrs.is_empty(),
-            "an address list the announced peer did not sign must not be dialed"
-        );
-        assert_eq!(
-            info.public_name, "test-node",
-            "the rest of the record still decodes"
-        );
-    }
-
-    /// Garbage in the field costs the addresses, not the record.
-    #[test]
-    fn decode_server_info_ext_ignores_an_unparseable_envelope() {
-        let peer = PeerId::random();
-        let mut info = crate::announce::DHTServerInfo::new(
-            0,
-            32,
-            "test-node",
-            true,
-            10.0,
-            Vec::new(),
-            None,
-            peer.to_base58(),
-        );
-        info.signed_addrs = vec![0xde, 0xad, 0xbe, 0xef];
-
-        let decoded =
-            decode_server_info_ext(&info.to_msgpack().expect("encodes")).expect("decodes");
-        assert!(decoded.dial_addrs.is_empty());
-        assert_eq!(
-            decoded.end_block, 32,
-            "the rest of the record still decodes"
-        );
-    }
-
-    /// The dictionary path keys an entry by its *subkey* but verified the
-    /// signature against the value's `peer_id`, and one writer controls both.
-    /// A value naming a different peer must be dropped, or the entry would
-    /// carry the victim's peer id beside a stranger's addresses.
-    #[test]
-    fn decode_server_info_dictionary_drops_a_value_naming_another_peer() {
-        let victim = PeerId::random();
-        let attacker = libp2p::identity::Keypair::generate_ed25519();
-        let mut forged = crate::announce::DHTServerInfo::new(
-            0,
-            32,
-            "test-node",
-            true,
-            10.0,
-            Vec::new(),
-            None,
-            attacker.public().to_peer_id().to_base58(),
-        );
-        forged.state = 2;
-        forged.signed_addrs = signed_envelope(&attacker, &["/ip4/198.51.100.9/tcp/4001"]);
-
-        let mut out = HashMap::new();
-        decode_server_info_dictionary(
-            &dictionary_bytes(&victim.to_base58(), &forged.to_msgpack().expect("encodes")),
-            &mut out,
-        );
-        assert!(
-            out.is_empty(),
-            "an entry whose value names a peer other than its subkey must not be used"
-        );
-    }
-
-    /// The same shape, honestly published, still decodes — so the check above
-    /// rejects the contradiction rather than the dictionary path itself.
-    #[test]
-    fn decode_server_info_dictionary_keeps_a_value_matching_its_subkey() {
-        let key = libp2p::identity::Keypair::generate_ed25519();
-        let peer = key.public().to_peer_id();
-        let mut honest = crate::announce::DHTServerInfo::new(
-            0,
-            32,
-            "test-node",
-            true,
-            10.0,
-            Vec::new(),
-            None,
-            peer.to_base58(),
-        );
-        honest.state = 2;
-        honest.signed_addrs = signed_envelope(&key, &["/ip4/203.0.113.7/tcp/4001"]);
-
-        let mut out = HashMap::new();
-        decode_server_info_dictionary(
-            &dictionary_bytes(&peer.to_base58(), &honest.to_msgpack().expect("encodes")),
-            &mut out,
-        );
-        let entry = out.get(&peer.to_base58()).expect("the entry decodes");
-        assert_eq!(
-            entry.dial_addrs,
-            vec![format!(
-                "/ip4/203.0.113.7/tcp/4001/p2p/{}",
-                peer.to_base58()
-            )]
-        );
-    }
-
-    /// Circuits are the whole motivation, and their shape is the one a dialer
-    /// cannot reconstruct: the relay hop must survive the round trip and the
-    /// destination must come back on the end, where `connect_peer` reads it.
-    #[test]
-    fn decode_server_info_ext_round_trips_a_circuit_address() {
-        let key = libp2p::identity::Keypair::generate_ed25519();
-        let peer = key.public().to_peer_id();
-        let relay = PeerId::random();
-        let circuit = format!("/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit", relay);
-
-        let mut published = crate::announce::DHTServerInfo::new(
-            0,
-            32,
-            "test-node",
-            true,
-            10.0,
-            Vec::new(),
-            None,
-            peer.to_base58(),
-        );
-        published.signed_addrs = signed_envelope(&key, &[&circuit]);
-
-        let info =
-            decode_server_info_ext(&published.to_msgpack().expect("encodes")).expect("decodes");
-        assert_eq!(info.dial_addrs, vec![format!("{circuit}/p2p/{peer}")]);
-    }
-
-    /// A peer on a binary that predates the field decodes to an empty list,
-    /// not a dropped record — it is still dialable by PeerId if it happens to
-    /// be in the routing table.
-    #[test]
-    fn decode_server_info_ext_defaults_addrs_empty_for_legacy_bytes() {
-        let bytes = make_server_info_ext_bytes(None);
-        let info = decode_server_info_ext(&bytes).expect("decodes");
-        assert_eq!(info.state, 2, "the rest of the record must still decode");
-        assert!(info.dial_addrs.is_empty());
-    }
-
-    #[test]
-    fn decode_server_info_ext_defaults_lease_v1_false_for_legacy_bytes() {
-        // No lease_v1 key at all — exactly what a pre-Capacity-Lease peer's
-        // announcement looks like. Must decode successfully (not error) and
-        // default to false, not panic or silently drop the record.
-        let bytes = make_server_info_ext_bytes(None);
-        let info = decode_server_info_ext(&bytes).expect("decodes");
-        let (state, lease_v1) = (info.state, info.lease_v1);
-        assert_eq!(
-            state, 2,
-            "pre-existing fields must still decode alongside the new one"
-        );
-        assert!(!lease_v1);
     }
 
     #[test]

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -2762,49 +2762,20 @@ pub fn snap_to_valid_blocks(n: usize) -> usize {
         .unwrap_or(&4)
 }
 
-/// Addresses from a signed peer record, but only if `peer_id_b58` really
-/// signed them.
+/// [`kwaai_p2p::peer_record::verified_addrs`], as dialable strings.
 ///
-/// The DHT has no record validators (`kwaai-hivemind-dht`), so the bytes under
-/// a peer's subkey are whatever the last writer put there — and an address
-/// list is a dialing instruction. Verification is what makes it safe to
-/// follow: `from_signed_envelope_interop` checks the signature and binds the
-/// record's peer id to the signing key, and the equality check below ties that
-/// to the peer being dialed. A record that fails either yields no addresses,
-/// which costs the peer nothing worse than the bare-PeerId dial it would have
-/// got before the field existed.
-///
-/// Both checks are load-bearing. The library only proves the record is
-/// self-consistent — that whoever signed it named themselves — so without the
-/// caller comparing that to the peer it is about, an attacker signs a record
-/// with their own key, stores it under the victim's subkey, and every library
-/// check passes.
-///
-/// Addresses come back with `/p2p/<peer>` re-attached, because a peer record
-/// stores them bare: the peer id is in the record, once, under the signature.
+/// The verification itself is network-layer work and lives in `kwaai-p2p`; all
+/// this adds is the announcement's string-typed peer id and the `/p2p/<peer>`
+/// the record deliberately omits — a peer record stores its addresses bare,
+/// with the id inside, under the signature, so a reader re-attaches it to dial.
 fn verified_dial_addrs(envelope_bytes: &[u8], peer_id_b58: &str) -> Vec<String> {
     let Ok(claimed) = peer_id_b58.parse::<PeerId>() else {
         return Vec::new();
     };
-    let Ok(envelope) = libp2p::core::SignedEnvelope::from_protobuf_encoding(envelope_bytes) else {
-        return Vec::new();
-    };
-    let Ok(record) = libp2p::core::PeerRecord::from_signed_envelope_interop(envelope) else {
-        return Vec::new();
-    };
-    if record.peer_id() != claimed {
-        return Vec::new();
-    }
-    record
-        .addresses()
-        .iter()
-        .take(crate::announce::MAX_DIAL_ADDRS)
-        // Stripped before re-attaching rather than appended blindly: a
-        // publisher that is not `select_dial_addrs` may leave the destination
-        // on, and `/p2p/X/p2p/X` is not a dialable address.
+    kwaai_p2p::peer_record::verified_addrs(envelope_bytes, claimed)
+        .into_iter()
         .map(|a| {
-            kwaai_p2p::addresses::strip_dest_p2p(a)
-                .with(libp2p::multiaddr::Protocol::P2p(claimed))
+            a.with(libp2p::multiaddr::Protocol::P2p(claimed))
                 .to_string()
         })
         .collect()
@@ -4173,22 +4144,6 @@ mod tests {
         let info =
             decode_server_info_ext(&published.to_msgpack().expect("encodes")).expect("decodes");
         assert_eq!(info.dial_addrs, vec![format!("{circuit}/p2p/{peer}")]);
-    }
-
-    /// The publisher signs in the interop domain deliberately, so that a Go or
-    /// JS reader can verify it. A record in rust-libp2p's legacy domain is not
-    /// that, and must not be accepted by accident.
-    #[test]
-    fn verified_dial_addrs_rejects_the_legacy_signing_domain() {
-        let key = libp2p::identity::Keypair::generate_ed25519();
-        let peer = key.public().to_peer_id();
-        let addr = "/ip4/203.0.113.7/tcp/4001".parse().expect("a valid addr");
-        let legacy = libp2p::core::PeerRecord::new(&key, vec![addr])
-            .expect("signs")
-            .into_signed_envelope()
-            .into_protobuf_encoding();
-
-        assert!(verified_dial_addrs(&legacy, &peer.to_base58()).is_empty());
     }
 
     /// A peer on a binary that predates the field decodes to an empty list,

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -2252,9 +2252,17 @@ async fn resolve_query_peers(client: &mut P2PClient, configured: &[String]) -> V
 pub async fn connect_chain_entry(client: &mut P2PClient, entry: &BlockServerEntry) -> bool {
     for addr in &entry.dial_addrs {
         if client.connect_peer(addr).await.is_ok() {
+            tracing::debug!(peer = %entry.peer_id, %addr, "pre-connected via published address");
             return true;
         }
     }
+    // Which path a pre-connect took is the one fact worth having when a chain
+    // fails to form, so the fallback is logged even though it is routine.
+    tracing::debug!(
+        peer = %entry.peer_id,
+        published = entry.dial_addrs.len(),
+        "no published address connected — falling back to a bare-PeerId dial"
+    );
     client
         .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
         .await

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -2152,10 +2152,11 @@ pub struct BlockServerEntry {
     /// the shard-chain integration phase without another decoder pass.
     #[allow(dead_code)]
     pub lease_v1: bool,
-    /// Multiaddrs the peer published for itself, each already ending in
-    /// `/p2p/<its-peer-id>`. Empty for a peer running a binary that predates
-    /// the `addrs` field — the case [`connect_chain_entry`] falls back to a
-    /// bare-PeerId dial for.
+    /// Multiaddrs the peer published for itself and signed, each ending in
+    /// `/p2p/<its-peer-id>` — see [`verified_dial_addrs`], which is the only
+    /// thing that fills this in. Empty for a peer running a binary that
+    /// predates the field, and for one whose record failed verification: both
+    /// are cases [`connect_chain_entry`] falls back to a bare-PeerId dial for.
     pub dial_addrs: Vec<String>,
 }
 
@@ -2238,7 +2239,7 @@ async fn resolve_query_peers(client: &mut P2PClient, configured: &[String]) -> V
 /// That form asks the daemon to resolve the peer through kad, which usually
 /// cannot: rust-libp2p answers `FIND_NODE` from its k-buckets alone, so a peer
 /// is findable only while it holds a slot in the right bucket on a peer the
-/// walk reaches — see [`crate::announce::DHTServerInfo::dial_addrs`]. When it
+/// walk reaches — see [`crate::announce::DHTServerInfo::signed_addrs`]. When it
 /// does not, the lookup returns nothing after spending a full query timeout.
 /// Dialing a published address needs no lookup at all.
 ///
@@ -2676,6 +2677,16 @@ fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockSe
             if !version_meets_minimum(&info.version) {
                 continue;
             }
+            // The entry is identified by its *subkey*, but the signature was
+            // checked against the `peer_id` inside the value — and one writer
+            // controls both. A value naming a different peer than the subkey
+            // it sits under would hand this entry `peer_id` from the subkey
+            // and addresses belonging to whoever the value names. Legacy
+            // records omit `peer_id` entirely, so only a present-and-different
+            // one is a contradiction.
+            if !info.peer_id_b58.is_empty() && info.peer_id_b58 != peer_id_b58 {
+                continue;
+            }
             let key = peer_id_b58.clone();
             out.entry(key).or_insert(BlockServerEntry {
                 peer_id,
@@ -2743,9 +2754,54 @@ pub fn snap_to_valid_blocks(n: usize) -> usize {
         .unwrap_or(&4)
 }
 
-/// Core decoder: `Ext(64, msgpack([state, throughput, {start_block, end_block, …}]))`
-/// Returns `(state, start_block, end_block, public_name, peer_id_b58, version, throughput, lease_v1)`.
-#[allow(clippy::type_complexity)]
+/// Addresses from a signed peer record, but only if `peer_id_b58` really
+/// signed them.
+///
+/// The DHT has no record validators (`kwaai-hivemind-dht`), so the bytes under
+/// a peer's subkey are whatever the last writer put there — and an address
+/// list is a dialing instruction. Verification is what makes it safe to
+/// follow: `from_signed_envelope_interop` checks the signature and binds the
+/// record's peer id to the signing key, and the equality check below ties that
+/// to the peer being dialed. A record that fails either yields no addresses,
+/// which costs the peer nothing worse than the bare-PeerId dial it would have
+/// got before the field existed.
+///
+/// Both checks are load-bearing. The library only proves the record is
+/// self-consistent — that whoever signed it named themselves — so without the
+/// caller comparing that to the peer it is about, an attacker signs a record
+/// with their own key, stores it under the victim's subkey, and every library
+/// check passes.
+///
+/// Addresses come back with `/p2p/<peer>` re-attached, because a peer record
+/// stores them bare: the peer id is in the record, once, under the signature.
+fn verified_dial_addrs(envelope_bytes: &[u8], peer_id_b58: &str) -> Vec<String> {
+    let Ok(claimed) = peer_id_b58.parse::<PeerId>() else {
+        return Vec::new();
+    };
+    let Ok(envelope) = libp2p::core::SignedEnvelope::from_protobuf_encoding(envelope_bytes) else {
+        return Vec::new();
+    };
+    let Ok(record) = libp2p::core::PeerRecord::from_signed_envelope_interop(envelope) else {
+        return Vec::new();
+    };
+    if record.peer_id() != claimed {
+        return Vec::new();
+    }
+    record
+        .addresses()
+        .iter()
+        .take(crate::announce::MAX_DIAL_ADDRS)
+        // Stripped before re-attaching rather than appended blindly: a
+        // publisher that is not `select_dial_addrs` may leave the destination
+        // on, and `/p2p/X/p2p/X` is not a dialable address.
+        .map(|a| {
+            kwaai_p2p::addresses::strip_dest_p2p(a)
+                .with(libp2p::multiaddr::Protocol::P2p(claimed))
+                .to_string()
+        })
+        .collect()
+}
+
 /// One decoded announcement, as a struct rather than the positional tuple this
 /// used to return: nine fields where three call sites want different subsets is
 /// exactly the shape where `_`-holes drift out of alignment with the producer.
@@ -2758,8 +2814,9 @@ struct ServerInfoFields {
     version: String,
     throughput: f64,
     lease_v1: bool,
-    /// Multiaddrs the peer says it can be dialed on (`addrs`), empty for a peer
-    /// that published none — see [`crate::announce::DHTServerInfo::dial_addrs`].
+    /// Verified multiaddrs the peer can be dialed on, empty for a peer that
+    /// published none or whose record did not verify — see
+    /// [`verified_dial_addrs`].
     dial_addrs: Vec<String>,
 }
 
@@ -2804,19 +2861,11 @@ fn decode_server_info_ext(bytes: &[u8]) -> Option<ServerInfoFields> {
         .and_then(|(_, v)| v.as_bool())
         .unwrap_or(false);
 
-    // Anything that is not a string is dropped rather than failing the whole
-    // record: an address list is an optimisation, and a peer that garbles one
-    // entry is still worth reaching on the others.
     let dial_addrs = map
         .iter()
-        .find(|(ky, _)| ky.as_str() == Some("addrs"))
-        .and_then(|(_, v)| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(str::to_string))
-                .take(crate::announce::MAX_DIAL_ADDRS)
-                .collect()
-        })
+        .find(|(ky, _)| ky.as_str() == Some("addrs_signed"))
+        .and_then(|(_, v)| v.as_slice())
+        .map(|bytes| verified_dial_addrs(bytes, &peer_id_b58))
         .unwrap_or_default();
 
     Some(ServerInfoFields {
@@ -3902,12 +3951,48 @@ mod tests {
         assert!(info.lease_v1);
     }
 
+    /// Helper: one entry wrapped in the `Ext(80, [expiry, created, [[subkey,
+    /// value, expiry]]])` shape a FoundDictionary response carries.
+    fn dictionary_bytes(subkey_peer_b58: &str, value: &[u8]) -> Vec<u8> {
+        let subkey = rmp_serde::to_vec(&subkey_peer_b58).expect("msgpack subkey");
+        let entry = rmpv::Value::Array(vec![
+            rmpv::Value::Binary(subkey),
+            rmpv::Value::Binary(value.to_vec()),
+            rmpv::Value::from(0.0),
+        ]);
+        let inner = rmpv::Value::Array(vec![
+            rmpv::Value::from(0.0),
+            rmpv::Value::from(0.0),
+            rmpv::Value::Array(vec![entry]),
+        ]);
+        let mut inner_bytes = Vec::new();
+        rmpv::encode::write_value(&mut inner_bytes, &inner).expect("encodes");
+        let mut out = Vec::new();
+        rmpv::encode::write_value(&mut out, &rmpv::Value::Ext(80, inner_bytes)).expect("encodes");
+        out
+    }
+
+    /// Helper: a signed envelope for `key` naming `addrs`, exactly as the
+    /// publisher emits one.
+    fn signed_envelope(key: &libp2p::identity::Keypair, addrs: &[&str]) -> Vec<u8> {
+        let addrs = addrs
+            .iter()
+            .map(|a| a.parse().expect("a valid addr"))
+            .collect();
+        libp2p::core::PeerRecord::new_interop(key, addrs)
+            .expect("signs")
+            .into_signed_envelope()
+            .into_protobuf_encoding()
+    }
+
     /// The publisher's own encoder is the producer of record, so the decoder is
-    /// tested against what it emits rather than against a hand-built map.
+    /// tested against what it emits rather than against a hand-built map. The
+    /// bare address the record carries comes back with `/p2p/<peer>` on it,
+    /// which is the form `connect_peer` needs.
     #[test]
-    fn decode_server_info_ext_round_trips_the_published_addrs() {
-        let peer = PeerId::random();
-        let addr = format!("/ip4/203.0.113.7/tcp/4001/p2p/{}", peer.to_base58());
+    fn decode_server_info_ext_round_trips_a_signed_address() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
         let mut published = crate::announce::DHTServerInfo::new(
             0,
             32,
@@ -3918,66 +4003,195 @@ mod tests {
             None,
             peer.to_base58(),
         );
-        published.dial_addrs = vec![addr.clone()];
+        published.signed_addrs = signed_envelope(&key, &["/ip4/203.0.113.7/tcp/4001"]);
 
         let info =
             decode_server_info_ext(&published.to_msgpack().expect("encodes")).expect("decodes");
-        assert_eq!(info.dial_addrs, vec![addr]);
+        assert_eq!(
+            info.dial_addrs,
+            vec![format!(
+                "/ip4/203.0.113.7/tcp/4001/p2p/{}",
+                peer.to_base58()
+            )]
+        );
     }
 
-    /// A peer on a binary that predates `addrs` decodes to an empty list, not a
-    /// dropped record — it is still dialable by PeerId if it happens to be in
-    /// the routing table.
+    /// The attack the signature exists to stop: anyone may write under any
+    /// subkey, so a record whose addresses were signed by a different key must
+    /// yield nothing — the peer falls back to a bare-PeerId dial rather than
+    /// being steered at an address its own key never vouched for.
+    #[test]
+    fn decode_server_info_ext_rejects_addresses_signed_by_another_key() {
+        let victim = libp2p::identity::Keypair::generate_ed25519()
+            .public()
+            .to_peer_id();
+        let attacker = libp2p::identity::Keypair::generate_ed25519();
+        let mut forged = crate::announce::DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            victim.to_base58(),
+        );
+        forged.signed_addrs = signed_envelope(&attacker, &["/ip4/198.51.100.9/tcp/4001"]);
+
+        let info = decode_server_info_ext(&forged.to_msgpack().expect("encodes")).expect("decodes");
+        assert!(
+            info.dial_addrs.is_empty(),
+            "an address list the announced peer did not sign must not be dialed"
+        );
+        assert_eq!(
+            info.public_name, "test-node",
+            "the rest of the record still decodes"
+        );
+    }
+
+    /// Garbage in the field costs the addresses, not the record.
+    #[test]
+    fn decode_server_info_ext_ignores_an_unparseable_envelope() {
+        let peer = PeerId::random();
+        let mut info = crate::announce::DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            peer.to_base58(),
+        );
+        info.signed_addrs = vec![0xde, 0xad, 0xbe, 0xef];
+
+        let decoded =
+            decode_server_info_ext(&info.to_msgpack().expect("encodes")).expect("decodes");
+        assert!(decoded.dial_addrs.is_empty());
+        assert_eq!(
+            decoded.end_block, 32,
+            "the rest of the record still decodes"
+        );
+    }
+
+    /// The dictionary path keys an entry by its *subkey* but verified the
+    /// signature against the value's `peer_id`, and one writer controls both.
+    /// A value naming a different peer must be dropped, or the entry would
+    /// carry the victim's peer id beside a stranger's addresses.
+    #[test]
+    fn decode_server_info_dictionary_drops_a_value_naming_another_peer() {
+        let victim = PeerId::random();
+        let attacker = libp2p::identity::Keypair::generate_ed25519();
+        let mut forged = crate::announce::DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            attacker.public().to_peer_id().to_base58(),
+        );
+        forged.state = 2;
+        forged.signed_addrs = signed_envelope(&attacker, &["/ip4/198.51.100.9/tcp/4001"]);
+
+        let mut out = HashMap::new();
+        decode_server_info_dictionary(
+            &dictionary_bytes(&victim.to_base58(), &forged.to_msgpack().expect("encodes")),
+            &mut out,
+        );
+        assert!(
+            out.is_empty(),
+            "an entry whose value names a peer other than its subkey must not be used"
+        );
+    }
+
+    /// The same shape, honestly published, still decodes — so the check above
+    /// rejects the contradiction rather than the dictionary path itself.
+    #[test]
+    fn decode_server_info_dictionary_keeps_a_value_matching_its_subkey() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let mut honest = crate::announce::DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            peer.to_base58(),
+        );
+        honest.state = 2;
+        honest.signed_addrs = signed_envelope(&key, &["/ip4/203.0.113.7/tcp/4001"]);
+
+        let mut out = HashMap::new();
+        decode_server_info_dictionary(
+            &dictionary_bytes(&peer.to_base58(), &honest.to_msgpack().expect("encodes")),
+            &mut out,
+        );
+        let entry = out.get(&peer.to_base58()).expect("the entry decodes");
+        assert_eq!(
+            entry.dial_addrs,
+            vec![format!(
+                "/ip4/203.0.113.7/tcp/4001/p2p/{}",
+                peer.to_base58()
+            )]
+        );
+    }
+
+    /// Circuits are the whole motivation, and their shape is the one a dialer
+    /// cannot reconstruct: the relay hop must survive the round trip and the
+    /// destination must come back on the end, where `connect_peer` reads it.
+    #[test]
+    fn decode_server_info_ext_round_trips_a_circuit_address() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let relay = PeerId::random();
+        let circuit = format!("/ip4/76.13.5.74/tcp/4001/p2p/{}/p2p-circuit", relay);
+
+        let mut published = crate::announce::DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            peer.to_base58(),
+        );
+        published.signed_addrs = signed_envelope(&key, &[&circuit]);
+
+        let info =
+            decode_server_info_ext(&published.to_msgpack().expect("encodes")).expect("decodes");
+        assert_eq!(info.dial_addrs, vec![format!("{circuit}/p2p/{peer}")]);
+    }
+
+    /// The publisher signs in the interop domain deliberately, so that a Go or
+    /// JS reader can verify it. A record in rust-libp2p's legacy domain is not
+    /// that, and must not be accepted by accident.
+    #[test]
+    fn verified_dial_addrs_rejects_the_legacy_signing_domain() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let addr = "/ip4/203.0.113.7/tcp/4001".parse().expect("a valid addr");
+        let legacy = libp2p::core::PeerRecord::new(&key, vec![addr])
+            .expect("signs")
+            .into_signed_envelope()
+            .into_protobuf_encoding();
+
+        assert!(verified_dial_addrs(&legacy, &peer.to_base58()).is_empty());
+    }
+
+    /// A peer on a binary that predates the field decodes to an empty list,
+    /// not a dropped record — it is still dialable by PeerId if it happens to
+    /// be in the routing table.
     #[test]
     fn decode_server_info_ext_defaults_addrs_empty_for_legacy_bytes() {
         let bytes = make_server_info_ext_bytes(None);
         let info = decode_server_info_ext(&bytes).expect("decodes");
         assert_eq!(info.state, 2, "the rest of the record must still decode");
         assert!(info.dial_addrs.is_empty());
-    }
-
-    /// A malformed entry costs that entry, not the record: the peer is still
-    /// worth reaching on whatever else it published.
-    #[test]
-    fn decode_server_info_ext_skips_non_string_addrs() {
-        let mut bytes_fields = vec![
-            (rmpv::Value::from("start_block"), rmpv::Value::from(0i64)),
-            (rmpv::Value::from("end_block"), rmpv::Value::from(32i64)),
-            (
-                rmpv::Value::from("public_name"),
-                rmpv::Value::from("test-node"),
-            ),
-            (
-                rmpv::Value::from("peer_id"),
-                rmpv::Value::from(PeerId::random().to_base58().as_str()),
-            ),
-            (
-                rmpv::Value::from("version"),
-                rmpv::Value::from("kwaai-0.5.4"),
-            ),
-        ];
-        bytes_fields.push((
-            rmpv::Value::from("addrs"),
-            rmpv::Value::Array(vec![
-                rmpv::Value::from(7i64),
-                rmpv::Value::from("/ip4/203.0.113.7/tcp/4001"),
-            ]),
-        ));
-        let inner = rmpv::Value::Array(vec![
-            rmpv::Value::from(2i32),
-            rmpv::Value::from(10.0),
-            rmpv::Value::Map(bytes_fields),
-        ]);
-        let mut inner_bytes = Vec::new();
-        rmpv::encode::write_value(&mut inner_bytes, &inner).unwrap();
-        let mut bytes = Vec::new();
-        rmpv::encode::write_value(&mut bytes, &rmpv::Value::Ext(64, inner_bytes)).unwrap();
-
-        let info = decode_server_info_ext(&bytes).expect("decodes");
-        assert_eq!(
-            info.dial_addrs,
-            vec!["/ip4/203.0.113.7/tcp/4001".to_string()]
-        );
     }
 
     #[test]

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -30,9 +30,7 @@ use std::{
 };
 use tokio::sync::RwLock;
 
-use crate::announce::{
-    decode_server_info_dictionary, decode_server_info_ext, decode_server_info_regular,
-};
+use crate::announce::decode_server_info_ext;
 use crate::block_rpc::{
     call_block_forward, f16_bytes_to_tensor, make_block_rpc_handler, token_ids_to_bytes,
     InferenceRequest, PayloadType, ShardCell,
@@ -1412,18 +1410,9 @@ pub async fn cmd_shard_run(args: ShardRunArgs) -> Result<()> {
     // Connect to all block-server peers — best effort, handing the daemon the
     // addresses each one published so that later dials can reuse them too.
     for entry in &chain {
-        // A peer whose binary predates `addrs_signed` publishes none, and the
-        // daemon rejects a connect carrying no addresses — that one case keeps
-        // the bare-PeerId dial.
-        let _ = if entry.dial_addrs.is_empty() {
-            client
-                .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
-                .await
-        } else {
-            client
-                .connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)
-                .await
-        };
+        let _ = client
+            .connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)
+            .await;
     }
 
     // ── Inference loop ────────────────────────────────────────────────────────
@@ -1894,18 +1883,9 @@ async fn run_streaming_inner(
 
     // Best-effort dial of every server in the chain (matches CLI).
     for entry in &chain {
-        // A peer whose binary predates `addrs_signed` publishes none, and the
-        // daemon rejects a connect carrying no addresses — that one case keeps
-        // the bare-PeerId dial.
-        let _ = if entry.dial_addrs.is_empty() {
-            client
-                .connect_peer(&format!("/p2p/{}", entry.peer_id.to_base58()))
-                .await
-        } else {
-            client
-                .connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)
-                .await
-        };
+        let _ = client
+            .connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)
+            .await;
     }
 
     // Pin the path for this session.
@@ -2570,6 +2550,139 @@ async fn pick_gap_blocks(
     Ok((start, end))
 }
 
+// ── Sharding's reading of an announcement ────────────────────────────────────
+//
+// `announce::decode_server_info_ext` turns bytes into fields; these two turn
+// fields into a `BlockServerEntry`, applying the policy only a chain builder
+// has an opinion about — ONLINE-only, a version floor — and so belong with the
+// consumer rather than with the wire format.
+
+/// Parse `Ext(64, [state, throughput, {start_block, end_block, peer_id, …}])`
+/// from a FoundRegular value.
+///
+/// Returns `(dedup_key, entry)`.  Legacy nodes (pre-v0.3.3) omit `peer_id`; we
+/// synthesise a stable key from `public_name:start_block` so they still count
+/// for gap detection even though they cannot be routed to directly.
+fn decode_server_info_regular(bytes: &[u8]) -> Option<(String, BlockServerEntry)> {
+    let info = decode_server_info_ext(bytes)?;
+    // Only include ONLINE nodes (state=2); skip JOINING (1) and OFFLINE (0/-1).
+    if info.state != 2 {
+        return None;
+    }
+    if !version_meets_minimum(&info.version) {
+        return None;
+    }
+    let (dedup_key, peer_id) = match info.peer_id_b58.parse::<PeerId>() {
+        Ok(pid) => (pid.to_base58(), pid),
+        Err(_) => {
+            let key = format!("legacy:{}:{}", info.public_name, info.start_block);
+            (key, PeerId::random())
+        }
+    };
+    Some((
+        dedup_key,
+        BlockServerEntry {
+            peer_id,
+            start_block: info.start_block,
+            end_block: info.end_block,
+            public_name: info.public_name,
+            throughput: info.throughput,
+            trust_score: None,
+            lease_v1: info.lease_v1,
+            dial_addrs: info.dial_addrs,
+        },
+    ))
+}
+
+/// Parse `Ext(80, [expiry, created, [[subkey_bytes, value_bytes, expiry], …]])`
+/// from a FoundDictionary value. Appends into `out` (deduplicates by peer_id).
+fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockServerEntry>) {
+    let outer = match rmpv::decode::read_value(&mut &bytes[..]) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let inner_bytes = match &outer {
+        rmpv::Value::Ext(80, b) => b.as_slice(),
+        _ => return,
+    };
+    let inner = match rmpv::decode::read_value(&mut &inner_bytes[..]) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let outer_arr = match inner.as_array() {
+        Some(a) if a.len() >= 3 => a,
+        _ => return,
+    };
+    let entries = match outer_arr[2].as_array() {
+        Some(e) => e,
+        None => return,
+    };
+
+    for entry in entries {
+        let arr = match entry.as_array() {
+            Some(a) if a.len() >= 2 => a,
+            _ => continue,
+        };
+
+        // Subkey is rmp_serde::to_vec(&peer_id_base58) = msgpack(string)
+        let peer_id_b58 = match &arr[0] {
+            rmpv::Value::String(s) => s.as_str().unwrap_or("").to_string(),
+            rmpv::Value::Binary(b) => {
+                // Decode as msgpack string
+                match rmpv::decode::read_value(&mut b.as_slice()) {
+                    Ok(rmpv::Value::String(s)) => s.as_str().unwrap_or("").to_string(),
+                    _ => continue,
+                }
+            }
+            _ => continue,
+        };
+
+        let value_bytes = match &arr[1] {
+            rmpv::Value::Binary(b) => b.as_slice(),
+            _ => continue,
+        };
+
+        if peer_id_b58.is_empty() {
+            continue;
+        }
+
+        let peer_id = match peer_id_b58.parse::<PeerId>() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        if let Some(info) = decode_server_info_ext(value_bytes) {
+            if info.state != 2 {
+                continue;
+            }
+            if !version_meets_minimum(&info.version) {
+                continue;
+            }
+            // The entry is identified by its *subkey*, but the signature was
+            // checked against the `peer_id` inside the value — and one writer
+            // controls both. A value naming a different peer than the subkey
+            // it sits under would hand this entry `peer_id` from the subkey
+            // and addresses belonging to whoever the value names. Legacy
+            // records omit `peer_id` entirely, so only a present-and-different
+            // one is a contradiction.
+            if !info.peer_id_b58.is_empty() && info.peer_id_b58 != peer_id_b58 {
+                continue;
+            }
+            let key = peer_id_b58.clone();
+            out.entry(key).or_insert(BlockServerEntry {
+                peer_id,
+                start_block: info.start_block,
+                end_block: info.end_block,
+                public_name: info.public_name,
+                throughput: info.throughput,
+                trust_score: None,
+                lease_v1: info.lease_v1,
+                dial_addrs: info.dial_addrs,
+            });
+        }
+    }
+}
+
 /// Minimum version required for a node's DHT record to be trusted.
 /// Nodes below this version announced stale block data unconditionally.
 const MIN_VERSION: (u32, u32, u32) = (0, 3, 15);
@@ -2588,7 +2701,7 @@ fn parse_kwaai_version(s: &str) -> Option<(u32, u32, u32)> {
     Some((maj, min, pat))
 }
 
-pub fn version_meets_minimum(version_str: &str) -> bool {
+fn version_meets_minimum(version_str: &str) -> bool {
     match parse_kwaai_version(version_str) {
         Some(v) => v >= MIN_VERSION,
         None => false, // unparseable / missing version → pre-0.3.15, exclude
@@ -3634,6 +3747,8 @@ mod assigned_range_is_persisted_whole {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::announce::DHTServerInfo;
+    use libp2p::Multiaddr;
 
     #[test]
     fn test_version_meets_minimum() {
@@ -3663,6 +3778,105 @@ mod tests {
         assert_eq!(snap_to_valid_blocks(25), 32);
         assert_eq!(snap_to_valid_blocks(32), 32);
         assert_eq!(snap_to_valid_blocks(64), 32);
+    }
+
+    // ── The consumer's half of the announcement decode ──────────────────────
+
+    /// Helper: a signed envelope for `key` naming `addrs`, exactly as the
+    /// publisher emits one.
+    fn signed_envelope(key: &libp2p::identity::Keypair, addrs: &[&str]) -> Vec<u8> {
+        let addrs = addrs
+            .iter()
+            .map(|a| a.parse().expect("a valid addr"))
+            .collect();
+        libp2p::core::PeerRecord::new_interop(key, addrs)
+            .expect("signs")
+            .into_signed_envelope()
+            .into_protobuf_encoding()
+    }
+
+    /// Helper: one entry wrapped in the `Ext(80, [expiry, created, [[subkey,
+    /// value, expiry]]])` shape a FoundDictionary response carries.
+    fn dictionary_bytes(subkey_peer_b58: &str, value: &[u8]) -> Vec<u8> {
+        let subkey = rmp_serde::to_vec(&subkey_peer_b58).expect("msgpack subkey");
+        let entry = rmpv::Value::Array(vec![
+            rmpv::Value::Binary(subkey),
+            rmpv::Value::Binary(value.to_vec()),
+            rmpv::Value::from(0.0),
+        ]);
+        let inner = rmpv::Value::Array(vec![
+            rmpv::Value::from(0.0),
+            rmpv::Value::from(0.0),
+            rmpv::Value::Array(vec![entry]),
+        ]);
+        let mut inner_bytes = Vec::new();
+        rmpv::encode::write_value(&mut inner_bytes, &inner).expect("encodes");
+        let mut out = Vec::new();
+        rmpv::encode::write_value(&mut out, &rmpv::Value::Ext(80, inner_bytes)).expect("encodes");
+        out
+    }
+
+    /// The dictionary path keys an entry by its *subkey* but verified the
+    /// signature against the value's `peer_id`, and one writer controls both.
+    /// A value naming a different peer must be dropped, or the entry would
+    /// carry the victim's peer id beside a stranger's addresses.
+    #[test]
+    fn decode_server_info_dictionary_drops_a_value_naming_another_peer() {
+        let victim = PeerId::random();
+        let attacker = libp2p::identity::Keypair::generate_ed25519();
+        let mut forged = DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            attacker.public().to_peer_id().to_base58(),
+        );
+        forged.state = 2;
+        forged.signed_addrs = signed_envelope(&attacker, &["/ip4/198.51.100.9/tcp/4001"]);
+
+        let mut out = HashMap::new();
+        decode_server_info_dictionary(
+            &dictionary_bytes(&victim.to_base58(), &forged.to_msgpack().expect("encodes")),
+            &mut out,
+        );
+        assert!(
+            out.is_empty(),
+            "an entry whose value names a peer other than its subkey must not be used"
+        );
+    }
+
+    /// The same shape, honestly published, still decodes — so the check above
+    /// rejects the contradiction rather than the dictionary path itself.
+    #[test]
+    fn decode_server_info_dictionary_keeps_a_value_matching_its_subkey() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let mut honest = DHTServerInfo::new(
+            0,
+            32,
+            "test-node",
+            true,
+            10.0,
+            Vec::new(),
+            None,
+            peer.to_base58(),
+        );
+        honest.state = 2;
+        honest.signed_addrs = signed_envelope(&key, &["/ip4/203.0.113.7/tcp/4001"]);
+
+        let mut out = HashMap::new();
+        decode_server_info_dictionary(
+            &dictionary_bytes(&peer.to_base58(), &honest.to_msgpack().expect("encodes")),
+            &mut out,
+        );
+        let entry = out.get(&peer.to_base58()).expect("the entry decodes");
+        assert_eq!(
+            entry.dial_addrs,
+            vec!["/ip4/203.0.113.7/tcp/4001".parse::<Multiaddr>().unwrap()]
+        );
     }
 }
 

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -2271,7 +2271,7 @@ pub async fn discover_chain(
         return vec![];
     }
 
-    let mut servers: HashMap<String, BlockServerEntry> = HashMap::new();
+    let mut servers: HashMap<String, Discovered> = HashMap::new();
 
     let query_peers = resolve_query_peers(client, bootstrap_peers).await;
 
@@ -2308,7 +2308,7 @@ pub async fn discover_chain(
             if rt == 1 {
                 // FoundRegular — single value, peer_id embedded in map
                 if let Some((key, entry)) = decode_server_info_regular(&result.value) {
-                    servers.entry(key).or_insert(entry);
+                    merge_record(&mut servers, key, result.expiration_time, entry);
                 }
             } else if rt == 2 {
                 // FoundDictionary — multiple subkeys (Python Hivemind)
@@ -2317,9 +2317,35 @@ pub async fn discover_chain(
         }
     }
 
-    let mut chain: Vec<BlockServerEntry> = servers.into_values().collect();
+    let mut chain: Vec<BlockServerEntry> = servers.into_values().map(|d| d.entry).collect();
     chain.sort_by_key(|e| e.start_block);
     chain
+}
+
+/// One peer's record as discovery holds it, with the DHT expiry it came with.
+struct Discovered {
+    expiry: f64,
+    entry: BlockServerEntry,
+}
+
+/// The same peer is read under every block key and from every bootstrap, and
+/// those copies disagree after it re-announces — most usefully about where it
+/// is reachable. A record with addresses beats one without; between two with
+/// the same standing, the later expiry is the later announcement.
+fn merge_record(
+    out: &mut HashMap<String, Discovered>,
+    key: String,
+    expiry: f64,
+    entry: BlockServerEntry,
+) {
+    let rank = |d: &Discovered| (!d.entry.dial_addrs.is_empty(), d.expiry);
+    let candidate = Discovered { expiry, entry };
+    match out.get(&key) {
+        Some(held) if rank(held) >= rank(&candidate) => {}
+        _ => {
+            out.insert(key, candidate);
+        }
+    }
 }
 
 /// Connect to the local p2pd and resolve everything [`discover_chain`]
@@ -2432,9 +2458,10 @@ pub async fn discover_inference_peer(
                     }
                 }
             } else if result.result_type == 2 {
-                let mut tmp: HashMap<String, BlockServerEntry> = HashMap::new();
+                let mut tmp: HashMap<String, Discovered> = HashMap::new();
                 decode_server_info_dictionary(&result.value, &mut tmp);
-                for (_, e) in tmp {
+                for d in tmp.into_values() {
+                    let e = d.entry;
                     candidates.push((e.throughput, e.peer_id, e.public_name, e.dial_addrs));
                 }
             }
@@ -2606,8 +2633,9 @@ fn decode_server_info_regular(bytes: &[u8]) -> Option<(String, BlockServerEntry)
 }
 
 /// Parse `Ext(80, [expiry, created, [[subkey_bytes, value_bytes, expiry], …]])`
-/// from a FoundDictionary value. Appends into `out` (deduplicates by peer_id).
-fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockServerEntry>) {
+/// from a FoundDictionary value. Merges into `out` by peer id — see
+/// [`merge_record`] for which copy of a peer wins.
+fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, Discovered>) {
     let outer = match rmpv::decode::read_value(&mut &bytes[..]) {
         Ok(v) => v,
         Err(_) => return,
@@ -2652,6 +2680,7 @@ fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockSe
             rmpv::Value::Binary(b) => b.as_slice(),
             _ => continue,
         };
+        let expiry = arr.get(2).and_then(|v| v.as_f64()).unwrap_or(0.0);
 
         if peer_id_b58.is_empty() {
             continue;
@@ -2682,8 +2711,7 @@ fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockSe
             {
                 continue;
             }
-            let key = peer_id_b58.clone();
-            out.entry(key).or_insert(BlockServerEntry {
+            let entry = BlockServerEntry {
                 peer_id,
                 start_block: info.start_block,
                 end_block: info.end_block,
@@ -2692,7 +2720,8 @@ fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockSe
                 trust_score: None,
                 lease_v1: info.lease_v1,
                 dial_addrs: info.dial_addrs,
-            });
+            };
+            merge_record(out, peer_id_b58.clone(), expiry, entry);
         }
     }
 }
@@ -3812,11 +3841,15 @@ mod tests {
     /// Helper: one entry wrapped in the `Ext(80, [expiry, created, [[subkey,
     /// value, expiry]]])` shape a FoundDictionary response carries.
     fn dictionary_bytes(subkey_peer_b58: &str, value: &[u8]) -> Vec<u8> {
+        dictionary_bytes_expiring(subkey_peer_b58, value, 0.0)
+    }
+
+    fn dictionary_bytes_expiring(subkey_peer_b58: &str, value: &[u8], expiry: f64) -> Vec<u8> {
         let subkey = rmp_serde::to_vec(&subkey_peer_b58).expect("msgpack subkey");
         let entry = rmpv::Value::Array(vec![
             rmpv::Value::Binary(subkey),
             rmpv::Value::Binary(value.to_vec()),
-            rmpv::Value::from(0.0),
+            rmpv::Value::from(expiry),
         ]);
         let inner = rmpv::Value::Array(vec![
             rmpv::Value::from(0.0),
@@ -3886,13 +3919,88 @@ mod tests {
             &dictionary_bytes(&peer.to_base58(), &honest.to_msgpack().expect("encodes")),
             &mut out,
         );
-        let entry = out.get(&peer.to_base58()).expect("the entry decodes");
+        let entry = &out.get(&peer.to_base58()).expect("the entry decodes").entry;
         assert_eq!(
             entry.dial_addrs,
             vec!["/ip4/203.0.113.7/tcp/4001".parse::<Multiaddr>().unwrap()]
         );
     }
 
+    /// Every bootstrap and block key hands back its own copy of a peer's
+    /// record. After the peer moves relay, the copy that names the old one is
+    /// still around; the later announcement must win, whichever is read
+    /// first — and a copy with no addresses never displaces one with.
+    #[test]
+    fn discovery_prefers_the_fresher_record_with_addresses() {
+        let key = libp2p::identity::Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let record = |addr: Option<&str>| {
+            let mut info = DHTServerInfo::new(
+                0,
+                32,
+                "test-node",
+                true,
+                10.0,
+                Vec::new(),
+                None,
+                peer.to_base58(),
+            );
+            info.state = 2;
+            if let Some(addr) = addr {
+                info.signed_addrs = signed_envelope(&key, &[addr]);
+            }
+            info.to_msgpack().expect("encodes")
+        };
+        let old_relay = "/ip4/198.51.100.1/tcp/4001/p2p/12D3KooWF7ckKo2HQojbtueQNuLYRT2XC2yzbvBbh4NK2rbi2Azg/p2p-circuit";
+        let new_relay = "/ip4/198.51.100.2/tcp/4001/p2p/12D3KooWF7ckKo2HQojbtueQNuLYRT2XC2yzbvBbh4NK2rbi2Azg/p2p-circuit";
+        let addrs_of = |out: &HashMap<String, Discovered>| {
+            out.get(&peer.to_base58())
+                .expect("decodes")
+                .entry
+                .dial_addrs
+                .clone()
+        };
+
+        // Stale copy read first, fresher copy second: the fresher wins.
+        let mut out = HashMap::new();
+        decode_server_info_dictionary(
+            &dictionary_bytes_expiring(&peer.to_base58(), &record(Some(old_relay)), 100.0),
+            &mut out,
+        );
+        decode_server_info_dictionary(
+            &dictionary_bytes_expiring(&peer.to_base58(), &record(Some(new_relay)), 200.0),
+            &mut out,
+        );
+        assert_eq!(
+            addrs_of(&out),
+            vec![new_relay.parse::<Multiaddr>().unwrap()]
+        );
+
+        // Same two, read the other way round: still the fresher.
+        let mut out = HashMap::new();
+        decode_server_info_dictionary(
+            &dictionary_bytes_expiring(&peer.to_base58(), &record(Some(new_relay)), 200.0),
+            &mut out,
+        );
+        decode_server_info_dictionary(
+            &dictionary_bytes_expiring(&peer.to_base58(), &record(Some(old_relay)), 100.0),
+            &mut out,
+        );
+        assert_eq!(
+            addrs_of(&out),
+            vec![new_relay.parse::<Multiaddr>().unwrap()]
+        );
+
+        // A fresher copy with no addresses does not displace one that has them.
+        decode_server_info_dictionary(
+            &dictionary_bytes_expiring(&peer.to_base58(), &record(None), 300.0),
+            &mut out,
+        );
+        assert_eq!(
+            addrs_of(&out),
+            vec![new_relay.parse::<Multiaddr>().unwrap()]
+        );
+    }
 }
 
 /// The rebalance gate. Regression for two bugs: `auto_rebalance` in config

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -1237,6 +1237,12 @@ pub async fn cmd_shard_run(args: ShardRunArgs) -> Result<()> {
     let our_peer_id =
         PeerId::from_bytes(&hex::decode(&peer_id_hex)?).context("parse our peer ID")?;
 
+    let bootstrap_peers: Vec<String> = if cfg.initial_peers.is_empty() {
+        NetworkConfig::with_petals_bootstrap().bootstrap_peers
+    } else {
+        cfg.initial_peers.clone()
+    };
+
     // ── Resolve chain: from circuit or fresh DHT discovery ─────────────────
     let (chain, using_circuit) = if let Some(ref circuit_id) = args.circuit {
         // Load pre-formed circuit — skip DHT discovery
@@ -1250,19 +1256,23 @@ pub async fn cmd_shard_run(args: ShardRunArgs) -> Result<()> {
         }
         let _ = save_circuits(&all);
 
-        let entries: Vec<BlockServerEntry> =
+        let mut entries: Vec<BlockServerEntry> =
             circuit.chain.iter().filter_map(|e| e.to_entry()).collect();
+        refresh_circuit_addrs(
+            &mut entries,
+            &mut client,
+            &our_peer_id,
+            &dht_prefix,
+            total_blocks,
+            &bootstrap_peers,
+        )
+        .await;
         println!("  Circuit:      {}", circuit.id);
         println!("  Nodes:        {} (from circuit)", entries.len());
         (entries, true)
     } else {
         // Fresh DHT discovery
         print!("  Discovering block circuit from DHT…");
-        let bootstrap_peers: Vec<String> = if cfg.initial_peers.is_empty() {
-            NetworkConfig::with_petals_bootstrap().bootstrap_peers
-        } else {
-            cfg.initial_peers.clone()
-        };
 
         let chain = discover_chain(
             &mut client,
@@ -1794,6 +1804,12 @@ async fn run_streaming_inner(
     let our_peer_id =
         PeerId::from_bytes(&hex::decode(&peer_id_hex)?).context("parse our peer ID")?;
 
+    let bootstrap_peers: Vec<String> = if cfg.initial_peers.is_empty() {
+        NetworkConfig::with_petals_bootstrap().bootstrap_peers
+    } else {
+        cfg.initial_peers.clone()
+    };
+
     // ── Resolve chain (circuit or fresh DHT discovery + 30 s wait) ──
     let chain: Vec<BlockServerEntry> = if let Some(ref cid) = opts.circuit_id {
         let mut circuit = load_circuit_by_id(cid)?;
@@ -1803,14 +1819,19 @@ async fn run_streaming_inner(
             c.last_used_epoch = circuit.last_used_epoch;
         }
         let _ = save_circuits(&all);
-        circuit.chain.iter().filter_map(|e| e.to_entry()).collect()
+        let mut entries: Vec<BlockServerEntry> =
+            circuit.chain.iter().filter_map(|e| e.to_entry()).collect();
+        refresh_circuit_addrs(
+            &mut entries,
+            &mut client,
+            &our_peer_id,
+            &dht_prefix,
+            total_blocks,
+            &bootstrap_peers,
+        )
+        .await;
+        entries
     } else {
-        let bootstrap_peers: Vec<String> = if cfg.initial_peers.is_empty() {
-            NetworkConfig::with_petals_bootstrap().bootstrap_peers
-        } else {
-            cfg.initial_peers.clone()
-        };
-
         // Poll DHT up to 30 s for peers serving this model.
         let deadline = std::time::Instant::now() + Duration::from_secs(30);
         let mut chain = discover_chain(
@@ -2838,6 +2859,10 @@ pub struct SerializableEntry {
     pub start_block: usize,
     pub end_block: usize,
     pub public_name: String,
+    /// The peer's dial addresses as discovered when the circuit was made.
+    /// Absent from files written before the field existed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dial_addrs: Vec<String>,
 }
 
 impl SerializableEntry {
@@ -2847,6 +2872,7 @@ impl SerializableEntry {
             start_block: e.start_block,
             end_block: e.end_block,
             public_name: e.public_name.clone(),
+            dial_addrs: e.dial_addrs.iter().map(|a| a.to_string()).collect(),
         }
     }
 
@@ -2863,11 +2889,46 @@ impl SerializableEntry {
             // Capacity Lease — conservatively unknown/false, same as any
             // other legacy-shaped record with the key absent.
             lease_v1: false,
-            // Likewise no addresses: a saved circuit is a list of peers, and
-            // where they were reachable months ago is not worth replaying.
-            // Rediscovery refills these from the live record.
-            dial_addrs: Vec::new(),
+            dial_addrs: self
+                .dial_addrs
+                .iter()
+                .filter_map(|a| a.parse().ok())
+                .collect(),
         })
+    }
+}
+
+/// A circuit loaded without addresses — saved before they were persisted,
+/// or made when its peers announced none — would pre-connect by bare
+/// PeerId, which is the failure circuits exist to skip. One DHT read fills
+/// in what the live records say; a peer not found keeps its empty list.
+pub async fn refresh_circuit_addrs(
+    entries: &mut [BlockServerEntry],
+    client: &mut P2PClient,
+    our_peer_id: &PeerId,
+    dht_prefix: &str,
+    total_blocks: usize,
+    bootstrap_peers: &[String],
+) {
+    if entries.iter().all(|e| !e.dial_addrs.is_empty()) {
+        return;
+    }
+    let live = discover_chain(
+        client,
+        our_peer_id,
+        dht_prefix,
+        total_blocks,
+        bootstrap_peers,
+    )
+    .await;
+    fill_missing_addrs(entries, &live);
+}
+
+fn fill_missing_addrs(entries: &mut [BlockServerEntry], live: &[BlockServerEntry]) {
+    for entry in entries.iter_mut().filter(|e| e.dial_addrs.is_empty()) {
+        if let Some(found) = live.iter().find(|l| l.peer_id == entry.peer_id) {
+            entry.dial_addrs = found.dial_addrs.clone();
+        }
     }
 }
 
@@ -3924,6 +3985,76 @@ mod tests {
             entry.dial_addrs,
             vec!["/ip4/203.0.113.7/tcp/4001".parse::<Multiaddr>().unwrap()]
         );
+    }
+
+    fn entry_with(peer_id: PeerId, addrs: &[&str]) -> BlockServerEntry {
+        BlockServerEntry {
+            peer_id,
+            start_block: 0,
+            end_block: 8,
+            public_name: "test-node".into(),
+            throughput: 0.0,
+            trust_score: None,
+            lease_v1: false,
+            dial_addrs: addrs.iter().map(|a| a.parse().unwrap()).collect(),
+        }
+    }
+
+    /// A saved circuit carries its peers' addresses through the file, so
+    /// loading one does not fall back to a bare-PeerId dial.
+    #[test]
+    fn serializable_entry_round_trips_dial_addrs() {
+        let peer = PeerId::random();
+        let circuit = "/ip4/198.51.100.1/tcp/4001/p2p/12D3KooWF7ckKo2HQojbtueQNuLYRT2XC2yzbvBbh4NK2rbi2Azg/p2p-circuit";
+        let saved = SerializableEntry::from_entry(&entry_with(peer, &[circuit]));
+        let json = serde_json::to_string(&saved).expect("serialises");
+        let loaded: SerializableEntry = serde_json::from_str(&json).expect("parses");
+        let entry = loaded.to_entry().expect("a valid entry");
+        assert_eq!(entry.peer_id, peer);
+        assert_eq!(
+            entry.dial_addrs,
+            vec![circuit.parse::<Multiaddr>().unwrap()]
+        );
+    }
+
+    /// A file written before the field existed still loads, with no addresses.
+    #[test]
+    fn serializable_entry_loads_a_file_without_dial_addrs() {
+        let peer = PeerId::random();
+        let json = format!(
+            r#"{{"peer_id_b58":"{}","start_block":0,"end_block":8,"public_name":"old"}}"#,
+            peer.to_base58()
+        );
+        let loaded: SerializableEntry = serde_json::from_str(&json).expect("parses");
+        let entry = loaded.to_entry().expect("a valid entry");
+        assert_eq!(entry.peer_id, peer);
+        assert!(entry.dial_addrs.is_empty());
+    }
+
+    /// The DHT fills only the entries that arrived empty; a peer the read
+    /// did not find keeps its empty list rather than blocking the circuit.
+    #[test]
+    fn fill_missing_addrs_touches_only_the_empty_entries() {
+        let (a, b, c) = (PeerId::random(), PeerId::random(), PeerId::random());
+        let mut entries = vec![
+            entry_with(a, &["/ip4/198.51.100.1/tcp/4001"]),
+            entry_with(b, &[]),
+            entry_with(c, &[]),
+        ];
+        let live = vec![
+            entry_with(a, &["/ip4/198.51.100.9/tcp/4001"]),
+            entry_with(b, &["/ip4/198.51.100.2/tcp/4001"]),
+        ];
+        fill_missing_addrs(&mut entries, &live);
+        assert_eq!(
+            entries[0].dial_addrs,
+            vec!["/ip4/198.51.100.1/tcp/4001".parse::<Multiaddr>().unwrap()]
+        );
+        assert_eq!(
+            entries[1].dial_addrs,
+            vec!["/ip4/198.51.100.2/tcp/4001".parse::<Multiaddr>().unwrap()]
+        );
+        assert!(entries[2].dial_addrs.is_empty());
     }
 
     /// Every bootstrap and block key hands back its own copy of a peer's

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -2675,8 +2675,11 @@ fn decode_server_info_dictionary(bytes: &[u8], out: &mut HashMap<String, BlockSe
             // it sits under would hand this entry `peer_id` from the subkey
             // and addresses belonging to whoever the value names. Legacy
             // records omit `peer_id` entirely, so only a present-and-different
-            // one is a contradiction.
-            if !info.peer_id_b58.is_empty() && info.peer_id_b58 != peer_id_b58 {
+            // one is a contradiction. Compared as ids so an alternative
+            // spelling of the same peer, should one ever parse, is agreement.
+            if !info.peer_id_b58.is_empty()
+                && info.peer_id_b58.parse::<PeerId>().ok() != Some(peer_id)
+            {
                 continue;
             }
             let key = peer_id_b58.clone();
@@ -3889,6 +3892,7 @@ mod tests {
             vec!["/ip4/203.0.113.7/tcp/4001".parse::<Multiaddr>().unwrap()]
         );
     }
+
 }
 
 /// The rebalance gate. Regression for two bugs: `auto_rebalance` in config

--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -443,6 +443,11 @@ impl P2PClient {
     ///
     /// Addresses are sent bare deliberately; that is what tells the daemon this
     /// is the split form rather than the classic one-full-multiaddr dial.
+    ///
+    /// An **empty** slice is valid and means "dial by id, from whatever you
+    /// already know" — the daemon takes its routed path, exactly as Go's
+    /// routed host does for an `AddrInfo` with no addresses. A caller holding a
+    /// peer that published none therefore needs no fallback of its own.
     pub async fn connect_peer_with_addrs(
         &mut self,
         peer: &libp2p::PeerId,

--- a/core/crates/kwaai-p2p-daemon/src/client.rs
+++ b/core/crates/kwaai-p2p-daemon/src/client.rs
@@ -432,6 +432,49 @@ impl P2PClient {
         Ok(())
     }
 
+    /// Connect to `peer`, supplying the addresses it can be reached at.
+    ///
+    /// The split form Go's `doConnect` took — `peer.AddrInfo{ID, Addrs}` — and
+    /// the one a signed peer record produces, where the id appears once inside
+    /// the record and the addresses are bare. Unlike [`Self::connect_peer`] the
+    /// daemon *keeps* these: they go into its learned-address map, so a later
+    /// routed request to the same peer re-dials from them rather than needing
+    /// the peer to be in the routing table.
+    ///
+    /// Addresses are sent bare deliberately; that is what tells the daemon this
+    /// is the split form rather than the classic one-full-multiaddr dial.
+    pub async fn connect_peer_with_addrs(
+        &mut self,
+        peer: &libp2p::PeerId,
+        addrs: &[libp2p::Multiaddr],
+    ) -> Result<()> {
+        let request = Request {
+            r#type: request::Type::Connect as i32,
+            connect: Some(ConnectRequest {
+                peer: peer.to_bytes(),
+                addrs: addrs
+                    .iter()
+                    .map(|a| kwaai_p2p::addresses::strip_dest_p2p(a).to_vec())
+                    .collect(),
+                timeout: Some(60),
+            }),
+            stream_open: None,
+            stream_handler: None,
+            remove_stream_handler: None,
+            dht: None,
+            conn_manager: None,
+            disconnect: None,
+            pubsub: None,
+        };
+
+        debug!(
+            "Connecting to peer {peer} with {} supplied address(es)",
+            addrs.len()
+        );
+        let _response = self.send_request(request).await?;
+        Ok(())
+    }
+
     /// Disconnect from a peer
     pub async fn disconnect_peer(&mut self, peer_id: &[u8]) -> Result<()> {
         let request = Request {

--- a/core/crates/kwaai-p2p-daemon/src/server.rs
+++ b/core/crates/kwaai-p2p-daemon/src/server.rs
@@ -651,11 +651,24 @@ impl ConnState {
 
     /// `CONNECT` — dial a peer at the supplied addresses.
     ///
-    /// The client sends one multiaddr that already carries `/p2p/<id>`;
-    /// `NetworkHandle::connect_peer` requires that component, so an address
-    /// without it is completed from the request's `peer` field rather than
-    /// rejected — Go accepts the split form (`peer.AddrInfo{ID, Addrs}`) and
-    /// some call sites rely on it.
+    /// Two shapes arrive on this one request, and they are told apart by
+    /// whether the address names its destination:
+    ///
+    /// * **One multiaddr ending in `/p2p/<peer>`** — the classic dial, what
+    ///   `P2PClient::connect_peer` and `p2p peers connect --addr` send. Handed
+    ///   to `NetworkHandle::connect_peer` unchanged, which is what makes a
+    ///   bare `/p2p/<id>` still resolve through the DHT like Go's routed host.
+    /// * **Anything else** — bare addresses, or several of them, beside an
+    ///   explicit `peer`: Go's `peer.AddrInfo{ID, Addrs}` split form, which is
+    ///   what `P2PClient::connect_peer_with_addrs` sends and what a signed
+    ///   peer record produces. These go to `connect_peer_with_addrs`, which
+    ///   *keeps* them in the daemon's learned-address map so later routed
+    ///   requests to the peer can re-dial from them.
+    ///
+    /// The distinction is the address shape rather than the count because a
+    /// NATed peer commonly publishes exactly one circuit address, and that is
+    /// the case the learned map exists for — a count-based rule would send it
+    /// down the old path and lose it.
     async fn do_connect(&self, request: Request) -> Response {
         let Some(connect) = request.connect else {
             return error_response("Malformed request; missing parameters".to_string());
@@ -668,6 +681,27 @@ impl ConnState {
 
         if connect.addrs.is_empty() {
             return error_response("Malformed request; missing parameters".to_string());
+        }
+
+        let parsed: Vec<Multiaddr> = connect
+            .addrs
+            .iter()
+            .filter_map(|raw| Multiaddr::try_from(raw.clone()).ok())
+            .collect();
+        let classic = parsed.len() == 1
+            && connect.addrs.len() == 1
+            && kwaai_p2p::addresses::dest_peer_id(&parsed[0]) == Some(peer);
+
+        if !classic && !parsed.is_empty() {
+            return match self
+                .shared
+                .handle
+                .connect_peer_with_addrs(peer, parsed)
+                .await
+            {
+                Ok(_) => ok_response(),
+                Err(e) => error_response(e.to_string()),
+            };
         }
 
         let mut last_error = String::from("no addresses could be dialed");

--- a/core/crates/kwaai-p2p-daemon/src/server.rs
+++ b/core/crates/kwaai-p2p-daemon/src/server.rs
@@ -651,9 +651,15 @@ impl ConnState {
 
     /// `CONNECT` — dial a peer at the supplied addresses.
     ///
-    /// Two shapes arrive on this one request, and they are told apart by
-    /// whether the address names its destination:
+    /// Three shapes arrive on this one request, told apart by the addresses:
     ///
+    /// * **No addresses at all** — the routed dial: `peer.AddrInfo{ID, Addrs:
+    ///   []}` on a Go routed host, which consults routing rather than erroring.
+    ///   Handed on as a bare `/p2p/<peer>`, so `dispatch_routed` finds the peer
+    ///   from what the daemon already knows. A caller reading a peer record
+    ///   that carried no addresses — a peer on a binary predating
+    ///   `addrs_signed` — arrives here, and finding a peer is the daemon's job
+    ///   rather than something every caller should branch on.
     /// * **One multiaddr ending in `/p2p/<peer>`** — the classic dial, what
     ///   `P2PClient::connect_peer` and `p2p peers connect --addr` send. Handed
     ///   to `NetworkHandle::connect_peer` unchanged, which is what makes a
@@ -680,7 +686,15 @@ impl ConnState {
         };
 
         if connect.addrs.is_empty() {
-            return error_response("Malformed request; missing parameters".to_string());
+            return match self
+                .shared
+                .handle
+                .connect_peer(&format!("/p2p/{peer}"))
+                .await
+            {
+                Ok(_) => ok_response(),
+                Err(e) => error_response(e.to_string()),
+            };
         }
 
         let parsed: Vec<Multiaddr> = connect

--- a/core/crates/kwaai-p2p-daemon/tests/control_server.rs
+++ b/core/crates/kwaai-p2p-daemon/tests/control_server.rs
@@ -242,6 +242,50 @@ async fn connect_with_addrs_seeds_the_daemon_and_survives_a_disconnect() {
     b.shutdown().await;
 }
 
+/// CONNECT with a peer and **no** addresses is the routed form, not a
+/// malformed request: finding the peer is the daemon's job. Already connected
+/// is the cheap end of that — the routed path forwards immediately.
+#[tokio::test]
+async fn connect_with_no_addrs_is_routed_not_malformed() {
+    let a = TestNode::spawn().await;
+    let b = TestNode::spawn().await;
+
+    let mut client = a.client().await;
+    tokio::time::timeout(TIMEOUT, client.connect_peer(&b.addr))
+        .await
+        .expect("connect must not hang")
+        .expect("dial B");
+
+    tokio::time::timeout(TIMEOUT, client.connect_peer_with_addrs(&b.peer_id, &[]))
+        .await
+        .expect("connect must not hang")
+        .expect("an empty address list must dial by id, not be refused");
+
+    a.shutdown().await;
+    b.shutdown().await;
+}
+
+/// The same request for a peer the daemon has never heard of fails on the
+/// *lookup*, which is the honest error — a caller that has no address for a
+/// peer has made a well-formed request the daemon could not satisfy.
+#[tokio::test]
+async fn connect_with_no_addrs_to_an_unknown_peer_fails_on_the_lookup() {
+    let node = TestNode::spawn().await;
+    let mut client = node.client().await;
+
+    let stranger = Keypair::generate_ed25519().public().to_peer_id();
+    let err = tokio::time::timeout(TIMEOUT, client.connect_peer_with_addrs(&stranger, &[]))
+        .await
+        .expect("connect must not hang")
+        .expect_err("a peer nothing knows about cannot be dialed");
+    assert!(
+        err.to_string().contains("peer not found in DHT"),
+        "expected a routing failure, not a protocol complaint, got: {err}"
+    );
+
+    node.shutdown().await;
+}
+
 /// A malformed CONNECT must come back as a protocol error on the socket, not
 /// close the connection — the client keeps using it afterwards.
 #[tokio::test]

--- a/core/crates/kwaai-p2p-daemon/tests/control_server.rs
+++ b/core/crates/kwaai-p2p-daemon/tests/control_server.rs
@@ -190,6 +190,58 @@ async fn connect_then_list_peers_shows_the_remote() {
     b.shutdown().await;
 }
 
+/// The split `AddrInfo{ID, Addrs}` form of CONNECT, which is what a signed peer
+/// record produces: bare addresses beside an explicit peer id.
+///
+/// It must dial like the classic form *and* leave the addresses in the daemon's
+/// learned map — proved here by dropping the connection and issuing a routed
+/// unary, which has no other way to find B (nothing bootstrapped these two
+/// together, so B is in no routing table of A's).
+#[tokio::test]
+async fn connect_with_addrs_seeds_the_daemon_and_survives_a_disconnect() {
+    let a = TestNode::spawn().await;
+    let b = TestNode::spawn().await;
+
+    b.handle
+        .add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("registering a handler on B");
+
+    let b_listen: Multiaddr = b
+        .addr
+        .parse::<Multiaddr>()
+        .expect("a valid addr")
+        .iter()
+        .filter(|p| !matches!(p, libp2p::multiaddr::Protocol::P2p(_)))
+        .collect();
+
+    let mut client = a.client().await;
+    tokio::time::timeout(
+        TIMEOUT,
+        client.connect_peer_with_addrs(&b.peer_id, &[b_listen]),
+    )
+    .await
+    .expect("connect must not hang")
+    .expect("a supplied address must be enough to dial");
+
+    a.handle
+        .disconnect_peer(b.peer_id)
+        .await
+        .expect("disconnect");
+
+    let echoed = tokio::time::timeout(
+        TIMEOUT,
+        a.handle.call_unary_handler(b.peer_id, PROTO, b"hi"),
+    )
+    .await
+    .expect("the re-dial must not hang")
+    .expect("the daemon must re-dial from the addresses CONNECT supplied");
+    assert_eq!(echoed, b"hi");
+
+    a.shutdown().await;
+    b.shutdown().await;
+}
+
 /// A malformed CONNECT must come back as a protocol error on the socket, not
 /// close the connection — the client keeps using it afterwards.
 #[tokio::test]

--- a/core/crates/kwaai-p2p/src/addresses.rs
+++ b/core/crates/kwaai-p2p/src/addresses.rs
@@ -152,6 +152,32 @@ pub fn is_circuit(addr: &Multiaddr) -> bool {
     addr.iter().any(|p| matches!(p, Protocol::P2pCircuit))
 }
 
+/// Whether this build could dial `addr` if a peer published it.
+///
+/// The swarm is built with TCP and QUIC only (`service.rs`, `with_tcp` →
+/// `with_quic` → `with_dns`), so a `/webtransport`, `/webrtc-direct` or
+/// `/ws` address is not merely unlikely to work — there is no transport
+/// registered that can attempt it. A relay that speaks those advertises them
+/// alongside its TCP and QUIC listeners, so our own circuit list picks them up
+/// and would otherwise publish them.
+///
+/// Worth filtering rather than letting the dial fail, on two counts: a
+/// certhash-bearing webtransport address is ~250 bytes against a DHT record
+/// replicated under every block key, and each undialable entry a peer
+/// publishes costs the dialer one more attempt before it reaches a usable one.
+pub fn uses_dialable_transport(addr: &Multiaddr) -> bool {
+    !addr.iter().any(|p| {
+        matches!(
+            p,
+            Protocol::WebTransport
+                | Protocol::WebRTCDirect
+                | Protocol::Ws(_)
+                | Protocol::Wss(_)
+                | Protocol::Certhash(_)
+        )
+    })
+}
+
 /// Whether a peer reachable at `addr` can serve as *our* relay.
 ///
 /// Deliberately **not** [`is_announceable`], which answers a different question.
@@ -287,6 +313,32 @@ mod tests {
 
     fn v4(s: &str) -> Ipv4Addr {
         s.parse().expect("test ipv4 should parse")
+    }
+
+    // -- transports this build can dial ---------------------------------
+
+    #[test]
+    fn tcp_and_quic_are_dialable_and_the_browser_transports_are_not() {
+        assert!(uses_dialable_transport(&ma("/ip4/1.2.3.4/tcp/4001")));
+        assert!(uses_dialable_transport(&ma(
+            "/ip4/1.2.3.4/udp/4001/quic-v1"
+        )));
+        assert!(!uses_dialable_transport(&ma(
+            "/ip4/1.2.3.4/udp/4001/webrtc-direct/certhash/uEiChFgLr6nfyrSBnELIvIQ0nEWo1hPP2shkHIZpFxRttKw"
+        )));
+        assert!(!uses_dialable_transport(&ma(
+            "/dns4/example.libp2p.direct/tcp/4001/tls/ws"
+        )));
+    }
+
+    /// A relay offering webtransport puts the certhash *before* the
+    /// `/p2p-circuit`, so the check has to look at the whole address rather
+    /// than just its tail.
+    #[test]
+    fn a_webtransport_circuit_is_rejected_despite_the_circuit_suffix() {
+        assert!(!uses_dialable_transport(&ma(
+            "/ip4/76.13.5.74/udp/4001/quic-v1/webtransport/certhash/uEiBIeyYi7BYMq_u71nPi3WJna-9kL5yAURJ5HYy0qXW3YQ/p2p/12D3KooWF7ckKo2HQojbtueQNuLYRT2XC2yzbvBbh4NK2rbi2Azg/p2p-circuit"
+        )));
     }
 
     // -- the golden case ------------------------------------------------

--- a/core/crates/kwaai-p2p/src/addresses.rs
+++ b/core/crates/kwaai-p2p/src/addresses.rs
@@ -152,20 +152,22 @@ pub fn is_circuit(addr: &Multiaddr) -> bool {
     addr.iter().any(|p| matches!(p, Protocol::P2pCircuit))
 }
 
-/// Whether this build could dial `addr` if a peer published it.
+/// Whether this swarm could dial `addr` if a peer published it.
 ///
-/// The swarm is built with TCP and QUIC only (`service.rs`, `with_tcp` →
-/// `with_quic` → `with_dns`), so a `/webtransport`, `/webrtc-direct` or
-/// `/ws` address is not merely unlikely to work — there is no transport
-/// registered that can attempt it. A relay that speaks those advertises them
-/// alongside its TCP and QUIC listeners, so our own circuit list picks them up
-/// and would otherwise publish them.
+/// The swarm is built with TCP always and QUIC only when `enable_quic` is set
+/// (`service.rs`, `with_tcp` → `with_quic` → `with_dns`), so a
+/// `/webtransport`, `/webrtc-direct` or `/ws` address — or a `/quic` one on a
+/// swarm built without it — is not merely unlikely to work: there is no
+/// transport registered that can attempt it, and the dial fails with
+/// `MultiaddrNotSupported`. A relay that speaks those advertises them
+/// alongside its TCP listeners, so our own circuit list picks them up and
+/// would otherwise publish them.
 ///
 /// Worth filtering rather than letting the dial fail, on two counts: a
 /// certhash-bearing webtransport address is ~250 bytes against a DHT record
 /// replicated under every block key, and each undialable entry a peer
 /// publishes costs the dialer one more attempt before it reaches a usable one.
-pub fn uses_dialable_transport(addr: &Multiaddr) -> bool {
+pub fn uses_dialable_transport(addr: &Multiaddr, quic: bool) -> bool {
     !addr.iter().any(|p| {
         matches!(
             p,
@@ -174,7 +176,7 @@ pub fn uses_dialable_transport(addr: &Multiaddr) -> bool {
                 | Protocol::Ws(_)
                 | Protocol::Wss(_)
                 | Protocol::Certhash(_)
-        )
+        ) || (!quic && matches!(p, Protocol::Quic | Protocol::QuicV1))
     })
 }
 
@@ -319,16 +321,31 @@ mod tests {
 
     #[test]
     fn tcp_and_quic_are_dialable_and_the_browser_transports_are_not() {
-        assert!(uses_dialable_transport(&ma("/ip4/1.2.3.4/tcp/4001")));
-        assert!(uses_dialable_transport(&ma(
-            "/ip4/1.2.3.4/udp/4001/quic-v1"
-        )));
-        assert!(!uses_dialable_transport(&ma(
-            "/ip4/1.2.3.4/udp/4001/webrtc-direct/certhash/uEiChFgLr6nfyrSBnELIvIQ0nEWo1hPP2shkHIZpFxRttKw"
-        )));
-        assert!(!uses_dialable_transport(&ma(
-            "/dns4/example.libp2p.direct/tcp/4001/tls/ws"
-        )));
+        assert!(uses_dialable_transport(&ma("/ip4/1.2.3.4/tcp/4001"), true));
+        assert!(uses_dialable_transport(
+            &ma("/ip4/1.2.3.4/udp/4001/quic-v1"),
+            true
+        ));
+        assert!(!uses_dialable_transport(
+            &ma("/ip4/1.2.3.4/udp/4001/webrtc-direct/certhash/uEiChFgLr6nfyrSBnELIvIQ0nEWo1hPP2shkHIZpFxRttKw"),
+            true
+        ));
+        assert!(!uses_dialable_transport(
+            &ma("/dns4/example.libp2p.direct/tcp/4001/tls/ws"),
+            true
+        ));
+    }
+
+    /// A swarm built without QUIC has no transport for a `/quic-v1` address,
+    /// direct or as a circuit's relay hop; TCP is unaffected.
+    #[test]
+    fn quic_is_dialable_only_on_a_swarm_that_enabled_it() {
+        let direct = ma("/ip4/1.2.3.4/udp/4001/quic-v1");
+        let circuit = ma("/ip4/76.13.5.74/udp/4001/quic-v1/p2p/12D3KooWF7ckKo2HQojbtueQNuLYRT2XC2yzbvBbh4NK2rbi2Azg/p2p-circuit");
+        assert!(!uses_dialable_transport(&direct, false));
+        assert!(!uses_dialable_transport(&circuit, false));
+        assert!(uses_dialable_transport(&circuit, true));
+        assert!(uses_dialable_transport(&ma("/ip4/1.2.3.4/tcp/4001"), false));
     }
 
     /// A relay offering webtransport puts the certhash *before* the
@@ -336,9 +353,10 @@ mod tests {
     /// than just its tail.
     #[test]
     fn a_webtransport_circuit_is_rejected_despite_the_circuit_suffix() {
-        assert!(!uses_dialable_transport(&ma(
-            "/ip4/76.13.5.74/udp/4001/quic-v1/webtransport/certhash/uEiBIeyYi7BYMq_u71nPi3WJna-9kL5yAURJ5HYy0qXW3YQ/p2p/12D3KooWF7ckKo2HQojbtueQNuLYRT2XC2yzbvBbh4NK2rbi2Azg/p2p-circuit"
-        )));
+        assert!(!uses_dialable_transport(
+            &ma("/ip4/76.13.5.74/udp/4001/quic-v1/webtransport/certhash/uEiBIeyYi7BYMq_u71nPi3WJna-9kL5yAURJ5HYy0qXW3YQ/p2p/12D3KooWF7ckKo2HQojbtueQNuLYRT2XC2yzbvBbh4NK2rbi2Azg/p2p-circuit"),
+            true
+        ));
     }
 
     // -- the golden case ------------------------------------------------

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -218,6 +218,17 @@ pub enum Command {
         addr: Multiaddr,
         reply: oneshot::Sender<P2PResult<PeerId>>,
     },
+    /// Connect to `peer`, seeding the learned-address map with `addrs` first.
+    ///
+    /// Go's `doConnect` took a `peer.AddrInfo{ID, Addrs}` and handed it to a
+    /// *routed* host: the addresses are a hint, and the DHT is the fallback.
+    /// This is that, with the hint kept — see [`crate::learned_addrs`] — so a
+    /// later dial to the same peer still has it after the connection drops.
+    ConnectPeerWithAddrs {
+        peer: PeerId,
+        addrs: Vec<Multiaddr>,
+        reply: oneshot::Sender<P2PResult<PeerId>>,
+    },
     /// Close all connections to a peer.
     DisconnectPeer {
         peer: PeerId,
@@ -423,6 +434,29 @@ impl NetworkHandle {
             .parse()
             .map_err(|e| P2PError::InvalidAddress(format!("{multiaddr_str}: {e}")))?;
         self.call(|reply| Command::ConnectPeer { addr, reply })
+            .await?
+    }
+
+    /// Connect to `peer`, first recording `addrs` as ways to reach it.
+    ///
+    /// The split `(peer, addrs)` form rather than one full multiaddr, because
+    /// that is what the sources of these addresses produce: a signed peer
+    /// record carries the id once, under the signature, and the addresses bare
+    /// ([`crate::peer_record::verified_addrs`]).
+    ///
+    /// Unlike [`Self::connect_peer`], the addresses outlive the call. They go
+    /// into the service's learned-address map, which every later dial to this
+    /// peer consults ahead of the routing table — so a routed unary request
+    /// after the connection drops re-dials from them instead of failing with
+    /// "peer not found in DHT (no addresses)". An empty list, or addresses that
+    /// all fail, falls back to the DHT walk exactly as a bare-PeerId connect
+    /// does today.
+    pub async fn connect_peer_with_addrs(
+        &self,
+        peer: PeerId,
+        addrs: Vec<Multiaddr>,
+    ) -> P2PResult<PeerId> {
+        self.call(|reply| Command::ConnectPeerWithAddrs { peer, addrs, reply })
             .await?
     }
 

--- a/core/crates/kwaai-p2p/src/handle.rs
+++ b/core/crates/kwaai-p2p/src/handle.rs
@@ -252,6 +252,12 @@ pub enum Command {
     ListenAddrs {
         reply: oneshot::Sender<Vec<Multiaddr>>,
     },
+    /// Addresses confirmed reachable from outside — a UPnP mapping, or a
+    /// candidate AutoNAT confirmed. Not listeners: a mapped port is one the
+    /// gateway binds, not the swarm.
+    ExternalAddrs {
+        reply: oneshot::Sender<Vec<Multiaddr>>,
+    },
     /// The protocol list a connected peer advertised over identify.
     PeerProtocols {
         peer: PeerId,
@@ -493,6 +499,11 @@ impl NetworkHandle {
     /// `/tcp/0` shows the real port).
     pub async fn listen_addrs(&self) -> P2PResult<Vec<Multiaddr>> {
         self.call(|reply| Command::ListenAddrs { reply }).await
+    }
+
+    /// Addresses confirmed reachable from outside (see [`Command::ExternalAddrs`]).
+    pub async fn external_addrs(&self) -> P2PResult<Vec<Multiaddr>> {
+        self.call(|reply| Command::ExternalAddrs { reply }).await
     }
 
     /// The protocols `peer` advertised in its most recent identify response, or

--- a/core/crates/kwaai-p2p/src/learned_addrs.rs
+++ b/core/crates/kwaai-p2p/src/learned_addrs.rs
@@ -1,0 +1,327 @@
+//! The peerstore rust-libp2p does not have.
+//!
+//! go-libp2p keeps every address it has ever learned for a peer in a peerstore,
+//! and its routed host consults that before anything else. rust-libp2p keeps
+//! addresses only inside behaviours: kad's k-buckets and identify's per-
+//! connection cache. Neither is a store.
+//!
+//! * A k-bucket holds **k = 20** peers, and a *disconnected* entry is the first
+//!   one replaced — so a peer we were explicitly told how to reach is evicted
+//!   by ordinary churn, precisely while it is not connected and we most need
+//!   its address.
+//! * kad answers `FIND_NODE` from those buckets alone
+//!   (`find_closest_local_peers`), where the kad-DHT spec §6.1.1 says a server
+//!   MUST answer for a peer held in its *peerstore* "even if the target node
+//!   isn't a DHT Server or only advertises private addresses". That missing
+//!   half is why a NATed peer cannot be resolved by PeerId at all, which is
+//!   what this whole branch is about.
+//! * kad never re-dials a tabled peer whose address failed, so simply calling
+//!   `kad.add_address` with a learned address is *not* an equivalent: once that
+//!   address fails, the entry is inert until something evicts it.
+//!
+//! So the service keeps its own map, filled from the signed records peers
+//! publish about themselves ([`crate::peer_record`]) and from callers that
+//! supply addresses with a connect request — Go's `peer.AddrInfo{ID, Addrs}`,
+//! which is exactly the shape the old p2pd `doConnect` took. `dial_routed`
+//! consults it before the k-bucket, so it survives a dropped connection: the
+//! next routed request re-dials from the same addresses rather than starting
+//! again from "no addresses". When the planned §6.1.1 `FIND_NODE` change lands,
+//! it will answer from this same map.
+//!
+//! Two bounds, because this is fed by remote claims:
+//!
+//! * per peer, [`MAX_ADDRS_PER_PEER`], oldest evicted;
+//! * across peers, [`MAX_PEERS`], oldest *first inserted* evicted.
+//!
+//! There is no TTL. Staleness is handled reactively instead, by
+//! [`LearnedAddrs::forget`] on a dial failure — the same evidence-based policy
+//! the routing table uses, and for the same reason: only a failed dial
+//! distinguishes an address that is stale from one that merely looks odd.
+
+use std::collections::{HashMap, VecDeque};
+
+use libp2p::{Multiaddr, PeerId};
+
+use crate::addresses::{strip_dest_p2p, strip_p2p};
+
+/// Cap on learned addresses per peer.
+///
+/// The same six as the routing table's `MAX_ADDRESSES_PER_PEER`, and for the
+/// same reason: every entry is dialed on the next attempt, so an unbounded
+/// list fans one dial out across a peer's entire history.
+///
+/// At the cap the **oldest** address is evicted. Refusing the new one instead
+/// would be simpler but wrong: a peer that legitimately moves — a NATed node
+/// rotating onto a new relay, which is routine — would be frozen at the six
+/// addresses it happened to publish first and could never become reachable
+/// again. Oldest-out keeps the list tracking where the peer is *now*.
+pub const MAX_ADDRS_PER_PEER: usize = 6;
+
+/// Cap on how many peers the map holds.
+///
+/// A memory bound, not a policy: at six addresses of ~40 bytes this is well
+/// under a megabyte, and it is comfortably larger than the neighbourhood a
+/// node actually talks to (the routing table itself tops out around the same
+/// order). Eviction is by *first insertion*, not by use — an LRU would need a
+/// touch on every read from the dial path, and the cheap approximation is
+/// enough for a bound that a real node is not expected to reach.
+pub const MAX_PEERS: usize = 1024;
+
+/// Addresses learned about other peers, bounded (see the module docs).
+///
+/// Addresses are stored **bare**, with the destination `/p2p/<peer>` stripped
+/// and a circuit's relay hop kept — the convention `candidate_addresses` hands
+/// out and `dial_routed` re-attaches the id to.
+#[derive(Debug)]
+pub struct LearnedAddrs {
+    /// Our own peer id, so a record naming us can never be stored. An address
+    /// of ours filed under someone else's id reaches our own listener and
+    /// fails `WrongPeerId`; the address-level guard is `OwnAddresses`, this is
+    /// the peer-level one.
+    local: PeerId,
+    peers: HashMap<PeerId, Vec<Multiaddr>>,
+    /// Peers in first-insertion order, oldest at the front. Kept in step with
+    /// `peers`: exactly one entry per key.
+    order: VecDeque<PeerId>,
+}
+
+impl LearnedAddrs {
+    pub fn new(local: PeerId) -> Self {
+        Self {
+            local,
+            peers: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    /// Learn `addrs` for `peer`, newest last. Returns how many were new.
+    ///
+    /// Empty addresses and our own peer id are refused; duplicates (compared
+    /// with the destination id stripped, so the same address in two
+    /// publishing conventions cannot occupy two slots) are ignored rather than
+    /// re-ordered, so a repeated announcement does not count as churn.
+    pub fn insert(&mut self, peer: PeerId, addrs: impl IntoIterator<Item = Multiaddr>) -> usize {
+        if peer == self.local {
+            return 0;
+        }
+        let mut added = 0;
+        for addr in addrs {
+            let addr = strip_dest_p2p(&addr);
+            if addr.is_empty() {
+                continue;
+            }
+            let entry = match self.peers.get_mut(&peer) {
+                Some(entry) => entry,
+                None => {
+                    self.evict_oldest_peer_if_full();
+                    self.order.push_back(peer);
+                    self.peers.entry(peer).or_default()
+                }
+            };
+            if entry.contains(&addr) {
+                continue;
+            }
+            if entry.len() >= MAX_ADDRS_PER_PEER {
+                entry.remove(0);
+            }
+            entry.push(addr);
+            added += 1;
+        }
+        added
+    }
+
+    /// Everything we have learned for `peer`, oldest first.
+    pub fn get(&self, peer: &PeerId) -> &[Multiaddr] {
+        self.peers.get(peer).map_or(&[], Vec::as_slice)
+    }
+
+    /// Drop the learned addresses in `failed`, and the peer's entry with them
+    /// if that empties it.
+    ///
+    /// Called from the dial-failure path, mirroring what the routing table
+    /// does: an address that failed to connect is the only evidence available
+    /// that it is stale, and a rotated-away circuit would otherwise stick
+    /// forever. Comparison strips every `/p2p` component, because a dial
+    /// reports the fully-qualified address it actually attempted.
+    pub fn forget(&mut self, peer: &PeerId, failed: &[Multiaddr]) -> usize {
+        let Some(entry) = self.peers.get_mut(peer) else {
+            return 0;
+        };
+        let before = entry.len();
+        entry.retain(|a| !failed.iter().any(|f| strip_p2p(f) == strip_p2p(a)));
+        let dropped = before - entry.len();
+        if entry.is_empty() {
+            self.peers.remove(peer);
+            self.order.retain(|p| p != peer);
+        }
+        dropped
+    }
+
+    /// How many peers the map currently holds.
+    pub fn len(&self) -> usize {
+        self.peers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+
+    fn evict_oldest_peer_if_full(&mut self) {
+        while self.peers.len() >= MAX_PEERS {
+            match self.order.pop_front() {
+                Some(oldest) => {
+                    self.peers.remove(&oldest);
+                }
+                None => break,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ma(s: &str) -> Multiaddr {
+        s.parse().expect("test multiaddr")
+    }
+
+    fn map() -> LearnedAddrs {
+        LearnedAddrs::new(PeerId::random())
+    }
+
+    #[test]
+    fn keeps_what_it_was_given() {
+        let mut m = map();
+        let peer = PeerId::random();
+        m.insert(peer, [ma("/ip4/203.0.113.7/tcp/4001")]);
+        assert_eq!(m.get(&peer), [ma("/ip4/203.0.113.7/tcp/4001")]);
+    }
+
+    /// The destination id is stripped on the way in, so the same address in
+    /// the two publishing conventions is one entry, not two.
+    #[test]
+    fn strips_the_destination_id_and_dedupes() {
+        let mut m = map();
+        let peer = PeerId::random();
+        m.insert(
+            peer,
+            [
+                ma(&format!("/ip4/203.0.113.7/tcp/4001/p2p/{peer}")),
+                ma("/ip4/203.0.113.7/tcp/4001"),
+            ],
+        );
+        assert_eq!(m.get(&peer), [ma("/ip4/203.0.113.7/tcp/4001")]);
+    }
+
+    /// A circuit keeps its relay hop — without it rust-libp2p refuses the dial
+    /// outright ("Missing relay peer id").
+    #[test]
+    fn keeps_a_circuits_relay_hop() {
+        let mut m = map();
+        let peer = PeerId::random();
+        let relay = PeerId::random();
+        m.insert(
+            peer,
+            [ma(&format!(
+                "/ip4/76.13.5.74/tcp/4001/p2p/{relay}/p2p-circuit/p2p/{peer}"
+            ))],
+        );
+        assert_eq!(
+            m.get(&peer),
+            [ma(&format!(
+                "/ip4/76.13.5.74/tcp/4001/p2p/{relay}/p2p-circuit"
+            ))]
+        );
+    }
+
+    /// A peer that moves must not be frozen at its first six addresses.
+    #[test]
+    fn per_peer_cap_evicts_the_oldest() {
+        let mut m = map();
+        let peer = PeerId::random();
+        for i in 0..(MAX_ADDRS_PER_PEER + 2) {
+            m.insert(peer, [ma(&format!("/ip4/203.0.113.{i}/tcp/4001"))]);
+        }
+        let held = m.get(&peer);
+        assert_eq!(held.len(), MAX_ADDRS_PER_PEER);
+        assert_eq!(held[0], ma("/ip4/203.0.113.2/tcp/4001"), "oldest two gone");
+        assert_eq!(
+            held[MAX_ADDRS_PER_PEER - 1],
+            ma(&format!(
+                "/ip4/203.0.113.{}/tcp/4001",
+                MAX_ADDRS_PER_PEER + 1
+            )),
+            "the newest is kept"
+        );
+    }
+
+    #[test]
+    fn total_cap_evicts_the_oldest_peer() {
+        let mut m = map();
+        let first = PeerId::random();
+        m.insert(first, [ma("/ip4/203.0.113.1/tcp/4001")]);
+        for _ in 1..MAX_PEERS {
+            m.insert(PeerId::random(), [ma("/ip4/203.0.113.2/tcp/4001")]);
+        }
+        assert_eq!(m.len(), MAX_PEERS);
+
+        m.insert(PeerId::random(), [ma("/ip4/203.0.113.3/tcp/4001")]);
+        assert_eq!(m.len(), MAX_PEERS, "the map stays bounded");
+        assert!(
+            m.get(&first).is_empty(),
+            "the first peer inserted is the one evicted"
+        );
+    }
+
+    /// Our own addresses filed under our own id would only ever dial our own
+    /// listener.
+    #[test]
+    fn refuses_our_own_peer_id() {
+        let local = PeerId::random();
+        let mut m = LearnedAddrs::new(local);
+        assert_eq!(m.insert(local, [ma("/ip4/203.0.113.7/tcp/4001")]), 0);
+        assert!(m.get(&local).is_empty());
+    }
+
+    /// A dial reports the fully-qualified address it attempted; the stored one
+    /// is bare. They must still match, or a stale circuit sticks forever.
+    #[test]
+    fn forget_drops_the_failed_address_however_it_is_qualified() {
+        let mut m = map();
+        let peer = PeerId::random();
+        m.insert(
+            peer,
+            [
+                ma("/ip4/203.0.113.7/tcp/4001"),
+                ma("/ip4/203.0.113.8/tcp/4001"),
+            ],
+        );
+
+        let dropped = m.forget(
+            &peer,
+            &[ma(&format!("/ip4/203.0.113.7/tcp/4001/p2p/{peer}"))],
+        );
+        assert_eq!(dropped, 1);
+        assert_eq!(m.get(&peer), [ma("/ip4/203.0.113.8/tcp/4001")]);
+    }
+
+    #[test]
+    fn forget_removes_a_peer_whose_last_address_failed() {
+        let mut m = map();
+        let peer = PeerId::random();
+        m.insert(peer, [ma("/ip4/203.0.113.7/tcp/4001")]);
+        m.forget(&peer, &[ma("/ip4/203.0.113.7/tcp/4001")]);
+        assert!(m.is_empty(), "an empty entry must not linger");
+    }
+
+    /// An address with no transport cannot be dialed, only mistaken for
+    /// reachability.
+    #[test]
+    fn refuses_an_address_that_is_only_a_peer_id() {
+        let mut m = map();
+        let peer = PeerId::random();
+        assert_eq!(m.insert(peer, [ma(&format!("/p2p/{peer}"))]), 0);
+        assert!(m.is_empty());
+    }
+}

--- a/core/crates/kwaai-p2p/src/lib.rs
+++ b/core/crates/kwaai-p2p/src/lib.rs
@@ -42,6 +42,8 @@ pub mod dht_service;
 pub mod error;
 pub mod handle;
 pub mod identity;
+pub mod learned_addrs;
+pub mod peer_record;
 pub mod raw_stream;
 pub mod reachability;
 pub mod relay_manager;
@@ -60,6 +62,8 @@ pub use error::{P2PError, P2PResult};
 pub use handle::{
     Direction, InboundUnaryCall, KnownPeer, NetworkHandle, NetworkSnapshot, PeerInfo, UnaryHandler,
 };
+pub use learned_addrs::LearnedAddrs;
+pub use peer_record::verified_addrs;
 pub use raw_stream::{InboundStream, RawStream, RawStreamError};
 pub use reachability::{
     AnnounceState, Reachability, ReachabilityKind, Source as ReachabilitySource,

--- a/core/crates/kwaai-p2p/src/lib.rs
+++ b/core/crates/kwaai-p2p/src/lib.rs
@@ -49,7 +49,7 @@ pub mod service;
 pub mod transport;
 pub mod unary;
 
-pub use addresses::{is_announceable, is_circuit, is_routable_v4};
+pub use addresses::{is_announceable, is_circuit, is_routable_v4, uses_dialable_transport};
 pub use behaviour::{KwaaiBehaviour, KwaaiBehaviourEvent};
 pub use config::{
     kad_protocols, NetworkConfig, KAD_MULTI_PROTOCOL_BUILD, KWAAI_BOOTSTRAP_SERVERS,

--- a/core/crates/kwaai-p2p/src/peer_record.rs
+++ b/core/crates/kwaai-p2p/src/peer_record.rs
@@ -15,9 +15,10 @@
 //! peer's subkey are whatever the last writer put there; verification is the
 //! only thing that makes them safe to follow.
 
+use libp2p::multiaddr::Protocol;
 use libp2p::{Multiaddr, PeerId};
 
-use crate::addresses::strip_dest_p2p;
+use crate::addresses::{is_announceable, is_circuit, strip_dest_p2p, uses_dialable_transport};
 
 /// How many addresses one record may contribute.
 ///
@@ -56,6 +57,16 @@ pub const MAX_RECORD_ADDRS: usize = 4;
 /// empty vec. That costs the peer nothing worse than the bare-PeerId dial it
 /// would have got before the field existed.
 ///
+/// # The signature is not a sanity check
+///
+/// It proves who wrote the list, not that the list is worth following. A
+/// peer's own key can vouch for `/ip4/127.0.0.1/tcp/25`, and every reader
+/// would then dial its own port 25 on that peer's say-so. So the publisher's
+/// address-class rule is applied again here, by [`worth_dialing`]. This is the
+/// place for it: the daemon's dial path deliberately keeps loopback and LAN
+/// (two nodes on one host reach each other that way), and cannot tell an
+/// address it learned from a live connection from one a remote record named.
+///
 /// # Shape of what comes back
 ///
 /// Addresses are returned **bare**, each run through
@@ -77,10 +88,31 @@ pub fn verified_addrs(envelope: &[u8], claimed: PeerId) -> Vec<Multiaddr> {
     record
         .addresses()
         .iter()
-        .take(MAX_RECORD_ADDRS)
         .map(strip_dest_p2p)
-        .filter(|a| !a.is_empty())
+        .filter(|a| !a.is_empty() && worth_dialing(a))
+        .take(MAX_RECORD_ADDRS)
         .collect()
+}
+
+/// The publisher's filter, re-run on the reader: a direct address must be
+/// announceable and on a transport this build dials; a circuit's relay hop
+/// must not carry an unroutable IP. A relay named by DNS — how the bootstraps
+/// are addressed — has no IP to judge and passes, as it does when published.
+fn worth_dialing(addr: &Multiaddr) -> bool {
+    if !uses_dialable_transport(addr) {
+        return false;
+    }
+    if !is_circuit(addr) {
+        return is_announceable(addr);
+    }
+    let hop: Multiaddr = addr
+        .iter()
+        .take_while(|p| !matches!(p, Protocol::P2pCircuit))
+        .collect();
+    let has_ip = hop
+        .iter()
+        .any(|p| matches!(p, Protocol::Ip4(_) | Protocol::Ip6(_)));
+    !has_ip || is_announceable(&hop)
 }
 
 #[cfg(test)]
@@ -163,6 +195,47 @@ mod tests {
             verified_addrs(&envelope(&key, &[&qualified]), peer),
             expected,
             "the two publishing conventions must decode identically"
+        );
+    }
+
+    /// A valid signature over a loopback or LAN address is still a request to
+    /// dial something no remote peer should: the address class is checked
+    /// after the signature, and a circuit is judged by its relay hop.
+    #[test]
+    fn drops_addresses_no_remote_reader_should_dial() {
+        let key = Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let relay = PeerId::random();
+        let via_loopback = format!("/ip4/127.0.0.1/tcp/25/p2p/{relay}/p2p-circuit");
+        let bytes = envelope(
+            &key,
+            &[
+                "/ip4/127.0.0.1/tcp/25",
+                "/ip4/10.0.0.1/tcp/22",
+                "/ip6/::1/tcp/22",
+                &via_loopback,
+                "/ip4/203.0.113.7/tcp/4001",
+            ],
+        );
+
+        assert_eq!(
+            verified_addrs(&bytes, peer),
+            vec!["/ip4/203.0.113.7/tcp/4001".parse::<Multiaddr>().unwrap()]
+        );
+    }
+
+    /// The bootstraps are reached by name, so a circuit through one carries
+    /// no IP at all. That is not a reason to refuse it.
+    #[test]
+    fn keeps_a_circuit_through_a_relay_named_by_dns() {
+        let key = Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let relay = PeerId::random();
+        let addr = format!("/dns4/bootstrap1/tcp/8000/p2p/{relay}/p2p-circuit");
+
+        assert_eq!(
+            verified_addrs(&envelope(&key, &[&addr]), peer),
+            vec![addr.parse::<Multiaddr>().unwrap()]
         );
     }
 

--- a/core/crates/kwaai-p2p/src/peer_record.rs
+++ b/core/crates/kwaai-p2p/src/peer_record.rs
@@ -18,7 +18,7 @@
 use libp2p::multiaddr::Protocol;
 use libp2p::{Multiaddr, PeerId};
 
-use crate::addresses::{is_announceable, is_circuit, strip_dest_p2p, uses_dialable_transport};
+use crate::addresses::{is_announceable_with, is_circuit, strip_dest_p2p, uses_dialable_transport};
 
 /// How many addresses one record may contribute.
 ///
@@ -61,11 +61,15 @@ pub const MAX_RECORD_ADDRS: usize = 4;
 ///
 /// It proves who wrote the list, not that the list is worth following. A
 /// peer's own key can vouch for `/ip4/127.0.0.1/tcp/25`, and every reader
-/// would then dial its own port 25 on that peer's say-so. So the publisher's
-/// address-class rule is applied again here, by [`worth_dialing`]. This is the
-/// place for it: the daemon's dial path deliberately keeps loopback and LAN
-/// (two nodes on one host reach each other that way), and cannot tell an
-/// address it learned from a live connection from one a remote record named.
+/// would then dial its own port 25 on that peer's say-so. So the lenient
+/// address-class rule is applied here, by [`worth_dialing`]: loopback, LAN and
+/// the other classes no remote peer can use are dropped. This is the place
+/// for it — the daemon's dial path deliberately keeps loopback and LAN (two
+/// nodes on one host reach each other that way, and supply such addresses
+/// with a connect request) and cannot tell a record's address from a learned
+/// one. The reserved-range question (`require_global_ips`) is left to the
+/// dialer: this decoder has no config, and a signed claim of a reserved
+/// address costs a strict node at most one failed dial.
 ///
 /// # Shape of what comes back
 ///
@@ -94,16 +98,17 @@ pub fn verified_addrs(envelope: &[u8], claimed: PeerId) -> Vec<Multiaddr> {
         .collect()
 }
 
-/// The publisher's filter, re-run on the reader: a direct address must be
-/// announceable and on a transport this build dials; a circuit's relay hop
-/// must not carry an unroutable IP. A relay named by DNS — how the bootstraps
-/// are addressed — has no IP to judge and passes, as it does when published.
+/// The publisher's filter, re-run on the reader in its lenient tier: a direct
+/// address must be announceable and on a transport this build dials; a
+/// circuit's relay hop must not carry an unroutable IP. A relay named by DNS
+/// — how the bootstraps are addressed — has no IP to judge and passes, as it
+/// does when published.
 fn worth_dialing(addr: &Multiaddr) -> bool {
     if !uses_dialable_transport(addr) {
         return false;
     }
     if !is_circuit(addr) {
-        return is_announceable(addr);
+        return is_announceable_with(addr, false);
     }
     let hop: Multiaddr = addr
         .iter()
@@ -112,7 +117,7 @@ fn worth_dialing(addr: &Multiaddr) -> bool {
     let has_ip = hop
         .iter()
         .any(|p| matches!(p, Protocol::Ip4(_) | Protocol::Ip6(_)));
-    !has_ip || is_announceable(&hop)
+    !has_ip || is_announceable_with(&hop, false)
 }
 
 #[cfg(test)]

--- a/core/crates/kwaai-p2p/src/peer_record.rs
+++ b/core/crates/kwaai-p2p/src/peer_record.rs
@@ -1,0 +1,203 @@
+//! Reading the signed address records peers publish about themselves.
+//!
+//! A KwaaiNet node announces the addresses it can be dialed on — chiefly the
+//! relay circuits a NATed node holds, which no dialer can reconstruct — as an
+//! RFC 0003 `PeerRecord` inside a protobuf `SignedEnvelope`, in the interop
+//! signing domain so a Go or JS reader can verify the same bytes. This module
+//! is the reading half. The writing half lives with the announcement
+//! (`kwaai-cli`'s `announce`), because only the node itself can sign.
+//!
+//! It sits in this crate rather than beside the announcement decoder because
+//! what it produces is a **dial instruction**, and everything downstream of
+//! that — seeding the learned-address map, choosing dial candidates — is
+//! network-layer work. The DHT store it arrives from
+//! (`kwaai-hivemind-dht`) has no record validators, so the bytes under a
+//! peer's subkey are whatever the last writer put there; verification is the
+//! only thing that makes them safe to follow.
+
+use libp2p::{Multiaddr, PeerId};
+
+use crate::addresses::strip_dest_p2p;
+
+/// How many addresses one record may contribute.
+///
+/// Matches the publisher's own cap (`announce::MAX_DIAL_ADDRS`), which is
+/// sized for the shapes that actually occur: a direct address plus the two or
+/// three circuits `relay_manager` holds reservations on at once, or one
+/// address per transport on a public node. Enforced again here because the
+/// record is a remote claim — a peer that publishes forty addresses (or a
+/// signed record replayed from a node with a very different address set)
+/// would otherwise cost every dialer forty attempts and forty slots in the
+/// learned-address map.
+pub const MAX_RECORD_ADDRS: usize = 4;
+
+/// The addresses `claimed` signed for itself, or nothing.
+///
+/// # What the check closes
+///
+/// Anyone may write under any subkey in the store, and an address list is a
+/// dialing instruction: without verification an attacker steers a peer's
+/// traffic at an address that peer never signed — black-holing it by naming a dead
+/// host, or aiming it at a third party. Impersonation itself is still
+/// caught at the Noise handshake, but neither of those attacks needs the
+/// attacker to complete one.
+///
+/// # Both checks are load-bearing
+///
+/// `PeerRecord::from_signed_envelope_interop` proves only that the record is
+/// **self-consistent** — that whoever signed it named themselves. It says
+/// nothing about *which* peer that is. The `record.peer_id() == claimed`
+/// comparison below is what ties the record to the peer being dialed; without
+/// it an attacker signs a record with their own key, stores it under the
+/// victim's subkey, and every library check passes.
+///
+/// Any failure — an unparseable envelope, a bad signature, the legacy
+/// (non-interop) signing domain, a record naming someone else — yields an
+/// empty vec. That costs the peer nothing worse than the bare-PeerId dial it
+/// would have got before the field existed.
+///
+/// # Shape of what comes back
+///
+/// Addresses are returned **bare**, each run through
+/// [`strip_dest_p2p`]: the destination `/p2p/<peer>` is dropped, a circuit's
+/// relay hop kept. That is the same convention `NetworkService`'s
+/// `candidate_addresses` hands out, so a record that carries the destination
+/// on its addresses and one that does not yield identical results, and a
+/// caller that re-attaches the id can never produce `/p2p/<id>/p2p/<id>`.
+pub fn verified_addrs(envelope: &[u8], claimed: PeerId) -> Vec<Multiaddr> {
+    let Ok(envelope) = libp2p::core::SignedEnvelope::from_protobuf_encoding(envelope) else {
+        return Vec::new();
+    };
+    let Ok(record) = libp2p::core::PeerRecord::from_signed_envelope_interop(envelope) else {
+        return Vec::new();
+    };
+    if record.peer_id() != claimed {
+        return Vec::new();
+    }
+    record
+        .addresses()
+        .iter()
+        .take(MAX_RECORD_ADDRS)
+        .map(strip_dest_p2p)
+        .filter(|a| !a.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p::identity::Keypair;
+
+    /// A signed envelope for `key` naming `addrs`, exactly as the publisher
+    /// emits one.
+    fn envelope(key: &Keypair, addrs: &[&str]) -> Vec<u8> {
+        let addrs = addrs
+            .iter()
+            .map(|a| a.parse().expect("a valid addr"))
+            .collect();
+        libp2p::core::PeerRecord::new_interop(key, addrs)
+            .expect("signs")
+            .into_signed_envelope()
+            .into_protobuf_encoding()
+    }
+
+    #[test]
+    fn round_trips_a_direct_address() {
+        let key = Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let bytes = envelope(&key, &["/ip4/203.0.113.7/tcp/4001"]);
+
+        assert_eq!(
+            verified_addrs(&bytes, peer),
+            vec!["/ip4/203.0.113.7/tcp/4001".parse::<Multiaddr>().unwrap()]
+        );
+    }
+
+    /// The attack the signature exists to stop: anyone may write under any
+    /// subkey, so a record whose addresses were signed by a different key must
+    /// yield nothing — the peer falls back to a bare-PeerId dial rather than
+    /// being steered at an address its own key never vouched for.
+    #[test]
+    fn rejects_a_record_signed_by_another_key() {
+        let victim = Keypair::generate_ed25519().public().to_peer_id();
+        let attacker = Keypair::generate_ed25519();
+        let bytes = envelope(&attacker, &["/ip4/198.51.100.9/tcp/4001"]);
+
+        assert!(
+            verified_addrs(&bytes, victim).is_empty(),
+            "an address list the announced peer did not sign must not be dialed"
+        );
+    }
+
+    /// The publisher signs in the interop domain deliberately, so that a Go or
+    /// JS reader can verify it. A record in rust-libp2p's legacy domain is not
+    /// that, and must not be accepted by accident.
+    #[test]
+    fn rejects_the_legacy_signing_domain() {
+        let key = Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let addr = "/ip4/203.0.113.7/tcp/4001".parse().expect("a valid addr");
+        let legacy = libp2p::core::PeerRecord::new(&key, vec![addr])
+            .expect("signs")
+            .into_signed_envelope()
+            .into_protobuf_encoding();
+
+        assert!(verified_addrs(&legacy, peer).is_empty());
+    }
+
+    /// Circuits are the whole motivation, and their shape is the one a dialer
+    /// cannot reconstruct. The relay hop must survive; only the destination is
+    /// stripped, so a publisher that leaves the destination on and one that
+    /// does not agree.
+    #[test]
+    fn strips_only_the_destination_from_a_circuit() {
+        let key = Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let relay = PeerId::random();
+        let bare = format!("/ip4/76.13.5.74/tcp/4001/p2p/{relay}/p2p-circuit");
+        let qualified = format!("{bare}/p2p/{peer}");
+
+        let expected: Vec<Multiaddr> = vec![bare.parse().unwrap()];
+        assert_eq!(verified_addrs(&envelope(&key, &[&bare]), peer), expected);
+        assert_eq!(
+            verified_addrs(&envelope(&key, &[&qualified]), peer),
+            expected,
+            "the two publishing conventions must decode identically"
+        );
+    }
+
+    #[test]
+    fn garbage_yields_nothing() {
+        assert!(verified_addrs(&[0xde, 0xad, 0xbe, 0xef], PeerId::random()).is_empty());
+        assert!(verified_addrs(&[], PeerId::random()).is_empty());
+    }
+
+    /// A remote claim is bounded here as well as at the publisher: the cap is
+    /// what keeps a signed record from filling a dialer's candidate list.
+    #[test]
+    fn caps_the_address_count() {
+        let key = Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let many: Vec<String> = (0..10)
+            .map(|i| format!("/ip4/203.0.113.{i}/tcp/4001"))
+            .collect();
+        let refs: Vec<&str> = many.iter().map(String::as_str).collect();
+
+        assert_eq!(
+            verified_addrs(&envelope(&key, &refs), peer).len(),
+            MAX_RECORD_ADDRS
+        );
+    }
+
+    /// A record carrying nothing but `/p2p/<self>` decodes to no addresses at
+    /// all, rather than to an empty multiaddr that cannot be dialed and would
+    /// occupy a slot in the learned map.
+    #[test]
+    fn drops_an_address_that_was_only_a_peer_id() {
+        let key = Keypair::generate_ed25519();
+        let peer = key.public().to_peer_id();
+        let bytes = envelope(&key, &[&format!("/p2p/{peer}")]);
+
+        assert!(verified_addrs(&bytes, peer).is_empty());
+    }
+}

--- a/core/crates/kwaai-p2p/src/peer_record.rs
+++ b/core/crates/kwaai-p2p/src/peer_record.rs
@@ -104,7 +104,9 @@ pub fn verified_addrs(envelope: &[u8], claimed: PeerId) -> Vec<Multiaddr> {
 /// — how the bootstraps are addressed — has no IP to judge and passes, as it
 /// does when published.
 fn worth_dialing(addr: &Multiaddr) -> bool {
-    if !uses_dialable_transport(addr) {
+    // QUIC passes here: this decoder has no config, and the daemon drops a
+    // `/quic` address at ingestion when its own swarm was built without it.
+    if !uses_dialable_transport(addr, true) {
         return false;
     }
     if !is_circuit(addr) {

--- a/core/crates/kwaai-p2p/src/reachability.rs
+++ b/core/crates/kwaai-p2p/src/reachability.rs
@@ -84,16 +84,19 @@ pub enum ReachabilityKind {
 
 /// What the announce loop needs to know, and nothing else.
 ///
-/// Notably **no addresses**. The DHT record (`DHTServerInfo`) carries no
-/// multiaddr field at all — peers resolve addresses through Kademlia and
-/// identify — so address publication is `Swarm::add_external_address` plus an
-/// identify push, entirely separate from announcing. The only address-derived
-/// fact the record contains is the `using_relay` boolean.
+/// The DHT record (`DHTServerInfo`) carries the node's *circuit* addresses —
+/// a dialer cannot reconstruct which relay a peer holds a reservation on, so
+/// the record has to say — but no direct ones: those still travel by
+/// `Swarm::add_external_address` plus an identify push, entirely separate from
+/// announcing. So this struct tracks exactly what the record depends on: the
+/// reachability verdict, and a fingerprint of the confirmed circuit set.
 ///
-/// That is what makes this channel quiet: an address can change, a reservation
-/// can move from one relay to another, identify can push a dozen times, and
-/// none of it alters this struct. Only a genuine change in *how reachable the
-/// node is* does.
+/// That keeps the channel quiet on everything else. Identify can push a dozen
+/// times and a direct address can churn without waking the announce loop. What
+/// *does* wake it is a reservation moving between relays: the published
+/// circuit is then wrong until the next tick, up to a full TTL of dials at a
+/// relay that answers `no reservation for destination`, so the record follows
+/// the reservation rather than waiting for the clock.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AnnounceState {
     /// Public, Private, or not yet known.
@@ -105,9 +108,28 @@ pub struct AnnounceState {
     /// is Unknown — a node that does not know where it stands should not be
     /// telling the network it is Direct.
     pub announceable: bool,
+    /// Order-independent fingerprint of the confirmed circuit addresses, `0`
+    /// when there are none. A hash rather than the list so the state stays
+    /// `Copy` and cheap to compare; the record reads the addresses themselves
+    /// from the swarm at announce time.
+    pub circuits: u64,
     /// Increments on every published change, so a consumer can tell "no change"
     /// from "changed back to what it was".
     pub epoch: u64,
+}
+
+/// Fingerprint a circuit set so that the same relays in any order compare
+/// equal and any addition, removal or swap does not.
+pub fn circuit_fingerprint(circuits: &[Multiaddr]) -> u64 {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    if circuits.is_empty() {
+        return 0;
+    }
+    let mut keys: Vec<String> = circuits.iter().map(ToString::to_string).collect();
+    keys.sort_unstable();
+    let mut h = DefaultHasher::new();
+    keys.hash(&mut h);
+    h.finish()
 }
 
 impl AnnounceState {
@@ -117,13 +139,14 @@ impl AnnounceState {
             reachability: ReachabilityKind::Unknown,
             using_relay: false,
             announceable: false,
+            circuits: 0,
             epoch: 0,
         }
     }
 
-    /// Derive the state from a reachability verdict and whether a circuit is
-    /// live, preserving `epoch` (the sender bumps it only on a real change).
-    pub fn derive(reachability: &Reachability, has_circuit: bool, epoch: u64) -> Self {
+    /// Derive the state from a reachability verdict and the confirmed circuit
+    /// set, preserving `epoch` (the sender bumps it only on a real change).
+    pub fn derive(reachability: &Reachability, circuits: &[Multiaddr], epoch: u64) -> Self {
         let kind = reachability.kind();
         Self {
             reachability: kind,
@@ -131,8 +154,9 @@ impl AnnounceState {
             // one is not a way for anybody to reach us, and announcing
             // `using_relay` on the strength of one would tell the map a node is
             // reachable when it is not.
-            using_relay: has_circuit,
+            using_relay: !circuits.is_empty(),
             announceable: kind != ReachabilityKind::Unknown,
+            circuits: circuit_fingerprint(circuits),
             epoch,
         }
     }
@@ -143,6 +167,7 @@ impl AnnounceState {
         self.reachability != other.reachability
             || self.using_relay != other.using_relay
             || self.announceable != other.announceable
+            || self.circuits != other.circuits
     }
 }
 
@@ -494,6 +519,59 @@ mod tests {
 
     fn ma(s: &str) -> Multiaddr {
         s.parse().unwrap()
+    }
+
+    fn circuit(relay: u8) -> Multiaddr {
+        ma(&format!(
+            "/ip4/198.18.0.{relay}/tcp/4001/p2p/{}/p2p-circuit",
+            peer(relay)
+        ))
+    }
+
+    /// The case the fingerprint exists for: a reservation moving from one relay
+    /// to another leaves `using_relay` true throughout, so before this only the
+    /// clock would have republished the record — with the old relay in it.
+    #[test]
+    fn a_rotation_between_relays_is_a_change_worth_announcing() {
+        let before = AnnounceState::derive(&Reachability::Private, &[circuit(1)], 0);
+        let after = AnnounceState::derive(&Reachability::Private, &[circuit(2)], 0);
+        assert!(
+            before.using_relay && after.using_relay,
+            "the flag alone cannot see it"
+        );
+        assert!(before.differs(&after));
+    }
+
+    /// Gaining or losing one of several also counts — the record lists them all.
+    #[test]
+    fn adding_or_dropping_a_circuit_is_a_change() {
+        let one = AnnounceState::derive(&Reachability::Private, &[circuit(1)], 0);
+        let two = AnnounceState::derive(&Reachability::Private, &[circuit(1), circuit(2)], 0);
+        assert!(one.differs(&two));
+        assert!(two.differs(&one));
+    }
+
+    /// The relay manager hands the set back from a map, so order is arbitrary
+    /// and must not look like churn.
+    #[test]
+    fn the_same_circuits_in_another_order_are_not_a_change() {
+        let a = AnnounceState::derive(&Reachability::Private, &[circuit(1), circuit(2)], 0);
+        let b = AnnounceState::derive(&Reachability::Private, &[circuit(2), circuit(1)], 0);
+        assert!(!a.differs(&b));
+        assert_eq!(a.circuits, b.circuits);
+    }
+
+    /// No circuits is the zero fingerprint and `using_relay` false, so the
+    /// initial state and a node that never reserved compare equal.
+    #[test]
+    fn no_circuits_matches_the_initial_state() {
+        let none = AnnounceState::derive(&Reachability::Private, &[], 0);
+        assert_eq!(none.circuits, 0);
+        assert!(!none.using_relay);
+        let mut initial = AnnounceState::initial();
+        initial.reachability = ReachabilityKind::Private;
+        initial.announceable = true;
+        assert!(!none.differs(&initial));
     }
 
     fn peer(n: u8) -> PeerId {

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -43,6 +43,7 @@ use crate::handle::{
     parse_protocols, Command, Direction, InboundStreamSender, InboundUnaryCall, InboundUnarySender,
     KnownPeer, NetworkHandle, NetworkSnapshot, PeerInfo, RoutingEntry,
 };
+use crate::learned_addrs::LearnedAddrs;
 use crate::raw_stream;
 use crate::reachability::{AnnounceState, Effect, Reachability, ReachabilityState, IDENTIFY_GRACE};
 use crate::relay_manager::{RelayAction, RelayManager};
@@ -130,6 +131,11 @@ pub struct NetworkService {
     /// Live connections, per peer, keyed by connection so multiple connections
     /// to one peer are tracked independently.
     connections: HashMap<PeerId, HashMap<ConnectionId, Connection>>,
+    /// Addresses we were told about peers — the peerstore rust-libp2p does not
+    /// have. Consulted ahead of the routing table by
+    /// [`Self::candidate_addresses`]; see [`crate::learned_addrs`] for why a
+    /// k-bucket cannot do this job.
+    learned_addrs: LearnedAddrs,
     /// When each peer last *established* a connection to us, in either
     /// direction. Unlike `connections` this survives the close, which is what
     /// makes bootstrap health readable: kad seeds its routing table with the
@@ -429,6 +435,7 @@ impl NetworkService {
             pending_routed: HashMap::new(),
             routed_attempts: HashMap::new(),
             connections: HashMap::new(),
+            learned_addrs: LearnedAddrs::new(local_peer_id),
             last_connected: HashMap::new(),
             observed_addrs: HashMap::new(),
             require_global_ips: config.require_global_ips,
@@ -567,6 +574,17 @@ impl NetworkService {
                         }
                     },
                 }
+            }
+
+            // Seed, then dial exactly as a bare-PeerId connect does. The
+            // seeding is the point: `dispatch_routed` reads its candidates
+            // through `candidate_addresses`, which puts learned addresses
+            // first, so the supplied ones are tried before the routing table
+            // and the DHT walk stays available behind them.
+            Command::ConnectPeerWithAddrs { peer, addrs, reply } => {
+                let added = self.learned_addrs.insert(peer, addrs);
+                debug!(%peer, added, "connect with supplied addresses");
+                self.dispatch_routed(peer, RoutedRequest::Connect { reply });
             }
 
             Command::DisconnectPeer { peer, reply } => {
@@ -1097,12 +1115,25 @@ impl NetworkService {
 
     /// `table_filter` decides which routing-table entries qualify; a live
     /// connection's address always does, since we are on it.
+    ///
+    /// Learned addresses come **first**. They arrive from a record the peer
+    /// signed about itself, or from a caller that supplied them with a connect
+    /// request, so they are both fresher and more specific than a table entry
+    /// — which may be anything a remote reported during a walk, and for a
+    /// NATed peer is usually a LAN address or a stale NAT port. The filter
+    /// applies to them too: they are a remote claim like any other.
     fn candidate_addresses(
         &mut self,
         peer: &PeerId,
         table_filter: impl Fn(&Multiaddr) -> bool,
     ) -> Vec<Multiaddr> {
-        let mut addrs: Vec<Multiaddr> = Vec::new();
+        let mut addrs: Vec<Multiaddr> = self
+            .learned_addrs
+            .get(peer)
+            .iter()
+            .filter(|a| table_filter(a))
+            .cloned()
+            .collect();
 
         if let Some(bucket) = self.swarm.behaviour_mut().kad.kbucket(*peer) {
             for entry in bucket.iter() {
@@ -1150,7 +1181,11 @@ impl NetworkService {
         let own = self.own_addrs();
         addrs.retain(|a| !own.is_ours(a));
 
-        addrs.dedup();
+        // Order-preserving, not `dedup()`: with learned addresses ahead of the
+        // table the same address arriving from both sources is no longer
+        // adjacent, and `Vec::dedup` only collapses neighbours.
+        let mut seen: HashSet<Multiaddr> = HashSet::new();
+        addrs.retain(|a| seen.insert(a.clone()));
 
         addrs
     }
@@ -1244,11 +1279,10 @@ impl NetworkService {
     /// kad never re-dials a tabled peer, so a walk can only re-route one it treats
     /// as new. The entry is stashed in [`RoutedAttempt::evicted`] for `fail_routed`.
     fn forget_exhausted_entry(&mut self, peer: &PeerId, error: &DialError) {
-        let failed: Vec<Multiaddr> = match error {
-            DialError::Transport(attempts) => attempts.iter().map(|(a, _)| strip_p2p(a)).collect(),
-            DialError::WrongPeerId { address, .. } => vec![strip_p2p(address)],
-            _ => return,
-        };
+        let failed = failed_addresses(error);
+        if failed.is_empty() {
+            return;
+        }
         let remaining: Vec<Multiaddr> = self
             .swarm
             .behaviour_mut()
@@ -1782,6 +1816,21 @@ impl NetworkService {
                     self.swarm.behaviour_mut().kad.remove_address(&peer, &addr);
                 }
 
+                // Same evidence, applied to the learned map: an address that
+                // failed to connect is stale, and a peer whose reservation
+                // rotated would otherwise be dialed at the relay it left until
+                // it republishes. Unconditional rather than routed-only —
+                // every dial is evidence about the address it used.
+                if let Some(peer) = peer_id {
+                    let failed = failed_addresses(&error);
+                    if !failed.is_empty() {
+                        let dropped = self.learned_addrs.forget(&peer, &failed);
+                        if dropped > 0 {
+                            debug!(%peer, dropped, "dropping learned addresses that failed to dial");
+                        }
+                    }
+                }
+
                 // A routed dial's first failure buys one DHT walk. Must follow the
                 // WrongPeerId eviction above so that address is never stashed and restored.
                 if let Some(peer) = peer_id {
@@ -2290,6 +2339,21 @@ impl NetworkService {
 
             other => trace!(?other, "kad event"),
         }
+    }
+}
+
+/// The addresses a failed dial actually tried, bare, or nothing.
+///
+/// Only two `DialError` variants name addresses at all, and only those two are
+/// evidence *about an address*: `Transport` is "this address did not answer",
+/// `WrongPeerId` is "somebody else answered at it". Everything else — the dial
+/// conditions, a local error, no addresses at all — says nothing about the
+/// addresses we hold and must not evict any.
+fn failed_addresses(error: &DialError) -> Vec<Multiaddr> {
+    match error {
+        DialError::Transport(attempts) => attempts.iter().map(|(a, _)| strip_p2p(a)).collect(),
+        DialError::WrongPeerId { address, .. } => vec![strip_p2p(address)],
+        _ => Vec::new(),
     }
 }
 

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -643,6 +643,11 @@ impl NetworkService {
                 let _ = reply.send(addrs);
             }
 
+            Command::ExternalAddrs { reply } => {
+                let addrs = self.swarm.external_addresses().cloned().collect();
+                let _ = reply.send(addrs);
+            }
+
             Command::PeerProtocols { peer, reply } => {
                 let _ = reply.send(self.peer_protocols.get(&peer).cloned());
             }

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -259,6 +259,9 @@ struct RoutedAttempt {
     dial: Option<RoutedDial>,
     /// Whether the attempt's one lookup has been used.
     lookup_spent: bool,
+    /// Whether the attempt's one extra dial on addresses learned mid-burst
+    /// has been used.
+    learned_retry_spent: bool,
     /// Routing-table entries [`NetworkService::forget_exhausted_entry`] took
     /// out, put back if the lookup finds nothing better.
     evicted: Vec<Multiaddr>,
@@ -1264,6 +1267,30 @@ impl NetworkService {
         true
     }
 
+    /// Dial `peer` once more if addresses were learned since the dial that
+    /// just failed with `error`, and this burst has not already done so.
+    /// Bounded twice over: once per burst, and only on addresses the failed
+    /// dial did not try.
+    fn retry_on_learned(&mut self, peer: PeerId, error: &DialError) -> bool {
+        let failed = failed_addresses(error);
+        let attempt = self.routed_attempts.entry(peer).or_default();
+        if attempt.learned_retry_spent || failed.is_empty() {
+            return false;
+        }
+        // Same normalisation as `LearnedAddrs::forget`: a dial reports the
+        // fully-qualified address it tried.
+        let fresh = self
+            .learned_addrs
+            .get(&peer)
+            .iter()
+            .any(|a| !failed.contains(&strip_p2p(a)));
+        if !fresh {
+            return false;
+        }
+        attempt.learned_retry_spent = true;
+        self.dial_routed(peer)
+    }
+
     /// Whether `connection_id` is the dial `peer`'s parked requests were
     /// waiting on, clearing it when it is.
     fn routed_dial_ended(&mut self, peer: &PeerId, connection_id: ConnectionId) -> bool {
@@ -1847,7 +1874,14 @@ impl NetworkService {
                             .get(&peer)
                             .is_some_and(|attempt| attempt.lookup_spent);
                         if spent {
-                            self.fail_routed(peer, dial_error(&error, Some(peer)).to_string());
+                            // A request parked mid-dial may have brought addresses this
+                            // dial never tried; spend one more dial on those before
+                            // failing the burst with an error that predates them.
+                            if self.retry_on_learned(peer, &error) {
+                                debug!(%peer, "routed dial failed — retrying on addresses learned since");
+                            } else {
+                                self.fail_routed(peer, dial_error(&error, Some(peer)).to_string());
+                            }
                         } else {
                             debug!(%peer, error = %error, "routed dial failed — falling back to a DHT lookup");
                             self.forget_exhausted_entry(&peer, &error);

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -1956,16 +1956,17 @@ impl NetworkService {
     /// Recompute the announce state and publish it if anything a consumer acts
     /// on changed.
     ///
-    /// The equality gate is the whole point. A node's addresses churn
-    /// constantly — identify pushes, a reservation moving between relays, a
-    /// re-NAT — and none of that belongs in a DHT record that carries no
-    /// addresses (see [`AnnounceState`]). Only a change in *how reachable the
-    /// node is* wakes the announce loop.
+    /// The equality gate is the whole point. Direct addresses churn constantly
+    /// — identify pushes, a re-NAT — and none of that belongs in the DHT
+    /// record. What does is the *circuit* set (see [`AnnounceState`]): the
+    /// record publishes those addresses, so a reservation moving between
+    /// relays has to wake the announce loop or the record names a relay the
+    /// node has left.
     fn publish_announce_state(&mut self) {
         let current = self.reachability.current().clone();
-        let has_circuit = self.relays.has_circuit();
+        let circuits = self.relays.confirmed_addrs();
         self.announce_tx.send_if_modified(|state| {
-            let next = AnnounceState::derive(&current, has_circuit, state.epoch);
+            let next = AnnounceState::derive(&current, &circuits, state.epoch);
             if !next.differs(state) {
                 return false;
             }

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -34,7 +34,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::addresses::{
     dest_peer_id, is_announceable_with, is_circuit, peer_id_from_multiaddr, strip_dest_p2p,
-    strip_p2p, OwnAddresses,
+    strip_p2p, uses_dialable_transport, OwnAddresses,
 };
 use crate::behaviour::{KwaaiBehaviour, KwaaiBehaviourEvent};
 use crate::config::NetworkConfig;
@@ -153,6 +153,10 @@ pub struct NetworkService {
     /// because identify-learned addresses are filtered before they reach kad,
     /// and that decision has to match the one the reachability state makes.
     require_global_ips: bool,
+    /// Whether the swarm was built with a QUIC transport. Mirrors
+    /// `NetworkConfig::enable_quic`; a supplied `/quic` address is dropped
+    /// at ingestion when it was not, rather than failing every dial.
+    dials_quic: bool,
     /// The protocol list each connected peer advertised over identify. This is
     /// the capability feed: relay-hop support, AutoNAT and dcutr all show up
     /// here. Dropped when the last connection to a peer closes, so an entry
@@ -442,6 +446,7 @@ impl NetworkService {
             last_connected: HashMap::new(),
             observed_addrs: HashMap::new(),
             require_global_ips: config.require_global_ips,
+            dials_quic: config.enable_quic,
             peer_protocols: HashMap::new(),
             peer_rtt: HashMap::new(),
             peer_agent: HashMap::new(),
@@ -585,6 +590,10 @@ impl NetworkService {
             // first, so the supplied ones are tried before the routing table
             // and the DHT walk stays available behind them.
             Command::ConnectPeerWithAddrs { peer, addrs, reply } => {
+                let quic = self.dials_quic;
+                let addrs = addrs
+                    .into_iter()
+                    .filter(|a| uses_dialable_transport(a, quic));
                 let added = self.learned_addrs.insert(peer, addrs);
                 debug!(%peer, added, "connect with supplied addresses");
                 self.dispatch_routed(peer, RoutedRequest::Connect { reply });

--- a/core/crates/kwaai-p2p/tests/learned_addrs.rs
+++ b/core/crates/kwaai-p2p/tests/learned_addrs.rs
@@ -107,8 +107,8 @@ async fn connect_with_addresses_reaches_a_peer_the_dht_cannot() {
     assert_eq!(echoed, b"hello");
 }
 
-/// The property `connect_chain_entry`'s pre-connect could not give: the
-/// addresses outlive the connection.
+/// The property a caller-side pre-connect could not give: the addresses
+/// outlive the connection.
 ///
 /// A pre-connect only helps while its connection lasts. The hop RPCs go through
 /// `dispatch_routed`, which never saw the published addresses — so a dropped

--- a/core/crates/kwaai-p2p/tests/learned_addrs.rs
+++ b/core/crates/kwaai-p2p/tests/learned_addrs.rs
@@ -1,0 +1,200 @@
+//! The learned-address map, through the full service.
+//!
+//! `src/learned_addrs.rs` unit-tests the container's bounds. What only a real
+//! swarm can show is the property the map exists for: that an address supplied
+//! with a connect request is **kept**, so a later dial to the same peer uses it
+//! instead of asking a routing table that never held the peer.
+//!
+//! The two nodes here share no bootstrap and never meet through the DHT, so A's
+//! only way to reach B is what the test hands it. That is deliberate: it is the
+//! shape of the real failure — a NATed peer discovered as a bare PeerId, which
+//! kad cannot resolve because it answers `FIND_NODE` from its k-buckets alone.
+//!
+//! Negative control, run: with the learned-address consult removed from
+//! `candidate_addresses`, both `connect_with_addresses_reaches_a_peer_the_dht_cannot`
+//! and `a_routed_request_redials_from_the_learned_map_after_a_disconnect` fail
+//! with `peer not found in DHT (no addresses)`.
+
+use std::time::Duration;
+
+use kwaai_p2p::{Multiaddr, NetworkConfig, NetworkHandle, NetworkService, PeerId};
+use libp2p::identity::Keypair;
+
+const PROTO: &str = "DHTProtocol.rpc_ping";
+const TEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// A loopback service with no bootstraps at all — nothing it can discover.
+fn spawn_isolated() -> (NetworkHandle, tokio::task::JoinHandle<()>, PeerId) {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "off".into()),
+        )
+        .with_test_writer()
+        .try_init();
+
+    let keypair = Keypair::generate_ed25519();
+    let peer_id = keypair.public().to_peer_id();
+    let mut config = NetworkConfig::for_tests();
+    // Both lists empty would fall through to the compiled-in bootstraps; a
+    // syntactically valid address on a port nothing listens on keeps this test
+    // from dialing anything real.
+    config.initial_peers = vec![
+        "/ip4/127.0.0.1/tcp/1/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN".to_string(),
+    ];
+    let (handle, task) = NetworkService::spawn(config, keypair).expect("service should start");
+    (handle, task, peer_id)
+}
+
+async fn first_listen_addr(handle: &NetworkHandle) -> Multiaddr {
+    let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
+    loop {
+        if let Some(addr) = handle
+            .listen_addrs()
+            .await
+            .ok()
+            .and_then(|a| a.into_iter().next())
+        {
+            return addr;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for a listen address"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn within<T>(what: &str, f: impl std::future::Future<Output = T>) -> T {
+    tokio::time::timeout(TEST_TIMEOUT, f)
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for: {what}"))
+}
+
+/// The base case. B is in no routing table of A's, so a bare-PeerId connect
+/// could only fail; supplying the address makes it work, and the routed unary
+/// that follows proves the connection is a real one the behaviours can use.
+#[tokio::test]
+async fn connect_with_addresses_reaches_a_peer_the_dht_cannot() {
+    let (a, _a_task, _a_id) = spawn_isolated();
+    let (b, _b_task, b_id) = spawn_isolated();
+
+    b.add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("registering a handler should succeed");
+
+    let b_addr = first_listen_addr(&b).await;
+    assert!(
+        !a.routing_peers()
+            .await
+            .expect("routing table reads")
+            .contains(&b_id),
+        "the test is meaningless if B is already reachable through kad"
+    );
+
+    let connected = within(
+        "the seeded connect",
+        a.connect_peer_with_addrs(b_id, vec![b_addr]),
+    )
+    .await
+    .expect("a supplied address must be enough to reach a peer kad cannot resolve");
+    assert_eq!(connected, b_id);
+
+    let echoed = within("a routed unary over the seeded connection", async {
+        a.call_unary_handler(b_id, PROTO, b"hello").await
+    })
+    .await
+    .expect("the connection must be usable by the behaviours");
+    assert_eq!(echoed, b"hello");
+}
+
+/// The property `connect_chain_entry`'s pre-connect could not give: the
+/// addresses outlive the connection.
+///
+/// A pre-connect only helps while its connection lasts. The hop RPCs go through
+/// `dispatch_routed`, which never saw the published addresses — so a dropped
+/// connection put the next dial back at "no addresses". Here the connection is
+/// dropped deliberately and the *routed request itself* re-dials from the map.
+///
+/// The re-dial must also be quick: a DHT walk would take the query timeout to
+/// come back empty, so completing in a fraction of that is the evidence that no
+/// walk was needed.
+#[tokio::test]
+async fn a_routed_request_redials_from_the_learned_map_after_a_disconnect() {
+    let (a, _a_task, _a_id) = spawn_isolated();
+    let (b, _b_task, b_id) = spawn_isolated();
+
+    b.add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("registering a handler should succeed");
+
+    let b_addr = first_listen_addr(&b).await;
+    within(
+        "the seeded connect",
+        a.connect_peer_with_addrs(b_id, vec![b_addr]),
+    )
+    .await
+    .expect("the seeded connect must succeed");
+
+    a.disconnect_peer(b_id).await.expect("disconnect");
+    // The close is asynchronous; wait for the swarm to agree it is gone, or
+    // the request below would simply ride the old connection and prove nothing.
+    let deadline = tokio::time::Instant::now() + TEST_TIMEOUT;
+    while a
+        .list_peers()
+        .await
+        .expect("list_peers")
+        .iter()
+        .any(|p| p.peer_id == b_id)
+    {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for the connection to close"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // The map really is the only source: kad never took B in, so nothing else
+    // in the node knows an address for it.
+    assert!(
+        !a.routing_peers()
+            .await
+            .expect("routing table reads")
+            .contains(&b_id),
+        "the re-dial must come from the learned map, not from a routing-table entry"
+    );
+
+    let started = std::time::Instant::now();
+    let echoed = within("the re-dialed unary", async {
+        a.call_unary_handler(b_id, PROTO, b"again").await
+    })
+    .await
+    .expect("a routed request must re-dial from the learned addresses");
+    assert_eq!(echoed, b"again");
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "a re-dial from the learned map must not wait out a DHT walk (took {:?})",
+        started.elapsed()
+    );
+}
+
+/// Addresses supplied for a peer that cannot be reached at them must not
+/// silently succeed, and must not wedge: the connect fails with the DHT
+/// fallback's error, exactly as a bare-PeerId connect to an unknown peer does.
+#[tokio::test]
+async fn unreachable_supplied_addresses_still_fail() {
+    let (a, _a_task, _a_id) = spawn_isolated();
+    let unknown = PeerId::random();
+
+    let result = within(
+        "the doomed connect",
+        a.connect_peer_with_addrs(
+            unknown,
+            vec!["/ip4/127.0.0.1/tcp/1".parse().expect("a valid addr")],
+        ),
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "a connect to a peer nothing can reach must report failure"
+    );
+}


### PR DESCRIPTION
## Problem

Distributed-inference dispatch discovers a peer from its DHT record and dials it by bare PeerId. On the native stack that resolves through kad, and kad cannot answer: rust-libp2p serves `FIND_NODE` from its k-buckets alone (`find_closest_local_peers`), where the kad-DHT spec §6.1.1 says a server MUST answer for a requested peer held in its *peerstore* — which is what go-libp2p's `handleFindPeer` did for the old p2pd bootstraps. So a peer is findable only while it holds one of twenty slots in the right bucket on a peer the walk reaches, and a disconnected entry is the first one replaced.

Measured on a live node: **~2000** `Dial failed: <peer>: peer not found in DHT (no addresses)` in one day's log, against a handful of real transport errors. Every peer in a chain build showed as unreachable; the one that connected was one we had spoken to before.

Relaying itself works. Dialing a target through a bootstrap it has *not* reserved on returns `Relay has no reservation for destination` — so the hop is live and the only thing missing is the address, which nothing carried: reservations rotate, and a dialer cannot guess which relay a peer holds one on.

This is **not** about kad's mode. `dht_server` is true on every native node, so kad is pinned to `Mode::Server` whether the node is reachable or not.

## Fix — two layers, the way p2pd had them

**The record carries the address (announce layer).** `DHTServerInfo` gains `signed_addrs`: an RFC 0003 `PeerRecord` in a protobuf `SignedEnvelope`, published under the msgpack key `addrs_signed` as binary. Interop format (`libp2p-peer-record`) rather than rust-libp2p's legacy domain, since this is a published wire format a Go/JS reader may one day verify. Legacy readers ignore the unknown key exactly as they ignore `vpk` and `lease_v1`. Addresses come from the swarm's live listeners — where an accepted reservation appears, already carrying both hops — filtered by `is_announceable` and a new `uses_dialable_transport` (this build is TCP+QUIC only), deduped one per relay, direct before circuit, capped at four because the value is stored under every block key. Published bare; the peer id is in the record once, under the signature. A reservation moving between relays now re-announces (`AnnounceState` fingerprints the confirmed circuit set), so a rotated circuit does not stay published for a full TTL. Encode and wire-decode (`decode_server_info_ext` → `ServerInfoFields`) sit side by side in `announce.rs`; the ONLINE/min-version policy and the mapping to `BlockServerEntry` stay with the consumer in `shard_cmd.rs`.

**The daemon keeps what it learns (network layer).** `kwaai_p2p::peer_record::verified_addrs` verifies the envelope and binds it to the claimed peer. The daemon holds a bounded **learned-addresses map** — the peerstore rust-libp2p does not have — that `dial_routed` consults *before* the k-bucket and the DHT walk, and forgets an address on the dial failure that proves it stale. It is seeded through the control-socket `Connect` request, which now carries addresses the way Go's `AddrInfo{ID, Addrs}` did: no addresses → routed dial by id; one destination-qualified address → the classic dial; anything else → seed and route. So the published addresses help **every** dial to that peer — the hop RPCs through `dispatch_routed` included — not only a pre-connect, and if a connection drops mid-session the re-dial comes from the map without a walk. The CLI's part is one line per pre-connect site: `client.connect_peer_with_addrs(&entry.peer_id, &entry.dial_addrs)`.

### Why signed, and what the signature does and does not close

`kwaai-hivemind-dht` has no record validators: anyone can `STORE` under another node's subkey. A plaintext address list would be an instruction, from anyone, about where to send a victim's traffic. Verification (`from_signed_envelope_interop` + an equality check against the peer being dialed) closes **steering to addresses the peer never signed** — including the dictionary path, where the entry is keyed by subkey and a value naming a different peer is dropped.

It does not close overwriting an announcement to *omit* the field, tombstoning it, or replaying an older genuine list. All three are plain overwrites needing no forged signature, and all three are what a record validator in the DHT store would answer — the next piece of work, not this one.

## Verification

- `cargo test` on `kwaainet`, `kwaai-p2p`, `kwaai-p2p-daemon`: all suites green; `fmt --check` and `clippy --all-targets -D warnings` clean.
- New tests include: forged-signer rejection; subkey/value mismatch (confirmed to fail with the guard removed); circuit-address round trip; legacy-signing-domain rejection; the rotation fingerprint; the learned map's caps, dedupe and forget-on-failure; and two integration tests — a seeded connect reaches a peer the DHT cannot, and **a routed request re-dials from the learned map after a disconnect** with the peer asserted absent from the routing table (confirmed to fail with the map consult removed).
- **End to end on the sealed nat-test bed:** node-f (cone NAT) discovered all 8 nodes and handed each one's published addresses to its daemon — the daemon log shows `connect with supplied addresses … added=2` for node-g (its two bootstrap circuits), zero DHT walks and zero `no addresses` failures for the run. An earlier build of this branch, before the daemon-side move, dialed the same peers from those addresses directly, node-g and node-h **NAT→NAT through a bootstrap circuit**. The bed cannot show the re-dial-from-map property live — eight nodes are all already connected to each other within seconds — so that rests on the integration test above, which asserts the peer is absent from the routing table when the re-dial succeeds.
- Reviewed by independent agents at each step; findings folded in.

## Follow-ups (not in this PR)

1. Consume `PeerInfo.addrs` from kad walk results in `dial_routed` instead of re-reading the k-bucket.
2. Spec §6.1.1: answer `FIND_NODE` from the learned map in the vendored `libp2p-kad` — restores what the Go bootstrap did; needs the bootstraps redeployed.
3. A record validator in the DHT store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
