### PR TITLE
fix(cli): apply log_level from config.yaml to the daemon's log filter

### DIFF
--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -1031,7 +1031,6 @@ impl KwaaiNetConfig {
         Self::load_or_create().unwrap_or_else(|_| self.clone())
     }
 
-    /// Load config from `~/.kwaainet/config.yaml`, creating it with defaults if absent.
     /// `log_level` from the config file, without creating the file or
     /// parsing the rest of it. Read before logging is initialised, so it
     /// must not fail, create or log anything.
@@ -1044,6 +1043,7 @@ impl KwaaiNetConfig {
         serde_yaml::from_str::<LogLevelOnly>(&text).ok()?.log_level
     }
 
+    /// Load config from `~/.kwaainet/config.yaml`, creating it with defaults if absent.
     pub fn load_or_create() -> Result<Self> {
         let cfg_file = config_file();
         std::fs::create_dir_all(cfg_file.parent().unwrap())?;
@@ -1211,7 +1211,17 @@ impl KwaaiNetConfig {
             "blocks" => self.blocks = value.parse().context("blocks must be a number")?,
             "port" => self.port = value.parse().context("port must be a number")?,
             "use_gpu" => self.use_gpu = parse_bool(value)?,
-            "log_level" => self.log_level = value.to_string(),
+            "log_level" => {
+                self.log_level = parse_log_level(value)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "log_level must be one of {}, got '{}'",
+                            LOG_LEVELS.join(", "),
+                            value
+                        )
+                    })?
+                    .to_string()
+            }
             "public_name" => self.public_name = Some(value.to_string()),
             "public_ip" => self.public_ip = Some(value.to_string()),
             "public_port" => {
@@ -1291,6 +1301,18 @@ impl KwaaiNetConfig {
         }
         Ok(())
     }
+}
+
+/// Accepted `log_level` values, least to most verbose.
+pub const LOG_LEVELS: [&str; 6] = ["off", "error", "warn", "info", "debug", "trace"];
+
+/// The canonical name for a `log_level` value, or None if it is not one.
+pub fn parse_log_level(s: &str) -> Option<&'static str> {
+    let s = s.trim();
+    LOG_LEVELS
+        .iter()
+        .copied()
+        .find(|l| l.eq_ignore_ascii_case(s))
 }
 
 fn parse_bool(s: &str) -> Result<bool> {
@@ -1690,6 +1712,22 @@ mod start_block_provenance {
 }
 
 /// `cargo test` must not be able to touch the developer's real config.
+#[cfg(test)]
+mod log_level_values {
+    use super::*;
+
+    #[test]
+    fn set_key_rejects_a_level_the_filter_would_not_understand() {
+        let mut cfg = KwaaiNetConfig::default();
+        for typo in ["warning", "verbose", ""] {
+            assert!(cfg.set_key("log_level", typo).is_err(), "{typo:?}");
+        }
+        cfg.set_key("log_level", " Debug ").expect("set");
+        assert_eq!(cfg.log_level, "debug");
+        assert_eq!(parse_log_level("OFF"), Some("off"));
+    }
+}
+
 #[cfg(test)]
 mod test_isolation {
     use super::*;

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -1032,6 +1032,18 @@ impl KwaaiNetConfig {
     }
 
     /// Load config from `~/.kwaainet/config.yaml`, creating it with defaults if absent.
+    /// `log_level` from the config file, without creating the file or
+    /// parsing the rest of it. Read before logging is initialised, so it
+    /// must not fail, create or log anything.
+    pub fn peek_log_level() -> Option<String> {
+        #[derive(Deserialize)]
+        struct LogLevelOnly {
+            log_level: Option<String>,
+        }
+        let text = std::fs::read_to_string(config_file()).ok()?;
+        serde_yaml::from_str::<LogLevelOnly>(&text).ok()?.log_level
+    }
+
     pub fn load_or_create() -> Result<Self> {
         let cfg_file = config_file();
         std::fs::create_dir_all(cfg_file.parent().unwrap())?;

--- a/core/crates/kwaai-cli/src/config.rs
+++ b/core/crates/kwaai-cli/src/config.rs
@@ -1711,7 +1711,10 @@ mod start_block_provenance {
     }
 }
 
-/// `cargo test` must not be able to touch the developer's real config.
+/// A `log_level` the filter cannot parse must be refused at the boundary.
+/// `set_key` used to take any string: an unparseable level then silently
+/// disabled every log line including ERROR, because the bare word parsed as
+/// a target and left the filter with no directive for us at all.
 #[cfg(test)]
 mod log_level_values {
     use super::*;
@@ -1728,6 +1731,7 @@ mod log_level_values {
     }
 }
 
+/// `cargo test` must not be able to touch the developer's real config.
 #[cfg(test)]
 mod test_isolation {
     use super::*;

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -108,13 +108,17 @@ async fn main() -> Result<()> {
 
     // Initialise logging: RUST_LOG wins, then `log_level` from config.yaml,
     // then info. The config key used to be read only to print it back.
-    let default_filter = default_log_filter(config::KwaaiNetConfig::peek_log_level().as_deref());
+    let (default_filter, level_warning) =
+        default_log_filter(config::KwaaiNetConfig::peek_log_level().as_deref());
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&default_filter)),
         )
         .init();
+    if let Some(msg) = level_warning {
+        tracing::warn!("{msg}");
+    }
 
     // Spawn a background update check that runs concurrently with the command.
     // Uses a 24-hour on-disk cache so it only hits the network once per day.
@@ -1904,30 +1908,138 @@ fn print_last_lines(path: &std::path::Path, n: usize) {
     }
 }
 
-/// The log filter when RUST_LOG is unset: the configured level for kwaainet
-/// itself, with the noisy index crates held at warn regardless.
-fn default_log_filter(level: Option<&str>) -> String {
-    let level = match level.map(str::trim).filter(|l| !l.is_empty()) {
-        Some(l) => l.to_ascii_lowercase(),
-        None => "info".to_string(),
+/// The log filter when RUST_LOG is unset: the configured level for kwaainet's
+/// own crates (`kwaainet`, `kwaai_*`), dependencies at info, and the noisy
+/// index crates no louder than warn. An unknown level falls back to info and
+/// returns a warning to log once the subscriber is up.
+fn default_log_filter(level: Option<&str>) -> (String, Option<String>) {
+    let (level, warning) = match level.map(str::trim).filter(|l| !l.is_empty()) {
+        None => ("info", None),
+        Some(l) => match config::parse_log_level(l) {
+            Some(l) => (l, None),
+            None => (
+                "info",
+                Some(format!(
+                    "config log_level '{l}' is not one of {}; using info",
+                    config::LOG_LEVELS.join(", ")
+                )),
+            ),
+        },
     };
-    format!(
-        "{level},hnsw_rs=warn,kwaai_storage=warn,tantivy=warn,{}={level}",
-        env!("CARGO_PKG_NAME")
-    )
+    // min(level, warn): at error/off the index crates go quiet too.
+    let rank = |l: &str| config::LOG_LEVELS.iter().position(|x| *x == l).unwrap();
+    let pin = config::LOG_LEVELS[rank(level).min(rank("warn"))];
+    // `kwaai=` is a target prefix: it covers `kwaainet` and every `kwaai_*` crate.
+    let filter = format!("info,hnsw_rs={pin},kwaai_storage={pin},tantivy={pin},kwaai={level}");
+    (filter, warning)
 }
 
 #[cfg(test)]
 mod log_filter_tests {
     use super::default_log_filter;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::EnvFilter;
+
+    #[derive(Clone, Default)]
+    struct Buf(Arc<Mutex<Vec<u8>>>);
+    impl Write for Buf {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Whether one event at (target, level) gets through the filter: the
+    /// tests check what the subscriber does, not the string.
+    fn hits(filter: &str, target: &str, level: tracing::Level) -> bool {
+        let buf = Buf::default();
+        let sink = buf.clone();
+        let sub = tracing_subscriber::fmt()
+            .with_writer(move || sink.clone())
+            .with_env_filter(EnvFilter::new(filter))
+            .finish();
+        tracing::subscriber::with_default(sub, || emit(target, level));
+        let written = !buf.0.lock().unwrap().is_empty();
+        written
+    }
+
+    macro_rules! emit_all {
+        ($target:expr, $level:expr, $($t:literal),*) => {
+            match $target {
+                $($t => match $level {
+                    tracing::Level::ERROR => tracing::error!(target: $t, "hit"),
+                    tracing::Level::WARN => tracing::warn!(target: $t, "hit"),
+                    tracing::Level::INFO => tracing::info!(target: $t, "hit"),
+                    tracing::Level::DEBUG => tracing::debug!(target: $t, "hit"),
+                    tracing::Level::TRACE => tracing::trace!(target: $t, "hit"),
+                },)*
+                other => panic!("no probe for target {other}"),
+            }
+        };
+    }
+
+    // `target:` must be a literal, so dispatch on the target string.
+    fn emit(target: &str, level: tracing::Level) {
+        emit_all!(
+            target,
+            level,
+            "kwaainet::node",
+            "kwaai_p2p::swarm",
+            "kwaai_storage::index",
+            "hnsw_rs::hnsw",
+            "libp2p_swarm",
+            "quinn::connection"
+        );
+    }
 
     #[test]
     fn the_configured_level_drives_the_filter() {
-        assert!(default_log_filter(Some("debug")).starts_with("debug,"));
-        assert!(default_log_filter(Some("DEBUG")).ends_with("=debug"));
-        assert!(default_log_filter(None).starts_with("info,"));
-        assert!(default_log_filter(Some("  ")).starts_with("info,"));
-        // The index crates stay quiet whatever the level.
-        assert!(default_log_filter(Some("trace")).contains("hnsw_rs=warn"));
+        assert!(default_log_filter(Some("debug")).0.ends_with("kwaai=debug"));
+        assert!(default_log_filter(Some("DEBUG")).0.ends_with("kwaai=debug"));
+        assert!(default_log_filter(None).0.ends_with("kwaai=info"));
+        assert!(default_log_filter(Some("  ")).0.ends_with("kwaai=info"));
+    }
+
+    #[test]
+    fn unknown_levels_fall_back_to_info_with_a_warning() {
+        for typo in ["warning", "verbose"] {
+            let (filter, warning) = default_log_filter(Some(typo));
+            assert!(warning.unwrap().contains(typo));
+            // Not silently blind: kwaainet's own error and info still print.
+            assert!(hits(&filter, "kwaainet::node", tracing::Level::ERROR));
+            assert!(hits(&filter, "kwaainet::node", tracing::Level::INFO));
+            assert!(!hits(&filter, "kwaainet::node", tracing::Level::DEBUG));
+        }
+        assert!(default_log_filter(Some("debug")).1.is_none());
+    }
+
+    #[test]
+    fn off_is_really_off() {
+        let (filter, _) = default_log_filter(Some("off"));
+        for target in ["kwaainet::node", "kwaai_storage::index", "hnsw_rs::hnsw"] {
+            assert!(!hits(&filter, target, tracing::Level::ERROR), "{target}");
+        }
+        let (filter, _) = default_log_filter(Some("error"));
+        assert!(hits(&filter, "hnsw_rs::hnsw", tracing::Level::ERROR));
+        assert!(!hits(&filter, "hnsw_rs::hnsw", tracing::Level::WARN));
+    }
+
+    #[test]
+    fn the_level_applies_to_our_crates_and_not_to_dependencies() {
+        let (filter, _) = default_log_filter(Some("trace"));
+        assert!(hits(&filter, "kwaainet::node", tracing::Level::TRACE));
+        assert!(hits(&filter, "kwaai_p2p::swarm", tracing::Level::TRACE));
+        // The noisy index crates stay pinned at warn, even inside kwaai_*.
+        assert!(!hits(&filter, "kwaai_storage::index", tracing::Level::INFO));
+        assert!(hits(&filter, "kwaai_storage::index", tracing::Level::WARN));
+        // Dependencies keep the previous default of info.
+        for dep in ["libp2p_swarm", "quinn::connection"] {
+            assert!(hits(&filter, dep, tracing::Level::INFO), "{dep}");
+            assert!(!hits(&filter, dep, tracing::Level::DEBUG), "{dep}");
+        }
     }
 }

--- a/core/crates/kwaai-cli/src/main.rs
+++ b/core/crates/kwaai-cli/src/main.rs
@@ -106,13 +106,9 @@ async fn main() -> Result<()> {
     setup_cuda_library_path();
     let cli = Cli::parse();
 
-    // Initialise logging (RUST_LOG overrides config default).
-    // hnsw_rs and kwaai_storage are silenced at INFO — they emit noisy
-    // index-load messages that are implementation detail, not user-facing.
-    let default_filter = format!(
-        "info,hnsw_rs=warn,kwaai_storage=warn,tantivy=warn,{}=info",
-        env!("CARGO_PKG_NAME")
-    );
+    // Initialise logging: RUST_LOG wins, then `log_level` from config.yaml,
+    // then info. The config key used to be read only to print it back.
+    let default_filter = default_log_filter(config::KwaaiNetConfig::peek_log_level().as_deref());
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
@@ -1905,5 +1901,33 @@ fn print_last_lines(path: &std::path::Path, n: usize) {
             }
         }
         Err(e) => eprintln!("Error reading log: {}", e),
+    }
+}
+
+/// The log filter when RUST_LOG is unset: the configured level for kwaainet
+/// itself, with the noisy index crates held at warn regardless.
+fn default_log_filter(level: Option<&str>) -> String {
+    let level = match level.map(str::trim).filter(|l| !l.is_empty()) {
+        Some(l) => l.to_ascii_lowercase(),
+        None => "info".to_string(),
+    };
+    format!(
+        "{level},hnsw_rs=warn,kwaai_storage=warn,tantivy=warn,{}={level}",
+        env!("CARGO_PKG_NAME")
+    )
+}
+
+#[cfg(test)]
+mod log_filter_tests {
+    use super::default_log_filter;
+
+    #[test]
+    fn the_configured_level_drives_the_filter() {
+        assert!(default_log_filter(Some("debug")).starts_with("debug,"));
+        assert!(default_log_filter(Some("DEBUG")).ends_with("=debug"));
+        assert!(default_log_filter(None).starts_with("info,"));
+        assert!(default_log_filter(Some("  ")).starts_with("info,"));
+        // The index crates stay quiet whatever the level.
+        assert!(default_log_filter(Some("trace")).contains("hnsw_rs=warn"));
     }
 }


### PR DESCRIPTION
Part of #198 (item 9).

`log_level` in config.yaml was read only to print it back; the daemon's filter was a fixed `info` unless `RUST_LOG` was set, so `log_level: debug` changed nothing. `RUST_LOG` still wins; the config level is the default under it, read from the file without creating it and before logging exists.

Evidence: unit test on the filter; isolated LAN node at `log_level: debug` writes DEBUG lines with no `RUST_LOG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
