### PR TITLE
feat(jetson): CUDA shard serving on Orin — cudarc sync-allocation opt-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,15 @@ jobs:
         working-directory: core
         run: cargo test -p kwaai-p2p --features kad-multi-protocol
 
+      # Same trap for cudarc, which no CI job compiles (CUDA is release-only):
+      # `[patch.crates-io]` only applies when the patched version satisfies
+      # what candle asks for, and a candle bump past cudarc 0.19 turns the
+      # Jetson fix into a cargo *warning*. Assert the patch is what resolves.
+      - name: Check the cudarc patch is still in the graph
+        if: runner.os == 'Linux'
+        working-directory: core
+        run: bash patches/check-cudarc-patch.sh
+
   # ── 3b. Windows type check (#146) ──────────────────────────────────────────
   # `main` did not compile on Windows for five days between #130 and #142: a
   # field added to a struct was populated only in the `#[cfg(unix)]` arm, and

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ tests/rag-bench/results/*.md
 tests/rag-bench/.env
 core/patches/multistream-select/
 core/patches/libp2p-kad/
+core/patches/cudarc/
 
 # Human-readable renderings of tracked source docs (.docx/.pdf from .md).
 # Generated on request, never the source of truth — mirrors the source path,

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1192,8 +1192,6 @@ dependencies = [
 [[package]]
 name = "cudarc"
 version = "0.19.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
 dependencies = [
  "float8",
  "half",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,6 +29,8 @@ default-members = ["crates/kwaai-cli"]
 [patch.crates-io]
 multistream-select = { path = "patches/multistream-select" }
 libp2p-kad = { path = "patches/libp2p-kad" }
+# Behaves exactly as upstream unless CUDARC_DISABLE_ASYNC_ALLOC is set; see patches/README.md.
+cudarc = { path = "patches/cudarc" }
 
 # Root package for examples
 [package]

--- a/core/crates/kwaai-cli/Cargo.toml
+++ b/core/crates/kwaai-cli/Cargo.toml
@@ -125,6 +125,9 @@ default = ["storage", "rag"]
 cuda = ["kwaai-inference/flash-attn"]
 # cuda-windows: CUDA without flash-attn (flash-attn requires Linux nvcc and cannot build on Windows)
 cuda-windows = ["kwaai-inference/cuda"]
+# The same thing under a name that is not a lie on Linux: CUDA without
+# flash-attn, which is what a Jetson builds (docs/JETSON.md).
+cuda-no-flash = ["kwaai-inference/cuda"]
 llama-cpp = ["llama-cpp-2"]
 storage = ["kwaai-storage", "uuid"]
 rag = ["kwaai-rag", "uuid"]

--- a/core/crates/kwaai-cli/Cargo.toml
+++ b/core/crates/kwaai-cli/Cargo.toml
@@ -123,11 +123,10 @@ sha2 = "0.10"
 [features]
 default = ["storage", "rag"]
 cuda = ["kwaai-inference/flash-attn"]
-# cuda-windows: CUDA without flash-attn (flash-attn requires Linux nvcc and cannot build on Windows)
-cuda-windows = ["kwaai-inference/cuda"]
-# The same thing under a name that is not a lie on Linux: CUDA without
-# flash-attn, which is what a Jetson builds (docs/JETSON.md).
+# CUDA without flash-attn: what a Jetson builds (docs/JETSON.md), and the only
+# CUDA Windows can build (flash-attn needs Linux nvcc).
 cuda-no-flash = ["kwaai-inference/cuda"]
+cuda-windows = ["cuda-no-flash"]
 llama-cpp = ["llama-cpp-2"]
 storage = ["kwaai-storage", "uuid"]
 rag = ["kwaai-rag", "uuid"]

--- a/core/crates/kwaai-inference/src/lib.rs
+++ b/core/crates/kwaai-inference/src/lib.rs
@@ -276,6 +276,7 @@ impl DeviceType {
             DeviceType::Cpu => Ok(candle_core::Device::Cpu),
             #[cfg(feature = "cuda")]
             DeviceType::Cuda(ordinal) => {
+                jetson_default_sync_alloc();
                 candle_core::Device::new_cuda(*ordinal).map_err(InferenceError::from)
             }
             #[cfg(feature = "metal")]
@@ -295,6 +296,38 @@ impl DeviceType {
     }
 }
 
+/// Env var the patched cudarc honours (core/patches/README.md): any value
+/// makes CUDA allocation synchronous instead of stream-ordered.
+pub const CUDARC_DISABLE_ASYNC_ALLOC: &str = "CUDARC_DISABLE_ASYNC_ALLOC";
+
+/// L4T's stream-ordered allocator caps at ~1/3 of memory, so a Jetson with the
+/// variable unset gets it set before the first CUDA call. Fires only on Linux
+/// aarch64 with the Tegra release file present.
+#[cfg(feature = "cuda")]
+fn jetson_default_sync_alloc() {
+    if jetson_needs_sync_alloc(
+        cfg!(all(target_os = "linux", target_arch = "aarch64")),
+        std::path::Path::new("/etc/nv_tegra_release"),
+        std::env::var_os(CUDARC_DISABLE_ASYNC_ALLOC).is_some(),
+    ) {
+        std::env::set_var(CUDARC_DISABLE_ASYNC_ALLOC, "1");
+        tracing::info!(
+            "Jetson detected: set {CUDARC_DISABLE_ASYNC_ALLOC}=1 (L4T's async allocator caps at ~1/3 of memory)"
+        );
+    }
+}
+
+/// The decision behind `jetson_default_sync_alloc`, kept pure so it can be
+/// tested without CUDA or a Jetson.
+#[cfg(any(feature = "cuda", test))]
+fn jetson_needs_sync_alloc(
+    linux_aarch64: bool,
+    tegra_release: &std::path::Path,
+    already_set: bool,
+) -> bool {
+    linux_aarch64 && !already_set && tegra_release.exists()
+}
+
 impl std::fmt::Display for DeviceType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -303,5 +336,41 @@ impl std::fmt::Display for DeviceType {
             DeviceType::Metal(ord) => write!(f, "Metal (GPU {ord})"),
             DeviceType::Mlx => write!(f, "MLX (Apple Silicon)"),
         }
+    }
+}
+
+#[cfg(test)]
+mod jetson_tests {
+    use super::jetson_needs_sync_alloc;
+    use std::path::Path;
+
+    #[test]
+    fn sets_only_on_tegra_linux_aarch64_when_unset() {
+        let dir = std::env::temp_dir().join(format!("kwaai-tegra-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let tegra = dir.join("nv_tegra_release");
+        std::fs::write(&tegra, "# R36 (release)\n").unwrap();
+        let absent = dir.join("missing");
+
+        assert!(jetson_needs_sync_alloc(true, &tegra, false));
+        assert!(
+            !jetson_needs_sync_alloc(true, &tegra, true),
+            "operator's value wins"
+        );
+        assert!(
+            !jetson_needs_sync_alloc(true, &absent, false),
+            "not a Jetson"
+        );
+        assert!(
+            !jetson_needs_sync_alloc(false, &tegra, false),
+            "wrong platform"
+        );
+        assert!(!jetson_needs_sync_alloc(
+            false,
+            Path::new("/etc/nv_tegra_release"),
+            false
+        ));
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/core/patches/README.md
+++ b/core/patches/README.md
@@ -107,4 +107,9 @@ to load with `CUDA_ERROR_OUT_OF_MEMORY`. With the variable set, allocation is
 synchronous and the shard loads. Unset, the build is byte-for-byte upstream
 behaviour on every platform. Only pulled in by the CUDA features.
 
+`kwaai-inference` sets the variable itself on a Jetson (Linux aarch64 with
+`/etc/nv_tegra_release`) when it is unset, so a service-managed Orin needs no
+unit-file edit. CI checks that the patch is still what cargo resolves, so a
+candle bump past cudarc 0.19 fails there instead of silently dropping it.
+
 [cudarc]: https://github.com/coreylowman/cudarc

--- a/core/patches/README.md
+++ b/core/patches/README.md
@@ -92,3 +92,19 @@ The entire delta is `multistream-select.patch` (~23 changed lines, one file).
   `[patch.crates-io]` entry.
 
 [rust-libp2p]: https://github.com/libp2p/rust-libp2p
+
+## cudarc (sync-allocation opt-out)
+
+`cudarc 0.19.7` (from [cudarc], MIT/Apache-2.0) with one four-line change:
+the runtime choice between `cuMemAllocAsync` and `cuMemAlloc` also honours the
+environment variable `CUDARC_DISABLE_ASYNC_ALLOC`. Upstream picks the async,
+stream-ordered allocator whenever the device reports memory-pool support and
+offers no way to say no. On Jetson Orin (L4T r36 / CUDA 12.6) that pool
+hard-caps at roughly a third of system memory — 2.5 GB on a 7 GB Orin Nano,
+~20 GB on a 64 GB AGX Orin (NVIDIA/TensorRT-LLM#10894) — while plain
+`cuMemAlloc` reaches nearly all of it, so an 8-block f16 shard (4.5 GB) fails
+to load with `CUDA_ERROR_OUT_OF_MEMORY`. With the variable set, allocation is
+synchronous and the shard loads. Unset, the build is byte-for-byte upstream
+behaviour on every platform. Only pulled in by the CUDA features.
+
+[cudarc]: https://github.com/coreylowman/cudarc

--- a/core/patches/check-cudarc-patch.sh
+++ b/core/patches/check-cudarc-patch.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Fail if cargo no longer resolves cudarc to core/patches/cudarc. An unused
+# `[patch.crates-io]` entry is only a warning, so a candle bump past the
+# patched major would silently drop the Jetson fix. Run from core/.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+want="$(sed -n 's/^VERSION=//p' "$DIR/fetch-cudarc.sh")"
+
+# cudarc is optional (CUDA features only), so resolve with every feature on.
+# A path-patched package has no `source`; registry copies (ug-cuda's 0.17.x) do.
+got="$(cargo metadata --format-version 1 --locked --all-features \
+    | jq -r '.packages[] | select(.name == "cudarc" and .source == null) | .version')"
+
+if [ "$got" != "$want" ]; then
+    echo "error: patched cudarc $want is not in the dependency graph (resolved: '${got:-none}')." >&2
+    echo "       candle now wants a different cudarc; re-pin patches/fetch-cudarc.sh and cudarc.patch." >&2
+    exit 1
+fi
+echo "cudarc $want resolves to the patched source"

--- a/core/patches/cudarc.patch
+++ b/core/patches/cudarc.patch
@@ -1,0 +1,38 @@
+--- a/src/driver/safe/core.rs
++++ b/src/driver/safe/core.rs
+@@ -80,7 +80,7 @@
+                 cu_device,
+                 sys::CUdevice_attribute_enum::CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
+             )?;
+-            memory_pools_supported > 0
++            memory_pools_supported > 0 && std::env::var_os("CUDARC_DISABLE_ASYNC_ALLOC").is_none()
+         };
+         let ctx = Arc::new(CudaContext {
+             cu_device,
+@@ -152,7 +152,7 @@
+                 cu_device,
+                 sys::CUdevice_attribute_enum::CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
+             )?;
+-            memory_pools_supported > 0
++            memory_pools_supported > 0 && std::env::var_os("CUDARC_DISABLE_ASYNC_ALLOC").is_none()
+         };
+         let ctx = Arc::new(CudaContext {
+             cu_device,
+@@ -203,7 +203,7 @@
+                 cu_device,
+                 sys::CUdevice_attribute_enum::CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
+             )?;
+-            memory_pools_supported > 0
++            memory_pools_supported > 0 && std::env::var_os("CUDARC_DISABLE_ASYNC_ALLOC").is_none()
+         };
+         let ctx = Arc::new(CudaContext {
+             cu_device,
+@@ -240,7 +240,7 @@
+                 cu_device,
+                 sys::CUdevice_attribute_enum::CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
+             )?;
+-            memory_pools_supported > 0
++            memory_pools_supported > 0 && std::env::var_os("CUDARC_DISABLE_ASYNC_ALLOC").is_none()
+         };
+         let ctx = Arc::new(CudaContext {
+             cu_device,

--- a/core/patches/fetch-cudarc.sh
+++ b/core/patches/fetch-cudarc.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Fetch cudarc 0.19.7 from crates.io and apply the sync-allocation opt-out
+# patch. The patched source is used via `[patch.crates-io]` in core/Cargo.toml
+# and is NOT committed — this repo carries only the patch file, which is the
+# entire intentional delta against upstream.
+#
+# Idempotent: re-runs are no-ops unless the patch file changed.
+set -euo pipefail
+
+# Partial by design: this fetches one crate. Run directly it still exits 0 with
+# the other patched crates missing, and the omission only surfaces later as a
+# workspace parse failure — so say so. fetch-patches.sh sets the variable.
+if [ -z "${KWAAI_FETCH_PATCHES:-}" ]; then
+    echo "note: this script fetches only cudarc; run core/patches/fetch-patches.sh to get every patched crate" >&2
+fi
+
+# SHA-256 front end — probed by running, not `command -v`; see
+# fetch-multistream-select.sh for why.
+if echo | shasum -a 256 >/dev/null 2>&1; then
+    sha256() { shasum -a 256 "$@"; }
+elif echo | sha256sum >/dev/null 2>&1; then
+    sha256() { sha256sum "$@"; }
+else
+    echo "error: need a working 'shasum' or 'sha256sum' to verify the download" >&2
+    exit 1
+fi
+
+VERSION=0.19.7
+SHA256=1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc
+DIR="$(cd "$(dirname "$0")" && pwd)"
+DEST="$DIR/cudarc"
+PATCH="$DIR/cudarc.patch"
+STAMP="$DEST/.kwaai-patch-stamp"
+
+want_stamp="$VERSION $(sha256 "$PATCH" | cut -d' ' -f1)"
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$want_stamp" ]; then
+    exit 0
+fi
+
+echo "fetching cudarc $VERSION and applying the sync-allocation opt-out patch..."
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+crate="$tmp/cudarc.crate"
+curl -fsSL -o "$crate" \
+    "https://static.crates.io/crates/cudarc/cudarc-$VERSION.crate"
+echo "$SHA256  $crate" | sha256 -c - >/dev/null
+
+tar -xzf "$crate" -C "$tmp"
+rm -rf "$DEST"
+mv "$tmp/cudarc-$VERSION" "$DEST"
+patch -p1 -d "$DEST" --no-backup-if-mismatch <"$PATCH" >/dev/null
+echo "$want_stamp" >"$STAMP"
+echo "patched cudarc ready at core/patches/cudarc"

--- a/core/patches/fetch-patches.sh
+++ b/core/patches/fetch-patches.sh
@@ -9,3 +9,4 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 export KWAAI_FETCH_PATCHES=1
 bash "$DIR/fetch-multistream-select.sh"
 bash "$DIR/fetch-libp2p-kad.sh"
+bash "$DIR/fetch-cudarc.sh"

--- a/distrib/nix/crane.nix
+++ b/distrib/nix/crane.nix
@@ -60,6 +60,24 @@ let
         patch -p1 < ${./../.. + "/core/patches/libp2p-kad.patch"}
       '';
 
+  # cudarc with the CUDARC_DISABLE_ASYNC_ALLOC opt-out (Jetson). Only the CUDA
+  # features pull it in, but `[patch.crates-io]` must resolve for every build.
+  # sha256 matches core/patches/fetch-cudarc.sh.
+  cudarcPatched =
+    pkgs.runCommand "cudarc-0.19.7-sync-alloc-opt-out"
+      {
+        crate = pkgs.fetchurl {
+          url = "https://static.crates.io/crates/cudarc/cudarc-0.19.7.crate";
+          sha256 = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc";
+        };
+      }
+      ''
+        tar -xzf "$crate"
+        mv cudarc-0.19.7 $out
+        cd $out
+        patch -p1 < ${./../.. + "/core/patches/cudarc.patch"}
+      '';
+
   # Source filter: keep .rs, .toml, .lock, .proto, and non-code assets
   # that are embedded at compile time via include_str!() (.html, .sql).
   filteredSrc =
@@ -84,6 +102,8 @@ let
     cp -r ${multistreamSelectPatched} $out/patches/multistream-select
     rm -rf $out/patches/libp2p-kad
     cp -r ${libp2pKadPatched} $out/patches/libp2p-kad
+    rm -rf $out/patches/cudarc
+    cp -r ${cudarcPatched} $out/patches/cudarc
   '';
 
   commonArgs = {

--- a/docs/JETSON.md
+++ b/docs/JETSON.md
@@ -1,0 +1,47 @@
+# Serving on a Jetson Orin
+
+Measured 2026-09-08 on a Jetson Orin Nano (8 GB variant, 7 GB usable, L4T
+r36.5 / JetPack 6, CUDA 12.6), serving blocks 0–8 of Llama-3.1-8B-Instruct
+in f16 inside a three-node chain.
+
+## Build
+
+```bash
+cd core
+export PATH=/usr/local/cuda/bin:$HOME/.cargo/bin:$PATH   # nvcc is not on PATH for non-interactive shells
+core/patches/fetch-patches.sh                            # once; fetches the patched crates, cudarc included
+CUDA_COMPUTE_CAP=87 cargo build --release -p kwaainet --bin kwaainet --features cuda-no-flash -j 4
+```
+
+- `cuda-no-flash` is plain candle CUDA. `cuda` adds flash-attn, which is a far
+  longer build and was not tried on sm_87.
+- ~25 minutes warm; the final LTO link needs about 4 GB, so build with no
+  shard server resident — the OOM killer takes the 4.5 GB server first.
+
+## Run
+
+```bash
+CUDARC_DISABLE_ASYNC_ALLOC=1 kwaainet shard serve --use-gpu --start-block 0 --blocks 8 --model-path <snapshot>
+```
+
+- The variable is required: without it the stream-ordered allocator caps at
+  ~2.5 GB on this board and the load dies at block 3 (see
+  `core/patches/README.md`).
+- The first request after a fresh binary spends 15–40 s JIT-compiling PTX
+  into `~/.nv/ComputeCache`; later requests are normal. A client with a 30 s
+  call timeout may fail that first request.
+- Only the safetensors files carrying the shard's layers need to be present;
+  the loader reads per block from the index.
+
+## What to expect
+
+| | CPU | GPU |
+|---|---|---|
+| decode, 8 blocks + embeddings | ~440 ms/token | ~150 ms/token (median 156, min 109) |
+| prefill forward, 17 tokens | 730 ms | 120–170 ms |
+| resident memory | 4.5 GB | 5.25 GB (unified memory; GPU buffers count) |
+
+Decode is memory-bandwidth bound; the board's ~68 GB/s puts the floor for
+this shard near 66 ms, so there is roughly a 2× left in candle's per-op
+CUDA path (no fused attention at batch size 1). Four Orins at 8 blocks each
+cover the model.

--- a/docs/JETSON.md
+++ b/docs/JETSON.md
@@ -1,7 +1,7 @@
 # Serving on a Jetson Orin
 
 Measured 2026-09-08 on a Jetson Orin Nano (8 GB variant, 7 GB usable, L4T
-r36.5 / JetPack 6, CUDA 12.6), serving blocks 0–8 of Llama-3.1-8B-Instruct
+r36.5 / JetPack 6, CUDA 12.6), serving blocks 0–7 of Llama-3.1-8B-Instruct
 in f16 inside a three-node chain.
 
 ## Build
@@ -9,7 +9,7 @@ in f16 inside a three-node chain.
 ```bash
 cd core
 export PATH=/usr/local/cuda/bin:$HOME/.cargo/bin:$PATH   # nvcc is not on PATH for non-interactive shells
-core/patches/fetch-patches.sh                            # once; fetches the patched crates, cudarc included
+bash patches/fetch-patches.sh                            # once; fetches the patched crates, cudarc included
 CUDA_COMPUTE_CAP=87 cargo build --release -p kwaainet --bin kwaainet --features cuda-no-flash -j 4
 ```
 
@@ -21,12 +21,14 @@ CUDA_COMPUTE_CAP=87 cargo build --release -p kwaainet --bin kwaainet --features 
 ## Run
 
 ```bash
-CUDARC_DISABLE_ASYNC_ALLOC=1 kwaainet shard serve --use-gpu --start-block 0 --blocks 8 --model-path <snapshot>
+kwaainet shard serve --use-gpu --start-block 0 --blocks 8 --model-path <snapshot>
 ```
 
-- The variable is required: without it the stream-ordered allocator caps at
-  ~2.5 GB on this board and the load dies at block 3 (see
-  `core/patches/README.md`).
+- On a Jetson (Linux aarch64 with `/etc/nv_tegra_release`) the binary sets
+  `CUDARC_DISABLE_ASYNC_ALLOC=1` itself before the first CUDA call and logs
+  one INFO line saying so; a value already in the environment is left alone.
+  Without it the stream-ordered allocator caps at ~2.5 GB on this board and
+  the load dies at block 3 (see `core/patches/README.md`).
 - The first request after a fresh binary spends 15–40 s JIT-compiling PTX
   into `~/.nv/ComputeCache`; later requests are normal. A client with a 30 s
   call timeout may fail that first request.


### PR DESCRIPTION
Relates to #198 (goal 3: partial model on the Orin Nano).

## Problem
Serving blocks 0–8 of Llama-3.1-8B in f16 on a Jetson Orin Nano's GPU failed at block 3 with `CUDA_ERROR_OUT_OF_MEMORY` and 1.8 GB free. cudarc routes every allocation through `cuMemAllocAsync` whenever the device reports memory-pool support, and on L4T r36 / CUDA 12.6 that pool hard-caps at about a third of system memory: 2.5 GB on this 7 GB board, ~20 GB on a 64 GB AGX Orin (NVIDIA/TensorRT-LLM#10894, unresolved). Plain `cuMemAlloc` reaches 6.5 GB. No JetPack release in the Orin's line addresses it; JetPack 7 targets Thor.

## Change
- `core/patches/cudarc.patch` + `fetch-cudarc.sh`, in the existing fetch-and-patch convention: cudarc 0.19.7 with a four-line change so `CUDARC_DISABLE_ASYNC_ALLOC=1` selects synchronous allocation. Unset, the crate behaves exactly as upstream on every platform. Only the CUDA features pull it in. The right home for this is upstream cudarc (an opt-out beside the existing runtime check from cudarc#174); this carries it until then.
- `cuda-no-flash` feature on `kwaainet`: plain candle CUDA, the same as `cuda-windows`, named for what it is on Linux.
- `docs/JETSON.md`: build and run recipe, memory notes, measurements.

## Evidence (isolated 3-node chain, Orin → Mac → mini)
| | CPU | GPU |
|---|---|---|
| Orin hop, 8 blocks + embeddings | 403 ms/token | ~150 ms/token (median 156, min 109) |
| Orin prefill forward, 17 tokens | 730 ms | 120–170 ms |
| chain throughput | 1.8 tok/s | 2.7 tok/s |
| resident | 4.5 GB | 5.25 GB of 7 |

Output identical and correct across runs. Bandwidth floor for this shard is ~66 ms, so candle's per-op CUDA path has ~2× left; flash-attn not tried on sm_87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
