### PR TITLE
fix(kad): evict peers that turn out not to speak our kad name

### DIFF
--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -68,6 +68,10 @@ const LAST_CONNECTED_CAP: usize = 1024;
 /// How often the relay manager retries candidates whose backoff has expired.
 const RELAY_TICK_INTERVAL: Duration = Duration::from_secs(15);
 
+/// Upper bound on `pinned_addrs` peers. Explicit dials only, so a memory
+/// bound rather than a policy; oldest pin evicted, same shape as `last_connected`.
+const PINNED_PEERS_CAP: usize = 1024;
+
 /// Cap on routing-table addresses per peer.
 ///
 /// kad's own `Addresses` is an unbounded `SmallVec`: `insert` appends whatever
@@ -145,6 +149,13 @@ pub struct NetworkService {
     /// recently" is the signal that distinguishes the two. Recency cache, not
     /// a ledger — capped at [`LAST_CONNECTED_CAP`], oldest evicted.
     last_connected: HashMap<PeerId, Instant>,
+    /// Addresses we were *told* to dial — `dial()` and `AddKadAddress`, the
+    /// two uncapped seeds — stored bare, with when the peer was first pinned.
+    /// The routing table is the only other address book for dial-by-PeerId,
+    /// and the non-kad purge in `handle_identify_event` empties it for a
+    /// peer that speaks a foreign kad name. Consulted by
+    /// [`Self::candidate_addresses`] so such a peer stays reachable by id.
+    pinned_addrs: HashMap<PeerId, (Instant, Vec<Multiaddr>)>,
     /// Addresses peers reported observing us at → the set of peers that said so.
     /// A set (not a counter) so repeated identifies from one peer count once.
     observed_addrs: HashMap<Multiaddr, HashSet<PeerId>>,
@@ -443,6 +454,7 @@ impl NetworkService {
             routed_attempts: HashMap::new(),
             connections: HashMap::new(),
             learned_addrs: LearnedAddrs::new(local_peer_id),
+            pinned_addrs: HashMap::new(),
             last_connected: HashMap::new(),
             observed_addrs: HashMap::new(),
             require_global_ips: config.require_global_ips,
@@ -750,11 +762,13 @@ impl NetworkService {
                 // the operator naming an address, not a peer claiming one. A
                 // symmetric-NAT peer flooding identify must never be able to
                 // evict a bootstrap address someone configured by hand.
+                self.pin_address(peer, strip_dest_p2p(&addr));
                 self.swarm.behaviour_mut().kad.add_address(&peer, addr);
                 let _ = reply.send(());
             }
 
             Command::RemoveKadPeer { peer, reply } => {
+                self.pinned_addrs.remove(&peer);
                 let existed = self.swarm.behaviour_mut().kad.remove_peer(&peer).is_some();
                 let _ = reply.send(existed);
             }
@@ -978,6 +992,7 @@ impl NetworkService {
                 // Uncapped for the same reason as `AddKadAddress`: an address
                 // we are actively dialing is our own intent, not a remote
                 // claim, and is the one entry least worth evicting.
+                self.pin_address(peer, stripped.clone());
                 self.swarm.behaviour_mut().kad.add_address(&peer, stripped);
             }
         }
@@ -1170,6 +1185,15 @@ impl NetworkService {
             }
         }
 
+        if let Some((_, pinned)) = self.pinned_addrs.get(peer) {
+            let fresh: Vec<Multiaddr> = pinned
+                .iter()
+                .filter(|a| !addrs.contains(a) && table_filter(a))
+                .cloned()
+                .collect();
+            addrs.extend(fresh);
+        }
+
         if let Some(conns) = self.connections.get(peer) {
             for conn in conns.values() {
                 if !addrs.contains(&conn.addr) {
@@ -1206,6 +1230,35 @@ impl NetworkService {
         addrs.retain(|a| seen.insert(a.clone()));
 
         addrs
+    }
+
+    /// Remember an address the operator supplied for `peer`; see `pinned_addrs`.
+    /// Bounded like the routing table: six per peer, oldest out.
+    fn pin_address(&mut self, peer: PeerId, addr: Multiaddr) {
+        if addr.is_empty() {
+            return;
+        }
+        if self.pinned_addrs.len() >= PINNED_PEERS_CAP && !self.pinned_addrs.contains_key(&peer) {
+            if let Some(oldest) = self
+                .pinned_addrs
+                .iter()
+                .min_by_key(|(_, (at, _))| *at)
+                .map(|(p, _)| *p)
+            {
+                self.pinned_addrs.remove(&oldest);
+            }
+        }
+        let (_, addrs) = self
+            .pinned_addrs
+            .entry(peer)
+            .or_insert_with(|| (Instant::now(), Vec::new()));
+        if addrs.contains(&addr) {
+            return;
+        }
+        if addrs.len() >= MAX_ADDRESSES_PER_PEER {
+            addrs.remove(0);
+        }
+        addrs.push(addr);
     }
 
     /// Our own listen and confirmed-external addresses, snapshotted from the
@@ -2336,7 +2389,8 @@ impl NetworkService {
                 {
                     // Tabled by the V1Lazy false confirm (or `dial()`) before
                     // identify could say no; left in place it is served to every
-                    // FIND_NODE caller.
+                    // FIND_NODE caller. Table membership only: an address the
+                    // operator supplied survives in `pinned_addrs`.
                     debug!(peer = %peer_id, agent = %info.agent_version, "dropped non-kad peer from the routing table");
                 }
 

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -151,10 +151,11 @@ pub struct NetworkService {
     last_connected: HashMap<PeerId, Instant>,
     /// Addresses we were *told* to dial — `dial()` and `AddKadAddress`, the
     /// two uncapped seeds — stored bare, with when the peer was first pinned.
-    /// The routing table is the only other address book for dial-by-PeerId,
-    /// and the non-kad purge in `handle_identify_event` empties it for a
-    /// peer that speaks a foreign kad name. Consulted by
-    /// [`Self::candidate_addresses`] so such a peer stays reachable by id.
+    /// Neither seed reaches `learned_addrs` (only `ConnectPeerWithAddrs`
+    /// does), and a learned address is forgotten on a failed dial while an
+    /// operator's must not be; the routing table is the seeds' only other
+    /// home, and the non-kad purge in `handle_identify_event` empties it.
+    /// Consulted by [`Self::candidate_addresses`], which dedupes both stores.
     pinned_addrs: HashMap<PeerId, (Instant, Vec<Multiaddr>)>,
     /// Addresses peers reported observing us at → the set of peers that said so.
     /// A set (not a counter) so repeated identifies from one peer count once.

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -343,22 +343,22 @@ impl NetworkService {
                             // - `kad`: `on_fully_negotiated_outbound` marks the
                             //   protocol supported on the first negotiated
                             //   substream, which now fires before the remote
-                            //   confirms anything. A query to a connected
-                            //   non-kad peer can insert it into the routing
-                            //   table until identify corrects it. This is net
-                            //   new versus p2pd, where go-libp2p-kad-dht admits
-                            //   peers only from identify plus a live FIND_NODE
-                            //   probe.
+                            //   confirms anything, so a query to a non-kad
+                            //   peer inserts it. Identify does NOT correct
+                            //   that on its own — the later
+                            //   ProtocolNotSupported only marks the entry
+                            //   Disconnected, never removes it — so
+                            //   `handle_identify_event` evicts any tabled peer
+                            //   whose protocols lack our kad name. Measured on
+                            //   the 2026-09-06 probe: 160 kubo peers tabled
+                            //   and served to the fleet, from one query.
+                            //   Not `BucketInserts::Manual`: routed dials rely
+                            //   on the walk depositing its target in the table.
                             //
-                            //   Which build you are in decides how much of
-                            //   that caveat applies. A stock (single-name)
-                            //   build takes the 0-RTT shortcut on every kad
-                            //   substream, so the paragraph above is fully in
-                            //   force: during the migration window a routing
-                            //   table can fill with peers that never confirmed
-                            //   kad, and the connection-manager work (#174)
-                            //   plus gating laziness on identify's protocol
-                            //   set are the follow-ups that close it. The
+                            //   Which build you are in decides how far the
+                            //   shortcut reaches. A stock (single-name) build
+                            //   takes it on every kad substream — the false
+                            //   confirm above fires for every foreign peer. The
                             //   `kad-multi-protocol` (bootstrap) build offers
                             //   two names, V1Lazy only shortcuts the *last*
                             //   offer (see `dialer_select.rs`), so its
@@ -367,9 +367,9 @@ impl NetworkService {
                             //   legacy-only peer). Accepted for the migration
                             //   window on the handful of hosts that run it.
                             //
-                            // Closing both at the source means gating laziness
-                            // on identify's known-protocol set, as go does.
-                            // Tracked as a follow-up, not done here.
+                            // Gating laziness itself on identify's known-protocol
+                            // set, as go does, would also fix `ping`; swarm 0.47
+                            // has no per-behaviour override, so that remains open.
                             //
                             // Raw streams opt out via a trailing sentinel
                             // protocol, so their refusals stay eager — see
@@ -2327,6 +2327,17 @@ impl NetworkService {
                         }
                         self.add_routing_address(&peer_id, addr.clone());
                     }
+                } else if self
+                    .swarm
+                    .behaviour_mut()
+                    .kad
+                    .remove_peer(&peer_id)
+                    .is_some()
+                {
+                    // Tabled by the V1Lazy false confirm (or `dial()`) before
+                    // identify could say no; left in place it is served to every
+                    // FIND_NODE caller.
+                    debug!(peer = %peer_id, agent = %info.agent_version, "dropped non-kad peer from the routing table");
                 }
 
                 // (b) Record what this peer observed our address to be. Counting

--- a/core/crates/kwaai-p2p/tests/swarm.rs
+++ b/core/crates/kwaai-p2p/tests/swarm.rs
@@ -384,6 +384,52 @@ async fn a_foreign_kad_peer_served_by_a_neighbour_is_never_tabled() {
     );
 }
 
+/// The purge drops table membership, not the operator's address. `connect
+/// --addr` is the documented way to reach a legacy-only peer; if the purge
+/// discarded that address it would survive only as long as the live
+/// connection, and every later call by PeerId would fall to a DHT lookup
+/// that cannot find a peer nobody tables. Fails without `pinned_addrs`.
+#[tokio::test]
+async fn an_operator_supplied_address_outlives_the_purge() {
+    const PROTO: &str = "/kwaai/test/echo/1.0.0";
+    let (a, _a_task, a_id) = spawn_swarm_with_kad_protocols(&[kwaai_p2p::KWAAI_KAD_PROTOCOL]);
+    let (b, _b_task, b_id) = spawn_swarm_with_kad_protocols(&[kwaai_p2p::LEGACY_KAD_PROTOCOL]);
+    b.add_unary_handler(PROTO, |data: Vec<u8>| async move { Ok(data) })
+        .await
+        .expect("B serves echo");
+
+    let b_addr = dialable_addr(&b, b_id).await;
+    a.connect_peer(&b_addr.to_string()).await.expect("A → B");
+    identified(&a, b_id).await;
+    assert!(
+        !a.routing_peers()
+            .await
+            .expect("routing peers")
+            .contains(&b_id),
+        "B must have been purged"
+    );
+
+    // Drop the connection so the only way back to B is an address book. B
+    // hangs up, not A: the re-dial reuses A's listen port as its source, and
+    // the closer's TIME_WAIT on that 4-tuple would refuse it (EADDRINUSE).
+    b.disconnect_peer(a_id).await.expect("disconnect");
+    eventually("B to leave A's peer list", || async {
+        a.list_peers()
+            .await
+            .ok()?
+            .iter()
+            .all(|p| p.peer_id != b_id)
+            .then_some(())
+    })
+    .await;
+
+    let reply = tokio::time::timeout(SETTLE_TIMEOUT, a.call_unary_handler(b_id, PROTO, b"ping"))
+        .await
+        .expect("routed call to settle")
+        .expect("B reachable by PeerId from the address the operator gave");
+    assert_eq!(reply, b"ping");
+}
+
 // ---------------------------------------------------------------------------
 // Handle semantics
 // ---------------------------------------------------------------------------

--- a/core/crates/kwaai-p2p/tests/swarm.rs
+++ b/core/crates/kwaai-p2p/tests/swarm.rs
@@ -194,10 +194,9 @@ async fn kad_resolves_a_peer_two_hops_away() {
 // Kad protocol migration: legacy-only ↔ dual-default ↔ kwaai-only
 // ---------------------------------------------------------------------------
 
-/// Like [`spawn_test_swarm`] but with an explicit kad protocol list.
-/// Needs the patched setter: a single-name build cannot construct the
-/// bridging node this topology tests.
-#[cfg(feature = "kad-multi-protocol")]
+/// Like [`spawn_test_swarm`] but with an explicit kad protocol list. A
+/// single foreign name works on every build; the multi-name bridging node
+/// needs the patched setter and the `kad-multi-protocol` feature.
 fn spawn_swarm_with_kad_protocols(
     protocols: &[&str],
 ) -> (NetworkHandle, tokio::task::JoinHandle<()>, PeerId) {
@@ -300,6 +299,89 @@ async fn a_legacy_only_bridge_cannot_resolve_across_the_protocol_boundary() {
              short-circuited: {addrs:?}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Foreign kad names must never enter the routing table
+// ---------------------------------------------------------------------------
+
+/// Wait until A has completed identify with `peer`, so the protocol set is
+/// known and any purge it triggers has run in the same handler.
+async fn identified(a: &NetworkHandle, peer: PeerId) {
+    eventually("identify to land", || async {
+        a.list_peers()
+            .await
+            .ok()?
+            .into_iter()
+            .find(|p| p.peer_id == peer && p.agent_version.is_some())
+            .map(|_| ())
+    })
+    .await;
+}
+
+/// `dial()` seeds the routing table for every dialled peer, before anything
+/// is known about it. A peer that then turns out to speak only a foreign kad
+/// name (`/ipfs/kad/1.0.0` here — kubo's) must be removed once identify says
+/// so, or it sits there Disconnected forever and is served to every
+/// FIND_NODE caller. Fails without the purge in `handle_identify_event`.
+#[tokio::test]
+async fn a_dialled_peer_with_a_foreign_kad_name_is_purged_on_identify() {
+    // A is pinned to the kwaai name: the dual-default build would otherwise
+    // share the legacy name with B, and B would be a legitimate kad peer.
+    let (a, _a_task, _a_id) = spawn_swarm_with_kad_protocols(&[kwaai_p2p::KWAAI_KAD_PROTOCOL]);
+    let (b, _b_task, b_id) = spawn_swarm_with_kad_protocols(&[kwaai_p2p::LEGACY_KAD_PROTOCOL]);
+
+    let b_addr = dialable_addr(&b, b_id).await;
+    a.connect_peer(&b_addr.to_string()).await.expect("A → B");
+    identified(&a, b_id).await;
+
+    let table = a.routing_peers().await.expect("routing peers");
+    assert!(
+        !table.contains(&b_id),
+        "B speaks only {} and must not be in A's routing table: {table:?}",
+        kwaai_p2p::LEGACY_KAD_PROTOCOL
+    );
+}
+
+/// The production shape (2026-09-06 probe): a neighbour serves an address for
+/// a peer it never identified, the walk dials it, and V1Lazy reports the kad
+/// substream negotiated before the remote has said anything — so kad tables
+/// it. That false confirm tabled every kubo peer a bootstrap handed out, and
+/// nothing removed them. Here C holds B by operator fiat and never connects
+/// to it, so C cannot purge it; once A has identified B, B must be gone.
+#[tokio::test]
+async fn a_foreign_kad_peer_served_by_a_neighbour_is_never_tabled() {
+    // Pinned to the kwaai name for the same reason as the test above.
+    let (a, _a_task, _a_id) = spawn_swarm_with_kad_protocols(&[kwaai_p2p::KWAAI_KAD_PROTOCOL]);
+    let (c, _c_task, c_id) = spawn_swarm_with_kad_protocols(&[kwaai_p2p::KWAAI_KAD_PROTOCOL]);
+    let (b, _b_task, b_id) = spawn_swarm_with_kad_protocols(&[kwaai_p2p::LEGACY_KAD_PROTOCOL]);
+
+    let c_addr = dialable_addr(&c, c_id).await;
+    let b_listen = eventually("B to report a listen address", || async {
+        b.listen_addrs().await.ok()?.into_iter().next()
+    })
+    .await;
+
+    a.connect_peer(&c_addr.to_string()).await.expect("A → C");
+    identified(&a, c_id).await;
+    c.add_kad_address(b_id, b_listen)
+        .await
+        .expect("C learns B by fiat");
+
+    // The walk reaches C, is handed B, and dials B to continue.
+    let _ = tokio::time::timeout(SETTLE_TIMEOUT, a.dht_find_peer(b_id)).await;
+    identified(&a, b_id).await;
+
+    let table = a.routing_peers().await.expect("routing peers");
+    assert!(
+        table.contains(&c_id),
+        "the kwaai neighbour C must still be tabled: {table:?}"
+    );
+    assert!(
+        !table.contains(&b_id),
+        "B was handed to A by C and dialled, but speaks only {} — it must not be tabled: {table:?}",
+        kwaai_p2p::LEGACY_KAD_PROTOCOL
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Every kwaainet node on 0.6.8 dials **~150 kubo/IPFS peers every 5 minutes**, and the bootstraps hand those peers to every joiner. This is why the Amino connections never drained after the `/kwaai/kad` cutover — it isn't kubo finding us, it's **our routing tables being poisoned with kubo entries that nothing ever removes**.

One change in `kwaai-p2p`, a single `else if` in `handle_identify_event`: when a peer's advertised protocols do **not** include our kad name, `kad.remove_peer(&peer_id)`.

Plus two regression tests and a correction to the V1Lazy comment, which claimed identify "corrects" a false insert. It doesn't — this makes it true.

## How it was found

A stock v0.6.8 probe (fresh identity, `RUST_LOG=libp2p_kad=debug,libp2p_swarm=debug`) joining production for 516 s:

| | |
|---|---|
| connections established | 366 — **328 to `:4001`**, all `Dialer`, zero inbound |
| distinct kubo peers dialled | **160** |
| identify agents | 303 `kubo/*` + 16 `go-ipfs/*` vs 12 `kwaainet/*` |
| first kubo dial | **330 ms** after connecting, with *only* the two bootstraps connected — so the addresses came from the bootstraps' own FIND_NODE replies |
| kubo-side lifetime | mean 31 s (kubo's connmgr trims us after its 20 s grace) |
| cadence | bursts of 60–90 dials every ~5 min — kad's `periodic_bootstrap_interval` |
| `Bucket full. Peer not added` | 114×, **all kubo**, the first firing **0.2 ms after connect** — before any round-trip |

That last line is the tell: a peer was being inserted before the remote had answered anything.

## Root cause (libp2p-kad 0.48.0 / libp2p-swarm 0.47.1 / multistream-select 0.13.0)

- `service.rs` sets `with_substream_upgrade_protocol_override(V1Lazy)` swarm-wide for 0-RTT unary requests.
- multistream-select's V1Lazy returns `Negotiated::expecting(...)` **immediately** when exactly one protocol is offered (`dialer_select.rs:145`) — no round trip.
- kad's handler takes that as proof: *"Upon the first successfully negotiated substream, we know that the remote is configured with the same protocol name"* → `ProtocolConfirmed` → `connection_updated(Connected)` → **inserted**. That is the only insert path under `BucketInserts::OnConnected` (`behaviour.rs:2297`).
- Identify then reports the real protocol set → `ProtocolNotSupported` → `connection_updated(Disconnected)`. The `Entry::Present` branch **only flips status; it never removes**. `address_failed` explicitly keeps the last address. `find_closest_local_peers` filters only `!= source`, so Disconnected kubo entries are served in every FIND_NODE reply. With ~18 fleet peers there is no bucket pressure to ever evict them.

**The dual-protocol build was immune**: with two names V1Lazy only shortcuts the *last* offer, so the preferred name negotiated eagerly and kubo's `na` was visible. Cutting over to the single-name stock build is what switched this on. The comment block in `service.rs` predicted exactly this and deferred it — *"gating laziness on identify's protocol set … Tracked as a follow-up, not done here."*

## Why evict-on-identify, and not `BucketInserts::Manual`

libp2p-swarm 0.47 has no per-behaviour upgrade-version override, so V1Lazy can't be turned off for kad alone without losing the 0-RTT win on unary.

I tried `Manual` first (identify as the only door). It is the go-libp2p shape, but it broke three DHT-resolution tests deterministically, and the reason is structural: the routed-dial path says *"the walk has populated the routing table with everything it found — flush decides from there"*. That population **is** the OnConnected insert on the walk's dial. Under `Manual` a walk-discovered target only enters the table when identify lands — a race against `flush_routed` in production, and never at all in loopback tests (identify refuses `127.0.0.1`). The AutoNAT dial-back tables NATed peers the same way. So the insert stays; what changes is that a peer which turns out not to speak our kad name is evicted the moment identify says so.

The cost is a poison window of one round trip per foreign peer, during which a FIND_NODE from a third party could pick it up. Against the current state — entries that live for the process lifetime and are served on every reply — that is the difference between a leak and a puddle.

## Tests

- `a_dialled_peer_with_a_foreign_kad_name_is_purged_on_identify` — `dial()` seeds B; identify says B speaks only `/ipfs/kad/1.0.0`; B must be gone. Exercises the purge.
- `a_foreign_kad_peer_served_by_a_neighbour_is_never_tabled` — the production shape: C holds B by fiat (never connects, so never purges), A walks to C, is handed B, dials it, gets the V1Lazy false confirm — and once identify lands, B must be gone.

Falsification — both tests run with `src/` stashed (the fix removed) **fail**, and pass with it:

```
test a_dialled_peer_with_a_foreign_kad_name_is_purged_on_identify ... FAILED
  B speaks only /ipfs/kad/1.0.0 and must not be in A's routing table: [PeerId("12D3KooWANdw…")]
test a_foreign_kad_peer_served_by_a_neighbour_is_never_tabled ... FAILED
  B was handed to A by C and dialled, but speaks only /ipfs/kad/1.0.0 — it must not be tabled: [PeerId("12D3KooWExWj…"), PeerId("12D3KooWMRTp…")]
```


`spawn_swarm_with_kad_protocols` is no longer feature-gated: a single foreign name works on every build (`kad::Config::new` takes the first name unconditionally); only the multi-name bridge needs `kad-multi-protocol`.

## What this does and doesn't do

- **Fixed stock nodes self-clean; the bootstraps do not.** A stock (single-name) node evicts every foreign peer the moment identify answers, and re-dials its stale entries into the purge on each 5-minute bootstrap walk. The `kad-multi-protocol` bootstrap build cannot tell kubo from a legacy-only 0.6.7 peer by protocol name (`/ipfs/kad/1.0.0` is what both speak), so the purge is a no-op there and the bootstraps keep serving their poisoned set on every walk. A fixed node's *table* is clean at every instant, but its kubo dial volume does **not** decay until the bootstraps either drop the legacy name or gain a kubo-specific eviction; the 2026-09-06 live run (1002 kubo dials in 480 s on the fixed build) is that ceiling measured.
- **Bootstraps-only is not enough.** Long-running fleet nodes keep their poisoned tables (no eviction path on the old binary) and re-infect each other and every joiner at hop two. This needs the release rollout; mixed fleets are safe (routing-table policy is purely local, no wire change).
- **Does not explain the ~230 kubo connections the bootstraps hold for 7+ hours** while a fleet node's die in 30 s. Separate hypothesis (kubo autorelay reserving on public peers advertising hop); separate test.
- `ping` under V1Lazy (re-pinging a non-ping peer forever) remains as documented — same root, no fix here.

## CI-equivalent run

Run in an **isolated `CARGO_TARGET_DIR`**, and that matters: another Claude session has a worktree of this repo (`feat/kad-client-mode`) with no `core/target` of its own, so both were compiling into `core/target/debug` and the test-binary hashes collide (`swarm-4a8cf5fccb77d338` in both). For an hour my test results depended on whose `libkwaai_p2p` was linked last. Everything below is from a clean, private target dir.

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p kwaai-p2p` — all green; `swarm`: 17 passed (incl. both new tests)
- `cargo test -p kwaai-p2p --features kad-multi-protocol` — all green; `swarm`: 19 passed (incl. both new tests)
- `cargo test -p kwaainet` — 252 passed, 1 ignored

Falsification (same isolated dir, `src/` stashed → `main`): both new tests **FAIL**; with the fix: pass.

## Overlap

`feat/kad-client-mode` (in flight, another session) edits the same neighbourhood — kad mode selection in `behaviour.rs`, and two `remove_peer` calls in `service.rs`. Expect a small, mechanical conflict on whichever lands second; the intent is compatible (a client-mode node advertises no kad name at all, so this purge would evict it from peers' tables — which is exactly what that branch's `a_kad_client_is_never_tabled_and_never_found_by_a_walk` wants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

