### PR TITLE
fix(announce): a whole-model node announces no block range

### DIFF
--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -759,6 +759,61 @@ pub fn build_unannounce_records(
     ctx: &AnnounceContext<'_>,
     server_info: &DHTServerInfo,
 ) -> Result<Vec<StoreRequest>> {
+    let subkey = rmp_serde::to_vec(&ctx.peer_id.to_base58())?;
+    let node_info = NodeInfo::from_peer_id(ctx.peer_id);
+    let expiration = get_dht_time() + ANNOUNCE_TTL_SECS;
+
+    let mut records = Vec::with_capacity(2);
+    records.extend(tombstone_blocks(
+        ctx,
+        server_info,
+        server_info.start_block..server_info.end_block,
+    )?);
+
+    // The VPK record is withdrawn with the *live* VPK value, not the offline
+    // ServerInfo — it has no state field to flip, so the only signal available
+    // is that it stops being refreshed.
+    if let Some(ref vpk) = server_info.vpk_info {
+        records.push(StoreRequest {
+            auth: Some(RequestAuthInfo::new()),
+            keys: vec![dht_id(VPK_NODES_KEY)],
+            subkeys: vec![subkey],
+            values: vec![vpk.to_msgpack_bytes()?],
+            expiration_time: vec![expiration],
+            in_cache: vec![false],
+            peer: Some(node_info),
+        });
+    }
+
+    Ok(records)
+}
+
+/// Tombstone the block records a previous announce wrote under
+/// `previous.0..previous.1` that the current range no longer refreshes, so
+/// a node whose range shrank — or collapsed to nothing — stops reading ONLINE
+/// for those blocks until the 360 s TTL runs out.
+///
+/// Blocks still in the current range are left alone: the fresh ONLINE record
+/// carries the same expiration and would be rejected as not strictly newer.
+pub fn build_dropped_block_records(
+    ctx: &AnnounceContext<'_>,
+    server_info: &DHTServerInfo,
+    previous: (i32, i32),
+) -> Result<Vec<StoreRequest>> {
+    let current = server_info.start_block..server_info.end_block;
+    let dropped = (previous.0..previous.1).filter(|b| !current.contains(b));
+    Ok(tombstone_blocks(ctx, server_info, dropped)?
+        .into_iter()
+        .collect())
+}
+
+/// One STORE request writing the `state = -1` tombstone under each of `blocks`;
+/// `None` when there is nothing to write, so no all-empty request goes out.
+fn tombstone_blocks(
+    ctx: &AnnounceContext<'_>,
+    server_info: &DHTServerInfo,
+    blocks: impl Iterator<Item = i32>,
+) -> Result<Option<StoreRequest>> {
     let offline_info = DHTServerInfo {
         state: -1, // OFFLINE — tells map.kwaai.ai to remove the node immediately
         throughput: 0.0,
@@ -783,49 +838,32 @@ pub fn build_unannounce_records(
 
     let info_bytes = offline_info.to_msgpack()?;
     let subkey = rmp_serde::to_vec(&ctx.peer_id.to_base58())?;
-    let node_info = NodeInfo::from_peer_id(ctx.peer_id);
     let expiration = get_dht_time() + ANNOUNCE_TTL_SECS;
-
-    let mut records = Vec::with_capacity(2);
 
     let mut keys = Vec::new();
     let mut subkeys = Vec::new();
     let mut values = Vec::new();
     let mut expirations = Vec::new();
     let mut in_cache = Vec::new();
-    for block in server_info.start_block..server_info.end_block {
+    for block in blocks {
         keys.push(dht_id(&format!("{}.{}", ctx.prefix, block)));
         subkeys.push(subkey.clone());
         values.push(info_bytes.clone());
         expirations.push(expiration);
         in_cache.push(false);
     }
-    records.push(StoreRequest {
+    if keys.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(StoreRequest {
         auth: Some(RequestAuthInfo::new()),
         keys,
         subkeys,
         values,
         expiration_time: expirations,
         in_cache,
-        peer: Some(node_info.clone()),
-    });
-
-    // The VPK record is withdrawn with the *live* VPK value, not the offline
-    // ServerInfo — it has no state field to flip, so the only signal available
-    // is that it stops being refreshed.
-    if let Some(ref vpk) = server_info.vpk_info {
-        records.push(StoreRequest {
-            auth: Some(RequestAuthInfo::new()),
-            keys: vec![dht_id(VPK_NODES_KEY)],
-            subkeys: vec![subkey],
-            values: vec![vpk.to_msgpack_bytes()?],
-            expiration_time: vec![expiration],
-            in_cache: vec![false],
-            peer: Some(node_info),
-        });
-    }
-
-    Ok(records)
+        peer: Some(NodeInfo::from_peer_id(ctx.peer_id)),
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -1625,6 +1663,82 @@ mod tests {
         };
         assert_eq!(parts[0].as_i64(), Some(-1), "state = -1 (offline)");
         assert_eq!(parts[1].as_f64(), Some(0.0), "throughput zeroed");
+    }
+
+    /// The regression guard for #183: an empty range writes no per-block
+    /// record at all — not a StoreRequest with zero keys — so a whole-model
+    /// node is never discovered as a block server.
+    #[test]
+    fn an_empty_range_announces_no_block_records() {
+        let p = peer();
+        let mut info = server_info(Some(vpk_info()));
+        info.start_block = 3;
+        info.end_block = 3;
+
+        let records = build_announce_records(&ctx(p), &info).unwrap();
+        assert_eq!(records.len(), 3, "models, inference nodes, vpk — no blocks");
+        assert_eq!(records[0].keys, vec![dht_id(PETALS_MODELS_KEY)]);
+        assert!(records.iter().all(|r| !r.keys.is_empty()));
+
+        let withdrawn = build_unannounce_records(&ctx(p), &info).unwrap();
+        assert_eq!(withdrawn.len(), 1, "only the VPK record is withdrawn");
+        assert_eq!(withdrawn[0].keys, vec![dht_id(VPK_NODES_KEY)]);
+        assert!(
+            build_unannounce_records(&ctx(p), &server_info_with_range(3, 3))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    fn server_info_with_range(start: i32, end: i32) -> DHTServerInfo {
+        let mut info = server_info(None);
+        info.start_block = start;
+        info.end_block = end;
+        info
+    }
+
+    /// Blocks that fall out of the announced range are tombstoned, and only
+    /// those: a block still in the range gets its fresh ONLINE record instead,
+    /// which the store would reject behind a same-expiration tombstone.
+    #[test]
+    fn a_shrunken_range_tombstones_only_the_dropped_blocks() {
+        let p = peer();
+        let block_key = |b: i32| dht_id(&format!("{}.{}", ctx(p).prefix, b));
+
+        // Collapsed to nothing: every previously announced block is withdrawn.
+        let collapsed =
+            build_dropped_block_records(&ctx(p), &server_info_with_range(3, 3), (0, 3)).unwrap();
+        assert_eq!(collapsed.len(), 1);
+        assert_eq!(
+            collapsed[0].keys,
+            vec![block_key(0), block_key(1), block_key(2)]
+        );
+        let value = rmpv::decode::read_value(&mut &collapsed[0].values[0][..]).unwrap();
+        let rmpv::Value::Ext(64, inner) = value else {
+            panic!("tombstone must be an Ext(64) ServerInfo");
+        };
+        let rmpv::Value::Array(parts) = rmpv::decode::read_value(&mut &inner[..]).unwrap() else {
+            panic!("Ext payload must be an array");
+        };
+        assert_eq!(parts[0].as_i64(), Some(-1), "state = -1 (offline)");
+
+        // Moved: only the block no longer covered.
+        let moved =
+            build_dropped_block_records(&ctx(p), &server_info_with_range(1, 4), (0, 3)).unwrap();
+        assert_eq!(moved.len(), 1);
+        assert_eq!(moved[0].keys, vec![block_key(0)]);
+
+        // Unchanged or grown: nothing to withdraw, and no empty request.
+        assert!(
+            build_dropped_block_records(&ctx(p), &server_info_with_range(0, 3), (0, 3))
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            build_dropped_block_records(&ctx(p), &server_info_with_range(0, 5), (0, 3))
+                .unwrap()
+                .is_empty()
+        );
     }
 
     /// The load-bearing correction: the tombstone's expiration is in the

--- a/core/crates/kwaai-cli/src/announce.rs
+++ b/core/crates/kwaai-cli/src/announce.rs
@@ -680,15 +680,18 @@ pub fn build_announce_records(
         expirations.push(expiration);
         in_cache.push(false);
     }
-    records.push(StoreRequest {
-        auth: Some(RequestAuthInfo::new()),
-        keys,
-        subkeys,
-        values,
-        expiration_time: expirations,
-        in_cache,
-        peer: Some(node_info.clone()),
-    });
+    // An empty range (a whole-model node) has no per-block record to send.
+    if !keys.is_empty() {
+        records.push(StoreRequest {
+            auth: Some(RequestAuthInfo::new()),
+            keys,
+            subkeys,
+            values,
+            expiration_time: expirations,
+            in_cache,
+            peer: Some(node_info.clone()),
+        });
+    }
 
     // 2. Model registry — subkeyed by *prefix*, not by peer, so one entry per
     //    model rather than one per server.

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -52,8 +52,8 @@ use std::time::Duration;
 use tracing::{error, info, warn};
 
 use crate::announce::{
-    build_announce_records, build_unannounce_records, send_records_via_handle, AnnounceContext,
-    DHTServerInfo, StoreTiming,
+    build_announce_records, build_dropped_block_records, build_unannounce_records,
+    send_records_via_handle, AnnounceContext, DHTServerInfo, StoreTiming,
 };
 use crate::config::KwaaiNetConfig;
 use crate::daemon::ShardManager;
@@ -107,6 +107,9 @@ pub struct NativeNode {
     /// dial-address record is selected under the policy the daemon dials by.
     require_global_ips: bool,
     dials_quic: bool,
+    /// Block range of the last announce that reached the DHT, so a shrink can
+    /// tombstone the blocks it no longer refreshes.
+    announced_blocks: Option<(i32, i32)>,
 }
 
 impl NativeNode {
@@ -296,6 +299,7 @@ impl NativeNode {
             identity: keypair,
             require_global_ips,
             dials_quic,
+            announced_blocks: None,
         })
     }
 
@@ -335,7 +339,7 @@ impl NativeNode {
     /// store — the announce doubles as the reputation probe on both paths.
     ///
     pub async fn announce(
-        &self,
+        &mut self,
         ctx: &AnnounceContext<'_>,
         server_info: &mut DHTServerInfo,
         bootstrap_peers: &[String],
@@ -351,12 +355,19 @@ impl NativeNode {
             self.dials_quic,
         )
         .await;
-        let records = build_announce_records(ctx, server_info)?;
+        // Blocks the previous round published and this one will not refresh
+        // are tombstoned in the same round, rather than left ONLINE for a TTL.
+        let mut records = match self.announced_blocks {
+            Some(previous) => build_dropped_block_records(ctx, server_info, previous)?,
+            None => vec![],
+        };
+        records.extend(build_announce_records(ctx, server_info)?);
         for record in &records {
             self.storage.handle_store(record.clone());
         }
         let (ok, timings) = self.deliver(&records, bootstrap_peers).await;
         if ok {
+            self.announced_blocks = Some((server_info.start_block, server_info.end_block));
             info!(
                 "✅ Announced {} blocks",
                 server_info.end_block - server_info.start_block
@@ -434,7 +445,7 @@ pub async fn run_native_node(
     grpc: &crate::grpc_server::GrpcServerHandle,
 ) -> Result<Option<String>> {
     info!("[1/4] Starting the native p2p stack...");
-    let node = NativeNode::start(config, bootstrap_peers).await?;
+    let mut node = NativeNode::start(config, bootstrap_peers).await?;
     let peer_id = node.peer_id;
 
     // Hand the swarm to the gRPC surface, which bound before the node existed
@@ -500,7 +511,7 @@ pub async fn run_native_node(
     let (start_block, end_block) = announced_range(
         &config,
         ShardManager::shard_is_ready(),
-        ShardManager::whole_model_is_ready(),
+        KwaaiNetConfig::announce_state(),
     );
     let mut server_info = DHTServerInfo::new(
         start_block,
@@ -527,11 +538,14 @@ pub async fn run_native_node(
     if config.announce_self {
         info!("   Name    : {}", public_name);
         info!("   Model   : {}", config.model);
-        info!(
-            "   Blocks  : {}–{}",
-            config.start_block(),
-            config.effective_end_block()
-        );
+        if server_info.start_block == server_info.end_block {
+            info!("   Blocks  : none (no block shard to route through)");
+        } else {
+            info!(
+                "   Blocks  : {}–{}",
+                server_info.start_block, server_info.end_block
+            );
+        }
         info!("   Map     : https://map.kwaai.ai");
     }
 
@@ -571,7 +585,7 @@ pub async fn run_native_node(
             _ = sighup.recv() => {
                 info!("SIGHUP received — re-reading config");
                 reload_block_range(&mut config);
-                refresh_server_info(&mut server_info, &config);
+                refresh_server_info(&mut server_info, &config).await;
                 if config.announce_self {
                     if let Err(e) = node.announce(&ctx, &mut server_info, bootstrap_peers).await {
                         warn!("Re-announce after SIGHUP failed: {e:#}");
@@ -615,11 +629,7 @@ pub async fn run_native_node(
                 }
 
                 if config.announce_self {
-                    // Re-derive whole-model readiness first: on a Mac this is what
-                    // makes the difference between ONLINE and JOINING, and Ollama
-                    // can come and go under a long-running node.
-                    crate::ollama::refresh_whole_model_ready(config.ollama_port).await;
-                    refresh_server_info(&mut server_info, &config);
+                    refresh_server_info(&mut server_info, &config).await;
                     info!(
                         "Re-announcing to DHT (shard_ready={}, whole_model_ready={})...",
                         ShardManager::shard_is_ready(),
@@ -686,7 +696,7 @@ pub async fn run_native_node(
                 );
                 crate::node::refresh_throughput(&mut server_info, &config.model, dl_bps, using_relay);
                 server_info.using_relay = using_relay;
-                refresh_server_info(&mut server_info, &config);
+                refresh_server_info(&mut server_info, &config).await;
                 match node.announce(&ctx, &mut server_info, bootstrap_peers).await {
                     // Only a successful publish consumes the epoch; on failure
                     // the next settle window or the 300 s tick retries it.
@@ -699,7 +709,7 @@ pub async fn run_native_node(
             // host is usable again without waiting out the 300 s tick.
             Some(()) = ollama_recovery_rx.recv(), if config.announce_self => {
                 info!("Ollama recovered — triggering immediate re-announce");
-                refresh_server_info(&mut server_info, &config);
+                refresh_server_info(&mut server_info, &config).await;
                 if let Err(e) = node.announce(&ctx, &mut server_info, bootstrap_peers).await {
                     warn!("Re-announce after Ollama recovery failed: {e:#}");
                 }
@@ -813,36 +823,42 @@ fn reload_block_range(config: &mut KwaaiNetConfig) {
     config.blocks = fresh.blocks;
 }
 
-/// Sync the announced block range and readiness state from the live config.
-/// The block range this node announces.
+/// The block range this node announces, given the `state` it announces.
 ///
-/// A node serving the whole model through Ollama has no blocks a chain can
-/// route through, so it announces none: its `_kwaai.inference.nodes` entry
-/// still says it serves whole-model inference. Announcing the configured
-/// range made every macOS node a 0–32 block server in every chain build,
-/// where it refused `/kwaai/inference/1.0.0` on the first hop.
-fn announced_range(
-    config: &KwaaiNetConfig,
-    shard_ready: bool,
-    whole_model_ready: bool,
-) -> (i32, i32) {
+/// Only a ready block shard has blocks a chain can route through. A node
+/// announcing ONLINE without one — the whole model through Ollama, or
+/// `announce_online_without_shard` — announces an empty range, so no per-block
+/// record is written and it is never chosen as a hop; its
+/// `_kwaai.inference.nodes` entry still says what it serves. Announcing the
+/// configured range made every macOS node a 0–32 block server in every chain
+/// build, where it refused `/kwaai/inference/1.0.0` on the first hop.
+///
+/// JOINING keeps the configured range: it says what the node intends to
+/// serve, and no consumer routes through a node that is not ONLINE.
+fn announced_range(config: &KwaaiNetConfig, shard_ready: bool, state: i32) -> (i32, i32) {
     let start = config.start_block() as i32;
-    if whole_model_ready && !shard_ready {
+    if state == STATE_ONLINE && !shard_ready {
         (start, start)
     } else {
         (start, config.effective_end_block() as i32)
     }
 }
 
-fn refresh_server_info(server_info: &mut DHTServerInfo, config: &KwaaiNetConfig) {
-    let (start_block, end_block) = announced_range(
-        config,
-        ShardManager::shard_is_ready(),
-        ShardManager::whole_model_is_ready(),
-    );
+/// petals' `ServerState.ONLINE`, as [`KwaaiNetConfig::announce_state`] reports it.
+const STATE_ONLINE: i32 = 2;
+
+/// Sync the announced block range and readiness state from the live config.
+///
+/// Whole-model readiness is re-derived here, not by the caller: on a Mac it is
+/// what separates ONLINE from JOINING, Ollama comes and goes under a long-running
+/// node, and an arm that skipped it re-announced from a stale sentinel.
+async fn refresh_server_info(server_info: &mut DHTServerInfo, config: &KwaaiNetConfig) {
+    crate::ollama::refresh_whole_model_ready(config.ollama_port).await;
+    let state = KwaaiNetConfig::announce_state();
+    let (start_block, end_block) = announced_range(config, ShardManager::shard_is_ready(), state);
     server_info.start_block = start_block;
     server_info.end_block = end_block;
-    server_info.state = KwaaiNetConfig::announce_state();
+    server_info.state = state;
     server_info.shard_loading = KwaaiNetConfig::announce_shard_loading();
 }
 
@@ -1045,7 +1061,7 @@ mod tests {
         kwaai_p2p::identity::generate_keypair(config.identity_key.as_ref().unwrap())
             .expect("the fixture key must generate");
 
-        let node = NativeNode::start(&config, &[])
+        let mut node = NativeNode::start(&config, &[])
             .await
             .expect("an ordinary node must start");
 
@@ -1092,21 +1108,23 @@ mod announced_range_tests {
         }
     }
 
+    const JOINING: i32 = 1;
+
     #[test]
     fn a_block_shard_announces_its_range() {
-        assert_eq!(announced_range(&config(), true, false), (4, 12));
-        // Both ready: the shard is what a chain can use.
-        assert_eq!(announced_range(&config(), true, true), (4, 12));
+        assert_eq!(announced_range(&config(), true, STATE_ONLINE), (4, 12));
     }
 
     #[test]
-    fn a_whole_model_node_announces_no_blocks() {
-        assert_eq!(announced_range(&config(), false, true), (4, 4));
+    fn online_without_a_shard_announces_no_blocks() {
+        // Whole model through Ollama, or `announce_online_without_shard`:
+        // ONLINE, but with nothing a chain can route through.
+        assert_eq!(announced_range(&config(), false, STATE_ONLINE), (4, 4));
     }
 
     #[test]
-    fn a_node_with_neither_keeps_the_configured_range() {
-        // Announces JOINING for it, as before; the range is what it intends.
-        assert_eq!(announced_range(&config(), false, false), (4, 12));
+    fn a_joining_node_keeps_the_configured_range() {
+        // Nothing routes through a JOINING node; the range is what it intends.
+        assert_eq!(announced_range(&config(), false, JOINING), (4, 12));
     }
 }

--- a/core/crates/kwaai-cli/src/node_native.rs
+++ b/core/crates/kwaai-cli/src/node_native.rs
@@ -497,9 +497,14 @@ pub async fn run_native_node(
     // already serving comes up ONLINE instead of sitting at JOINING until the
     // first re-announce tick.
     crate::ollama::refresh_whole_model_ready(config.ollama_port).await;
+    let (start_block, end_block) = announced_range(
+        &config,
+        ShardManager::shard_is_ready(),
+        ShardManager::whole_model_is_ready(),
+    );
     let mut server_info = DHTServerInfo::new(
-        config.start_block() as i32,
-        config.effective_end_block() as i32,
+        start_block,
+        end_block,
         public_name,
         using_relay,
         throughput,
@@ -809,9 +814,34 @@ fn reload_block_range(config: &mut KwaaiNetConfig) {
 }
 
 /// Sync the announced block range and readiness state from the live config.
+/// The block range this node announces.
+///
+/// A node serving the whole model through Ollama has no blocks a chain can
+/// route through, so it announces none: its `_kwaai.inference.nodes` entry
+/// still says it serves whole-model inference. Announcing the configured
+/// range made every macOS node a 0–32 block server in every chain build,
+/// where it refused `/kwaai/inference/1.0.0` on the first hop.
+fn announced_range(
+    config: &KwaaiNetConfig,
+    shard_ready: bool,
+    whole_model_ready: bool,
+) -> (i32, i32) {
+    let start = config.start_block() as i32;
+    if whole_model_ready && !shard_ready {
+        (start, start)
+    } else {
+        (start, config.effective_end_block() as i32)
+    }
+}
+
 fn refresh_server_info(server_info: &mut DHTServerInfo, config: &KwaaiNetConfig) {
-    server_info.start_block = config.start_block() as i32;
-    server_info.end_block = config.effective_end_block() as i32;
+    let (start_block, end_block) = announced_range(
+        config,
+        ShardManager::shard_is_ready(),
+        ShardManager::whole_model_is_ready(),
+    );
+    server_info.start_block = start_block;
+    server_info.end_block = end_block;
     server_info.state = KwaaiNetConfig::announce_state();
     server_info.shard_loading = KwaaiNetConfig::announce_shard_loading();
 }
@@ -1047,5 +1077,36 @@ mod tests {
 
         node.shutdown().await;
         std::env::remove_var("KWAAINET_SOCKET");
+    }
+}
+
+#[cfg(test)]
+mod announced_range_tests {
+    use super::*;
+
+    fn config() -> KwaaiNetConfig {
+        KwaaiNetConfig {
+            start_block: Some(4),
+            blocks: 8,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_block_shard_announces_its_range() {
+        assert_eq!(announced_range(&config(), true, false), (4, 12));
+        // Both ready: the shard is what a chain can use.
+        assert_eq!(announced_range(&config(), true, true), (4, 12));
+    }
+
+    #[test]
+    fn a_whole_model_node_announces_no_blocks() {
+        assert_eq!(announced_range(&config(), false, true), (4, 4));
+    }
+
+    #[test]
+    fn a_node_with_neither_keeps_the_configured_range() {
+        // Announces JOINING for it, as before; the range is what it intends.
+        assert_eq!(announced_range(&config(), false, false), (4, 12));
     }
 }


### PR DESCRIPTION
Part of #198 (item 6). Resolves #183.

## Problem
A macOS node serving the whole model through Ollama announced its configured block range anyway, ONLINE, so every chain build discovered it as a 0–32 block server, pinned it first, and had the hop refused: `remote does not support protocol /kwaai/inference/1.0.0` (christophermayfield-macos, v0.6.8, on every production chain build on 2026-09-07).

## Change
The announced range depends on what the node serves: a block shard announces its range; a whole-model node announces an empty one, so no per-block record is written and it is never chosen as a hop. Its `_kwaai.inference.nodes` entry is unchanged, which is how `p2p://auto` finds it. A node serving neither keeps the configured range and its JOINING state.

## Evidence
- Unit tests for the three cases.
- Isolated LAN: a Mac on the Ollama route logged `Announced 0 blocks` while its model and inference-node records were still stored.

## Deploy
Peers, 0.6.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
