### PR TITLE
feat(shard): serve a block range with MLX on Apple Silicon

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3039,6 +3039,7 @@ dependencies = [
  "criterion",
  "dirs",
  "half",
+ "memmap2",
  "mlx-rs",
  "safetensors 0.6.2",
  "serde",

--- a/core/crates/kwaai-cli/Cargo.toml
+++ b/core/crates/kwaai-cli/Cargo.toml
@@ -126,6 +126,8 @@ cuda = ["kwaai-inference/flash-attn"]
 # cuda-windows: CUDA without flash-attn (flash-attn requires Linux nvcc and cannot build on Windows)
 cuda-windows = ["kwaai-inference/cuda"]
 llama-cpp = ["llama-cpp-2"]
+# mlx: serve blocks with MLX on Apple Silicon. Needs Xcode's Metal Toolchain to build.
+mlx = ["kwaai-inference/mlx"]
 storage = ["kwaai-storage", "uuid"]
 rag = ["kwaai-rag", "uuid"]
 # Bootstrap-grade build: also serve the legacy /ipfs/kad/1.0.0 so peers that

--- a/core/crates/kwaai-cli/src/block_rpc.rs
+++ b/core/crates/kwaai-cli/src/block_rpc.rs
@@ -36,7 +36,49 @@ use tracing::{debug, error, info, warn};
 /// serving inference).  The background load task writes `Some(shard)` when
 /// model weights have been fully loaded.  Inference handlers read this cell
 /// without blocking the load task.
-pub type ShardCell = Arc<RwLock<Option<Arc<TransformerShard>>>>;
+pub type ShardCell = Arc<RwLock<Option<Arc<LoadedShard>>>>;
+
+/// The engine behind one `shard serve`: candle everywhere, MLX when built for it.
+/// MLX forwards take `&mut self`, hence the mutex — one request at a time per shard.
+pub enum LoadedShard {
+    Candle(TransformerShard),
+    #[cfg(feature = "mlx")]
+    Mlx(std::sync::Mutex<kwaai_inference::mlx_shard::MlxTransformerShard>),
+}
+
+impl LoadedShard {
+    pub fn blocks(&self) -> (usize, usize) {
+        match self {
+            Self::Candle(s) => (s.start_block, s.end_block),
+            #[cfg(feature = "mlx")]
+            Self::Mlx(m) => {
+                let m = m.lock().unwrap();
+                (m.start_block, m.end_block)
+            }
+        }
+    }
+    pub fn is_first(&self) -> bool {
+        match self {
+            Self::Candle(s) => s.is_first(),
+            #[cfg(feature = "mlx")]
+            Self::Mlx(m) => m.lock().unwrap().is_first(),
+        }
+    }
+    pub fn is_last(&self) -> bool {
+        match self {
+            Self::Candle(s) => s.is_last(),
+            #[cfg(feature = "mlx")]
+            Self::Mlx(m) => m.lock().unwrap().is_last(),
+        }
+    }
+    pub fn gc_sessions(&self) {
+        match self {
+            Self::Candle(s) => s.gc_sessions(),
+            #[cfg(feature = "mlx")]
+            Self::Mlx(m) => m.lock().unwrap().gc_sessions(),
+        }
+    }
+}
 
 // ── Protocol constant ─────────────────────────────────────────────────────────
 
@@ -127,6 +169,40 @@ pub fn f16_bytes_to_tensor(bytes: &[u8], shape: &[u32], device: &Device) -> Resu
         .collect();
     let shape_usize: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
     Tensor::from_vec(f16_vec, shape_usize.as_slice(), device).context("Tensor::from_vec f16")
+}
+
+/// Same wire format as [`tensor_to_f16_bytes`], for an MLX array.
+#[cfg(feature = "mlx")]
+pub fn array_to_f16_bytes(a: &kwaai_inference::mlx_rs::Array) -> Result<(Vec<u32>, Vec<u8>)> {
+    use kwaai_inference::mlx_rs::Dtype;
+    let a = a
+        .as_dtype(Dtype::Float16)
+        .map_err(|e| anyhow::anyhow!("as_dtype F16: {e}"))?;
+    a.eval().map_err(|e| anyhow::anyhow!("eval: {e}"))?;
+    let shape: Vec<u32> = a.shape().iter().map(|&d| d as u32).collect();
+    let bytes: Vec<u8> = a
+        .as_slice::<half::f16>()
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    Ok((shape, bytes))
+}
+
+/// Same wire format as [`f16_bytes_to_tensor`], into an MLX array.
+#[cfg(feature = "mlx")]
+pub fn f16_bytes_to_array(bytes: &[u8], shape: &[u32]) -> Result<kwaai_inference::mlx_rs::Array> {
+    if !bytes.len().is_multiple_of(2) {
+        bail!(
+            "f16 byte buffer length {} is not a multiple of 2",
+            bytes.len()
+        );
+    }
+    let f16_vec: Vec<half::f16> = bytes
+        .chunks_exact(2)
+        .map(|c| half::f16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    let shape: Vec<i32> = shape.iter().map(|&d| d as i32).collect();
+    Ok(kwaai_inference::mlx_rs::Array::from_slice(&f16_vec, &shape))
 }
 
 /// Serialise token IDs to raw `u32-LE` bytes.
@@ -252,7 +328,7 @@ pub fn make_block_rpc_handler(
         let device = device.clone();
         Box::pin(async move {
             // Read the shard cell and clone the Arc (drops the read lock immediately).
-            let shard_arc: Option<Arc<TransformerShard>> = {
+            let shard_arc: Option<Arc<LoadedShard>> = {
                 let guard = shard.read().await;
                 guard.as_ref().cloned()
             };
@@ -308,7 +384,7 @@ pub fn make_block_rpc_handler(
 /// async tasks (announcements, spinner updates, etc.) make progress while the GPU/CPU
 /// is crunching.
 pub async fn handle_inference_request(
-    shard: Arc<TransformerShard>,
+    shard: Arc<LoadedShard>,
     device: Device,
     raw: Vec<u8>,
 ) -> Result<InferenceResponse> {
@@ -319,8 +395,7 @@ pub async fn handle_inference_request(
     let seq_pos = req.seq_pos as usize;
     let is_first = shard.is_first();
     let is_last = shard.is_last();
-    let start_blk = shard.start_block;
-    let end_blk = shard.end_block;
+    let (start_blk, end_blk) = shard.blocks();
 
     debug!(
         session = session_id,
@@ -329,36 +404,65 @@ pub async fn handle_inference_request(
 
     // Run the synchronous forward pass on the blocking thread pool so the
     // tokio runtime stays responsive to other tasks during compute.
-    let (output, is_logits) =
-        tokio::task::spawn_blocking(move || -> Result<(candle_core::Tensor, bool)> {
+    let (shape, data, is_logits) =
+        tokio::task::spawn_blocking(move || -> Result<(Vec<u32>, Vec<u8>, bool)> {
             let fwd_start = std::time::Instant::now();
-            let result = match req.payload_type {
-                PayloadType::TokenIds => {
-                    if !is_first {
-                        bail!(
-                            "Received TokenIds payload but this shard starts at block {} (not 0)",
-                            start_blk
-                        );
-                    }
-                    let token_ids = bytes_to_token_ids(&req.data).context("decode token IDs")?;
-                    if is_last {
-                        let logits = shard.forward_full(session_id, &token_ids, seq_pos)?;
-                        (logits, true)
-                    } else {
-                        let hidden = shard.forward_first(session_id, &token_ids, seq_pos)?;
-                        (hidden, false)
-                    }
+            if req.payload_type == PayloadType::TokenIds && !is_first {
+                bail!(
+                    "Received TokenIds payload but this shard starts at block {} (not 0)",
+                    start_blk
+                );
+            }
+            let result = match &*shard {
+                LoadedShard::Candle(s) => {
+                    let (out, is_logits) = match req.payload_type {
+                        PayloadType::TokenIds => {
+                            let ids = bytes_to_token_ids(&req.data).context("decode token IDs")?;
+                            if is_last {
+                                (s.forward_full(session_id, &ids, seq_pos)?, true)
+                            } else {
+                                (s.forward_first(session_id, &ids, seq_pos)?, false)
+                            }
+                        }
+                        PayloadType::HiddenStates => {
+                            let hidden = f16_bytes_to_tensor(&req.data, &req.shape, &device)
+                                .context("decode hidden states")?;
+                            if is_last {
+                                (s.forward_last(session_id, hidden, seq_pos)?, true)
+                            } else {
+                                (s.forward_middle(session_id, hidden, seq_pos)?, false)
+                            }
+                        }
+                    };
+                    let (shape, data) =
+                        tensor_to_f16_bytes(&out).context("serialise output tensor")?;
+                    (shape, data, is_logits)
                 }
-                PayloadType::HiddenStates => {
-                    let hidden = f16_bytes_to_tensor(&req.data, &req.shape, &device)
-                        .context("decode hidden states")?;
-                    if is_last {
-                        let logits = shard.forward_last(session_id, hidden, seq_pos)?;
-                        (logits, true)
-                    } else {
-                        let out = shard.forward_middle(session_id, hidden, seq_pos)?;
-                        (out, false)
-                    }
+                #[cfg(feature = "mlx")]
+                LoadedShard::Mlx(m) => {
+                    let mut m = m.lock().unwrap();
+                    let (out, is_logits) = match req.payload_type {
+                        PayloadType::TokenIds => {
+                            let ids = bytes_to_token_ids(&req.data).context("decode token IDs")?;
+                            if is_last {
+                                (m.forward_full(session_id, &ids, seq_pos)?, true)
+                            } else {
+                                (m.forward_first(session_id, &ids, seq_pos)?, false)
+                            }
+                        }
+                        PayloadType::HiddenStates => {
+                            let hidden = f16_bytes_to_array(&req.data, &req.shape)
+                                .context("decode hidden states")?;
+                            if is_last {
+                                (m.forward_last(session_id, hidden, seq_pos)?, true)
+                            } else {
+                                (m.forward_middle(session_id, hidden, seq_pos)?, false)
+                            }
+                        }
+                    };
+                    let (shape, data) =
+                        array_to_f16_bytes(&out).context("serialise output array")?;
+                    (shape, data, is_logits)
                 }
             };
             let fwd_ms = fwd_start.elapsed().as_secs_f64() * 1000.0;
@@ -372,12 +476,6 @@ pub async fn handle_inference_request(
         })
         .await
         .map_err(|e| anyhow::anyhow!("forward pass panicked: {e}"))??;
-
-    // Serialise output tensor to f16 bytes
-    let ser_start = std::time::Instant::now();
-    let (shape, data) = tensor_to_f16_bytes(&output).context("serialise output tensor")?;
-    let ser_ms = ser_start.elapsed().as_secs_f64() * 1000.0;
-    debug!(ser_ms = format!("{ser_ms:.1}"), "response serialization");
 
     Ok(InferenceResponse {
         session_id,

--- a/core/crates/kwaai-cli/src/block_rpc.rs
+++ b/core/crates/kwaai-cli/src/block_rpc.rs
@@ -40,42 +40,63 @@ pub type ShardCell = Arc<RwLock<Option<Arc<LoadedShard>>>>;
 
 /// The engine behind one `shard serve`: candle everywhere, MLX when built for it.
 /// MLX forwards take `&mut self`, hence the mutex — one request at a time per shard.
+/// The block range is copied out at load so no async context ever waits on it.
 pub enum LoadedShard {
     Candle(TransformerShard),
     #[cfg(feature = "mlx")]
-    Mlx(std::sync::Mutex<kwaai_inference::mlx_shard::MlxTransformerShard>),
+    Mlx {
+        blocks: (usize, usize),
+        is_first: bool,
+        is_last: bool,
+        sessions: kwaai_inference::mlx_shard::MlxSessions,
+        shard: std::sync::Mutex<kwaai_inference::mlx_shard::MlxTransformerShard>,
+    },
+}
+
+/// Lock, recovering from poison: a forward that panicked leaves the weights
+/// untouched and its session dropped, so the shard is still usable.
+#[cfg_attr(not(feature = "mlx"), allow(dead_code))]
+fn lock_recover<T>(m: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|p| p.into_inner())
 }
 
 impl LoadedShard {
+    #[cfg(feature = "mlx")]
+    pub fn mlx(shard: kwaai_inference::mlx_shard::MlxTransformerShard) -> Self {
+        Self::Mlx {
+            blocks: (shard.start_block, shard.end_block),
+            is_first: shard.is_first(),
+            is_last: shard.is_last(),
+            sessions: shard.sessions(),
+            shard: std::sync::Mutex::new(shard),
+        }
+    }
     pub fn blocks(&self) -> (usize, usize) {
         match self {
             Self::Candle(s) => (s.start_block, s.end_block),
             #[cfg(feature = "mlx")]
-            Self::Mlx(m) => {
-                let m = m.lock().unwrap();
-                (m.start_block, m.end_block)
-            }
+            Self::Mlx { blocks, .. } => *blocks,
         }
     }
     pub fn is_first(&self) -> bool {
         match self {
             Self::Candle(s) => s.is_first(),
             #[cfg(feature = "mlx")]
-            Self::Mlx(m) => m.lock().unwrap().is_first(),
+            Self::Mlx { is_first, .. } => *is_first,
         }
     }
     pub fn is_last(&self) -> bool {
         match self {
             Self::Candle(s) => s.is_last(),
             #[cfg(feature = "mlx")]
-            Self::Mlx(m) => m.lock().unwrap().is_last(),
+            Self::Mlx { is_last, .. } => *is_last,
         }
     }
     pub fn gc_sessions(&self) {
         match self {
             Self::Candle(s) => s.gc_sessions(),
             #[cfg(feature = "mlx")]
-            Self::Mlx(m) => m.lock().unwrap().gc_sessions(),
+            Self::Mlx { sessions, .. } => sessions.gc(),
         }
     }
 }
@@ -168,6 +189,14 @@ pub fn f16_bytes_to_tensor(bytes: &[u8], shape: &[u32], device: &Device) -> Resu
         .map(|c| half::f16::from_le_bytes([c[0], c[1]]))
         .collect();
     let shape_usize: Vec<usize> = shape.iter().map(|&d| d as usize).collect();
+    // `Tensor::from_vec` does not check this: a short buffer would back an oversized tensor.
+    let n: usize = shape_usize.iter().product();
+    if n != f16_vec.len() {
+        bail!(
+            "shape {shape:?} needs {n} f16 elements, got {}",
+            f16_vec.len()
+        );
+    }
     Tensor::from_vec(f16_vec, shape_usize.as_slice(), device).context("Tensor::from_vec f16")
 }
 
@@ -201,7 +230,18 @@ pub fn f16_bytes_to_array(bytes: &[u8], shape: &[u32]) -> Result<kwaai_inference
         .chunks_exact(2)
         .map(|c| half::f16::from_le_bytes([c[0], c[1]]))
         .collect();
-    let shape: Vec<i32> = shape.iter().map(|&d| d as i32).collect();
+    // `Array::from_slice` asserts on a length/shape mismatch; fail like the candle twin instead.
+    let shape: Vec<i32> = shape
+        .iter()
+        .map(|&d| i32::try_from(d).with_context(|| format!("dim {d} exceeds i32")))
+        .collect::<Result<_>>()?;
+    let n: usize = shape.iter().map(|&d| d as usize).product();
+    if n != f16_vec.len() {
+        bail!(
+            "shape {shape:?} needs {n} f16 elements, got {}",
+            f16_vec.len()
+        );
+    }
     Ok(kwaai_inference::mlx_rs::Array::from_slice(&f16_vec, &shape))
 }
 
@@ -439,8 +479,8 @@ pub async fn handle_inference_request(
                     (shape, data, is_logits)
                 }
                 #[cfg(feature = "mlx")]
-                LoadedShard::Mlx(m) => {
-                    let mut m = m.lock().unwrap();
+                LoadedShard::Mlx { shard: m, .. } => {
+                    let mut m = lock_recover(m);
                     let (out, is_logits) = match req.payload_type {
                         PayloadType::TokenIds => {
                             let ids = bytes_to_token_ids(&req.data).context("decode token IDs")?;
@@ -609,6 +649,40 @@ mod tests {
             let decoded: ResponseType = rmp_serde::from_slice(&bytes).unwrap();
             assert_eq!(&decoded, v);
         }
+    }
+
+    #[test]
+    fn f16_bytes_shape_mismatch_errs() {
+        let bytes = vec![0u8; 8]; // four f16
+        assert!(f16_bytes_to_tensor(&bytes, &[1, 5], &Device::Cpu).is_err());
+        assert!(f16_bytes_to_tensor(&bytes, &[2, 2], &Device::Cpu).is_ok());
+    }
+
+    #[cfg(feature = "mlx")]
+    #[test]
+    fn f16_bytes_to_array_shape_mismatch_errs() {
+        let bytes = vec![0u8; 8]; // four f16
+        assert!(f16_bytes_to_array(&bytes, &[1, 5]).is_err());
+        assert!(f16_bytes_to_array(&bytes, &[u32::MAX]).is_err());
+        assert!(f16_bytes_to_array(&bytes, &[7]).is_err());
+        assert_eq!(
+            f16_bytes_to_array(&bytes, &[2, 2]).unwrap().shape(),
+            &[2, 2]
+        );
+    }
+
+    #[test]
+    fn lock_recover_survives_poison() {
+        let m = std::sync::Arc::new(std::sync::Mutex::new(1u32));
+        let m2 = m.clone();
+        let _ = std::thread::spawn(move || {
+            let _g = m2.lock().unwrap();
+            panic!("poison");
+        })
+        .join();
+        assert!(m.is_poisoned());
+        *lock_recover(&m) += 1;
+        assert_eq!(*lock_recover(&m), 2);
     }
 
     #[test]

--- a/core/crates/kwaai-cli/src/cli.rs
+++ b/core/crates/kwaai-cli/src/cli.rs
@@ -821,6 +821,11 @@ pub struct ShardServeArgs {
     #[arg(long)]
     pub force_blocks: bool,
 
+    /// Serve the blocks with MLX on Apple Silicon (needs a binary built with
+    /// `--features mlx`, and its `mlx.metallib` beside it). Implies --force-blocks.
+    #[arg(long)]
+    pub mlx: bool,
+
     /// HuggingFace access token for downloading private or gated models.
     /// Can also be set via the HF_TOKEN environment variable.
     #[arg(long, value_name = "TOKEN")]

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -32,7 +32,7 @@ use tokio::sync::RwLock;
 
 use crate::block_rpc::{
     call_block_forward, f16_bytes_to_tensor, make_block_rpc_handler, token_ids_to_bytes,
-    InferenceRequest, PayloadType, ShardCell,
+    InferenceRequest, LoadedShard, PayloadType, ShardCell,
 };
 use crate::cli::{
     CircuitAction, CircuitCloseArgs, CircuitCreateArgs, ShardAction, ShardArgs, ShardChainArgs,
@@ -336,8 +336,11 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
     // (`mlx_shard.rs`) already implements sharding and failed only on graph
     // recompilation, and `llama_local.rs` wraps the same llama.cpp engine Ollama
     // uses. See `projects/kwaai-compute/plans/MacOllamaStopgap-plan.md`.
-    if cfg!(target_os = "macos") && !args.force_blocks {
+    if cfg!(target_os = "macos") && !args.force_blocks && !args.mlx {
         return serve_whole_model_via_ollama(&cfg).await;
+    }
+    if args.mlx && !cfg!(feature = "mlx") {
+        bail!("--mlx needs a binary built with `cargo build -p kwaainet --features mlx`");
     }
 
     let target_blocks = snap_to_valid_blocks(args.blocks.unwrap_or(cfg.blocks) as usize);
@@ -558,7 +561,11 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
 
     print_box_header("🧩 KwaaiNet Shard Server");
     println!("  Blocks:      [{}, {})", start_block, end_block);
-    println!("  Device:      {}", device_type);
+    if args.mlx {
+        println!("  Device:      MLX (Apple Silicon)");
+    } else {
+        println!("  Device:      {}", device_type);
+    }
     println!("  Model:       {}", cfg.model);
     println!();
     print_success(&format!(
@@ -588,6 +595,7 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
     let model_path_bg = args.model_path.clone();
     let hf_token_bg = args.hf_token.clone();
     let device_bg = device.clone();
+    let mlx_bg = args.mlx;
     let total_blocks_bg = cfg.model_total_blocks() as usize;
 
     tokio::spawn(async move {
@@ -640,8 +648,15 @@ async fn cmd_shard_serve(args: ShardServeArgs) -> Result<ShardServeExit> {
                 end_block
             ));
             let shard = Arc::new(
-                TransformerShard::load(&paths, &config_path, &device_bg, start_block, end_block)
-                    .context("Failed to load transformer shard")?,
+                load_serving_shard(
+                    &paths,
+                    &config_path,
+                    &device_bg,
+                    start_block,
+                    end_block,
+                    mlx_bg,
+                )
+                .context("Failed to load transformer shard")?,
             );
 
             print_success(&format!(
@@ -3459,6 +3474,34 @@ pub fn shard_api_port_file() -> std::path::PathBuf {
     crate::config::run_dir().join("shard_api.port")
 }
 
+/// Load the block range on the engine `shard serve` was asked for.
+fn load_serving_shard(
+    paths: &[&Path],
+    config_path: &Path,
+    device: &candle_core::Device,
+    start: usize,
+    end: usize,
+    mlx: bool,
+) -> Result<LoadedShard> {
+    #[cfg(feature = "mlx")]
+    if mlx {
+        let shard =
+            kwaai_inference::mlx_shard::MlxTransformerShard::load(paths, config_path, start, end)?;
+        return Ok(LoadedShard::Mlx(std::sync::Mutex::new(shard)));
+    }
+    #[cfg(not(feature = "mlx"))]
+    if mlx {
+        bail!("this binary was built without MLX support");
+    }
+    Ok(LoadedShard::Candle(TransformerShard::load(
+        paths,
+        config_path,
+        device,
+        start,
+        end,
+    )?))
+}
+
 /// Spawn a local TCP server on `127.0.0.1:0` that serves the same
 /// msgpack inference protocol as the p2pd handler, without going through p2pd.
 /// Returns the bound port.  Called by `cmd_shard_serve`.
@@ -3497,7 +3540,7 @@ async fn start_local_inference_server(
                 }
 
                 // Grab the shard (if loaded) without holding the lock during inference.
-                let shard_arc: Option<Arc<TransformerShard>> = {
+                let shard_arc: Option<Arc<LoadedShard>> = {
                     let guard = shard.read().await;
                     guard.as_ref().cloned()
                 };

--- a/core/crates/kwaai-cli/src/shard_cmd.rs
+++ b/core/crates/kwaai-cli/src/shard_cmd.rs
@@ -3487,7 +3487,7 @@ fn load_serving_shard(
     if mlx {
         let shard =
             kwaai_inference::mlx_shard::MlxTransformerShard::load(paths, config_path, start, end)?;
-        return Ok(LoadedShard::Mlx(std::sync::Mutex::new(shard)));
+        return Ok(LoadedShard::mlx(shard));
     }
     #[cfg(not(feature = "mlx"))]
     if mlx {

--- a/core/crates/kwaai-inference/Cargo.toml
+++ b/core/crates/kwaai-inference/Cargo.toml
@@ -46,6 +46,7 @@ harness = false
 [target.'cfg(target_os = "macos")'.dependencies]
 mlx-rs = { version = "0.25", optional = true, features = ["safetensors"] }
 safetensors = { version = "0.6", optional = true }
+memmap2 = { version = "0.9", optional = true }
 
 [features]
 default = ["cpu"]
@@ -53,4 +54,4 @@ cpu = []
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
 flash-attn = ["cuda", "candle-flash-attn"]
 metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
-mlx = ["mlx-rs", "safetensors"]
+mlx = ["mlx-rs", "safetensors", "memmap2"]

--- a/core/crates/kwaai-inference/src/lib.rs
+++ b/core/crates/kwaai-inference/src/lib.rs
@@ -40,6 +40,11 @@ pub mod tokenizer;
 #[cfg(feature = "mlx")]
 pub mod mlx_shard;
 
+/// Re-exported so downstream crates can handle MLX arrays without taking a
+/// direct mlx-rs dependency (and without it drifting from the version we link).
+#[cfg(feature = "mlx")]
+pub use mlx_rs;
+
 pub use config::EngineConfig;
 pub use engine::InferenceEngine;
 pub use error::{InferenceError, InferenceResult};

--- a/core/crates/kwaai-inference/src/mlx_shard.rs
+++ b/core/crates/kwaai-inference/src/mlx_shard.rs
@@ -10,9 +10,10 @@ use crate::tokenizer::BpeTokenizer;
 use mlx_rs::module::Module;
 use mlx_rs::ops::indexing::IndexOp;
 use mlx_rs::{nn, Array};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tracing::info;
 
@@ -23,42 +24,58 @@ fn load_err(msg: impl std::fmt::Display) -> InferenceError {
     InferenceError::ModelLoadError(msg.to_string())
 }
 
-fn load_tensor(shards: &[safetensors::SafeTensors<'_>], name: &str) -> InferenceResult<Array> {
-    for st in shards {
-        if let Ok(view) = st.tensor(name) {
-            // Convert SafeTensors data to Float16 via Rust Vec copy.
-            // Array::try_from(TensorView) creates arrays with a memory layout
-            // that causes 1000x slower matmul on Metal. Copying through from_slice
-            // ensures proper GPU-friendly contiguous layout.
-            let arr = Array::try_from(view).map_err(|e| load_err(format!("{name}: {e}")))?;
-            let arr = if arr.dtype() != mlx_rs::Dtype::Float16 {
-                arr.as_dtype(mlx_rs::Dtype::Float16)
-                    .map_err(|e| load_err(format!("{name} dtype: {e}")))?
-            } else {
-                arr
-            };
-            arr.eval()
-                .map_err(|e| load_err(format!("{name} eval: {e}")))?;
-            // Force contiguous GPU copy: convert to F32, rebuild from slice, convert back.
-            // This ensures the MLX array has proper GPU-friendly contiguous layout.
-            let f32_arr = arr
-                .as_dtype(mlx_rs::Dtype::Float32)
-                .map_err(|e| load_err(format!("{name} to_f32: {e}")))?;
-            f32_arr
-                .eval()
-                .map_err(|e| load_err(format!("{name} eval_f32: {e}")))?;
-            let shape: Vec<i32> = f32_arr.shape().to_vec();
-            let data: &[f32] = f32_arr.as_slice::<f32>();
-            let fresh = Array::from_slice::<f32>(data, &shape)
-                .as_dtype(mlx_rs::Dtype::Float16)
-                .map_err(|e| load_err(format!("{name} back_f16: {e}")))?;
-            fresh
-                .eval()
-                .map_err(|e| load_err(format!("{name} fresh_eval: {e}")))?;
-            return Ok(fresh);
-        }
+/// View little-endian bytes as `T`s in place; copies only if unaligned or big-endian.
+fn le_elems<T: Copy, const N: usize>(bytes: &[u8], from_le: fn([u8; N]) -> T) -> Cow<'_, [T]> {
+    if cfg!(target_endian = "little") && bytes.as_ptr().align_offset(std::mem::align_of::<T>()) == 0
+    {
+        // SAFETY: aligned, in bounds, and T is a plain numeric type with no invalid bit patterns.
+        let n = bytes.len() / N;
+        return Cow::Borrowed(unsafe { std::slice::from_raw_parts(bytes.as_ptr().cast(), n) });
     }
-    Err(load_err(format!("tensor '{name}' not found")))
+    Cow::Owned(
+        bytes
+            .chunks_exact(N)
+            .map(|c| from_le(c.try_into().unwrap()))
+            .collect(),
+    )
+}
+
+/// One safetensors view into a fresh, contiguous MLX f16 array.
+///
+/// The file is mmapped, so the only CPU copy is the one MLX makes from the
+/// element slice — no whole-file read and no f32 detour.
+fn load_tensor(shards: &[safetensors::SafeTensors<'_>], name: &str) -> InferenceResult<Array> {
+    let view = shards
+        .iter()
+        .find_map(|st| st.tensor(name).ok())
+        .ok_or_else(|| load_err(format!("tensor '{name}' not found")))?;
+    let shape: Vec<i32> = view
+        .shape()
+        .iter()
+        .map(|&d| i32::try_from(d).map_err(|_| load_err(format!("{name}: dim {d} exceeds i32"))))
+        .collect::<InferenceResult<_>>()?;
+    let bytes = view.data();
+    let to_f16 = |a: Array| {
+        a.as_dtype(mlx_rs::Dtype::Float16)
+            .map_err(|e| load_err(format!("{name} to f16: {e}")))
+    };
+    let arr = match view.dtype() {
+        safetensors::Dtype::F16 => {
+            Array::from_slice(&le_elems(bytes, half::f16::from_le_bytes), &shape)
+        }
+        safetensors::Dtype::BF16 => to_f16(Array::from_slice(
+            &le_elems(bytes, half::bf16::from_le_bytes),
+            &shape,
+        ))?,
+        safetensors::Dtype::F32 => to_f16(Array::from_slice(
+            &le_elems(bytes, f32::from_le_bytes),
+            &shape,
+        ))?,
+        other => return Err(load_err(format!("{name}: unsupported dtype {other:?}"))),
+    };
+    arr.eval()
+        .map_err(|e| load_err(format!("{name} eval: {e}")))?;
+    Ok(arr)
 }
 fn set_linear(
     l: &mut nn::Linear,
@@ -132,7 +149,10 @@ impl MlxAttention {
         set_linear(&mut self.k_proj, s, &format!("{p}.k_proj"))?;
         set_linear(&mut self.v_proj, s, &format!("{p}.v_proj"))?;
         set_linear(&mut self.o_proj, s, &format!("{p}.o_proj"))?;
-        // Pre-transpose and materialize — eliminates lazy .t() per forward call
+        self.pretranspose()
+    }
+    /// Pre-transpose and materialize — eliminates lazy .t() per forward call.
+    fn pretranspose(&mut self) -> InferenceResult<()> {
         self.q_wt = self.q_proj.weight.as_ref().t();
         self.q_wt.eval().map_err(load_err)?;
         self.k_wt = self.k_proj.weight.as_ref().t();
@@ -408,8 +428,28 @@ pub struct MlxTransformerShard {
     pub start_block: usize,
     pub end_block: usize,
     pub cfg: MlxShardConfig,
-    sessions: Mutex<HashMap<u64, MlxSession>>,
+    sessions: Arc<Mutex<HashMap<u64, MlxSession>>>,
 }
+
+/// Handle on a shard's session table that outlives any lock on the shard itself.
+#[derive(Clone)]
+pub struct MlxSessions(Arc<Mutex<HashMap<u64, MlxSession>>>);
+impl MlxSessions {
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<u64, MlxSession>> {
+        self.0.lock().unwrap_or_else(|p| p.into_inner())
+    }
+    /// Evict sessions idle for 10 minutes. Never contends with a forward:
+    /// `run_blocks` takes its session out of the table while it runs.
+    pub fn gc(&self) {
+        let mut s = self.lock();
+        let b = s.len();
+        s.retain(|_, v| v.last_access.elapsed().as_secs() < 600);
+        if b > s.len() {
+            info!("MLX GC: {}", b - s.len());
+        }
+    }
+}
+
 impl MlxTransformerShard {
     pub fn load(
         st_paths: &[&Path],
@@ -449,11 +489,18 @@ impl MlxTransformerShard {
             "MLX: Loading [{start}..{end}) of {}: h={} heads={}({} kv)",
             c.num_total_blocks, c.hidden_dim, c.num_heads, c.num_kv_heads
         );
-        let sd: Vec<Vec<u8>> = st_paths
+        // mmap, as candle does: a 16-block shard must not page in every file.
+        let maps: Vec<memmap2::Mmap> = st_paths
             .iter()
-            .map(|p| std::fs::read(p).map_err(load_err))
+            .map(|p| {
+                let f = std::fs::File::open(p)
+                    .map_err(|e| load_err(format!("{}: {e}", p.display())))?;
+                // SAFETY: the snapshot is read-only for the life of the mapping.
+                unsafe { memmap2::Mmap::map(&f) }
+                    .map_err(|e| load_err(format!("{}: {e}", p.display())))
+            })
             .collect::<InferenceResult<_>>()?;
-        let shards: Vec<safetensors::SafeTensors<'_>> = sd
+        let shards: Vec<safetensors::SafeTensors<'_>> = maps
             .iter()
             .map(|d| safetensors::SafeTensors::deserialize(d).map_err(load_err))
             .collect::<InferenceResult<_>>()?;
@@ -561,7 +608,7 @@ impl MlxTransformerShard {
             start_block: start,
             end_block: end,
             cfg: c,
-            sessions: Mutex::new(HashMap::new()),
+            sessions: Arc::new(Mutex::new(HashMap::new())),
         })
     }
     pub fn is_first(&self) -> bool {
@@ -570,28 +617,37 @@ impl MlxTransformerShard {
     pub fn is_last(&self) -> bool {
         self.end_block == self.cfg.num_total_blocks
     }
+    pub fn sessions(&self) -> MlxSessions {
+        MlxSessions(self.sessions.clone())
+    }
     pub fn gc_sessions(&self) {
-        let mut s = self.sessions.lock().unwrap();
-        let b = s.len();
-        s.retain(|_, v| v.last_access.elapsed().as_secs() < 600);
-        if b > s.len() {
-            info!("MLX GC: {}", b - s.len());
-        }
+        self.sessions().gc()
+    }
+    /// Take the session out of the table for the forward. A forward that fails
+    /// drops it: its KV cache is half-appended and cannot be resumed.
+    fn take_session(&self, sid: u64) -> MlxSession {
+        let mut sess = self
+            .sessions()
+            .lock()
+            .remove(&sid)
+            .unwrap_or_else(|| MlxSession::new(self.blocks.len()));
+        sess.last_access = Instant::now();
+        sess
+    }
+    fn put_session(&self, sid: u64, sess: MlxSession) {
+        self.sessions().lock().insert(sid, sess);
     }
     fn run_blocks(&mut self, mut x: Array, sp: usize, sid: u64) -> InferenceResult<Array> {
         // `compiled_block_forward` cannot read a traced scalar, so it ropes every
         // decode step at offset 0. The uncompiled path is the default;
         // KWAAINET_MLX_COMPILE=1 opts back in for A/B timing.
         if std::env::var("KWAAINET_MLX_COMPILE").as_deref() != Ok("1") {
-            let mut ss = self.sessions.lock().unwrap();
-            let sess = ss
-                .entry(sid)
-                .or_insert_with(|| MlxSession::new(self.blocks.len()));
-            sess.last_access = Instant::now();
+            let mut sess = self.take_session(sid);
             for (i, b) in self.blocks.iter_mut().enumerate() {
                 x = b.forward(&x, &mut sess.kv[i], sp)?;
             }
             x.eval().map_err(err)?;
+            self.put_session(sid, sess);
             return Ok(x);
         }
 
@@ -622,11 +678,7 @@ impl MlxTransformerShard {
             .lock()
             .unwrap();
 
-        let mut ss = self.sessions.lock().unwrap();
-        let s = ss
-            .entry(sid)
-            .or_insert_with(|| MlxSession::new(self.blocks.len()));
-        s.last_access = Instant::now();
+        let mut s = self.take_session(sid);
 
         let empty_kv = Array::from_slice::<f32>(&[0.0], &[1]);
 
@@ -657,6 +709,7 @@ impl MlxTransformerShard {
         }
 
         x.eval().map_err(err)?;
+        self.put_session(sid, s);
         Ok(x)
     }
     /// **First node**: embed token IDs, run this shard's blocks, return hidden
@@ -772,25 +825,72 @@ mod tests {
         eprintln!("[OK] raw_matmul [1,{h}]x[{inter},{h}]^T = {ms:.1}ms (expect <5ms on Metal)");
     }
 
+    /// Half-split RoPE (HF Llama / candle `RopeCache` convention) on one head vector.
+    fn rope_ref(x: &[f32], pos: usize, base: f32) -> Vec<f32> {
+        let (d, half) = (x.len(), x.len() / 2);
+        let mut out = vec![0.0; d];
+        for i in 0..half {
+            let freq = base.powf(-(2.0 * i as f32) / d as f32);
+            let (sin, cos) = (pos as f32 * freq).sin_cos();
+            out[i] = x[i] * cos - x[i + half] * sin;
+            out[i + half] = x[i] * sin + x[i + half] * cos;
+        }
+        out
+    }
+
+    /// `y = x · Wᵀ` with `w` in mlx `nn::Linear` layout `[n_out, n_in]`.
+    fn linear_ref(x: &[f32], w: &[f32], n_in: usize, n_out: usize) -> Vec<f32> {
+        let rows = x.len() / n_in;
+        let mut y = vec![0.0; rows * n_out];
+        for r in 0..rows {
+            for o in 0..n_out {
+                y[r * n_out + o] = (0..n_in).map(|i| x[r * n_in + i] * w[o * n_in + i]).sum();
+            }
+        }
+        y
+    }
+
+    fn find_model_dir() -> Option<std::path::PathBuf> {
+        if let Ok(d) = std::env::var("KWAAI_TEST_MODEL") {
+            return Some(d.into());
+        }
+        let home = dirs::home_dir()?;
+        [
+            ".cache/huggingface/models--unsloth--Llama-3.1-8B-Instruct/snapshots",
+            ".cache/huggingface/hub/models--unsloth--Llama-3.1-8B-Instruct/snapshots",
+        ]
+        .iter()
+        .map(|b| home.join(b))
+        .filter(|d| d.exists())
+        .find_map(|d| {
+            std::fs::read_dir(&d)
+                .ok()?
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .find(|p| p.join("config.json").exists())
+        })
+    }
+
     /// Bisect MLX against candle on identical weights and inputs.
     ///
     /// Both load blocks [0, 1) from the same SafeTensors file and run the same
     /// token IDs through `forward_first`, so any divergence is MLX's block math
-    /// — not the tokenizer, the sampler, the head, or the shard chain.
-    /// Ignored by default: needs the real model on disk.
+    /// — not the tokenizer, the sampler, the head, or the shard chain. A RoPE
+    /// axis fault shows as cosine falling off with position; f16 rounding does
+    /// not. Skips when the model is not on disk.
     #[test]
-    #[ignore]
     fn test_mlx_vs_candle_block0() {
-        let dir = std::path::PathBuf::from(
-            std::env::var("KWAAI_TEST_MODEL").expect("set KWAAI_TEST_MODEL to a HF snapshot dir"),
-        );
+        let Some(dir) = find_model_dir() else {
+            eprintln!("[SKIP] test_mlx_vs_candle_block0 — no model");
+            return;
+        };
         let f1 = dir.join("model-00001-of-00004.safetensors");
         let cfgp = dir.join("config.json");
         let ids: Vec<u32> = vec![128000, 3923, 374, 279, 6864];
 
         // ── raw weight load: does BF16 -> F16 survive? ───────────────────────
-        let data = std::fs::read(&f1).unwrap();
-        let st = safetensors::SafeTensors::deserialize(&data).unwrap();
+        let map = unsafe { memmap2::Mmap::map(&std::fs::File::open(&f1).unwrap()).unwrap() };
+        let st = safetensors::SafeTensors::deserialize(&map).unwrap();
         let mlx_w = super::load_tensor(&[st], "model.layers.0.self_attn.q_proj.weight").unwrap();
         let mlx_w32 = mlx_w.as_dtype(mlx_rs::Dtype::Float32).unwrap();
         mlx_w32.eval().unwrap();
@@ -811,6 +911,12 @@ mod tests {
         let cwv: Vec<f32> = cw.flatten_all().unwrap().to_vec1().unwrap()[..8].to_vec();
         println!("q_proj[0..8] mlx    = {:?}", mw);
         println!("q_proj[0..8] candle = {:?}", cwv);
+        for (a, b) in mw.iter().zip(&cwv) {
+            assert!(
+                (a - b).abs() <= 1e-3 * a.abs().max(1.0),
+                "weight load: {a} vs {b}"
+            );
+        }
 
         // ── one block through both engines ──────────────────────────────────
         let cshard = crate::TransformerShard::load(&[f1.as_path()], &cfgp, &dev, 0, 1).unwrap();
@@ -836,76 +942,147 @@ mod tests {
             mh.shape()
         );
         assert_eq!(cv.len(), mv.len(), "hidden state length mismatch");
+        assert_eq!(cv.len(), ids.len() * 4096);
 
-        let max_abs = cv
-            .iter()
-            .zip(mv.iter())
-            .map(|(a, b): (&f32, &f32)| (a - b).abs())
-            .fold(0.0f32, f32::max);
-        let dot: f32 = cv.iter().zip(&mv).map(|(a, b)| a * b).sum();
-        let na: f32 = cv.iter().map(|a| a * a).sum::<f32>().sqrt();
-        let nb: f32 = mv.iter().map(|b| b * b).sum::<f32>().sqrt();
-        println!(
-            "max_abs_diff = {max_abs:.5}   cosine = {:.6}",
-            dot / (na * nb)
-        );
-        // Per-position cosine: a RoPE fault grows with position; an f16
-        // rounding difference does not.
+        let cosine = |a: &[f32], b: &[f32]| -> f32 {
+            let d: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+            let na: f32 = a.iter().map(|v| v * v).sum::<f32>().sqrt();
+            let nb: f32 = b.iter().map(|v| v * v).sum::<f32>().sqrt();
+            d / (na * nb)
+        };
         for t in 0..ids.len() {
-            let a = &cv[t * 4096..(t + 1) * 4096];
-            let b = &mv[t * 4096..(t + 1) * 4096];
-            let d: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-            let x: f32 = a.iter().map(|v| v * v).sum::<f32>().sqrt();
-            let y: f32 = b.iter().map(|v| v * v).sum::<f32>().sqrt();
+            let (a, b) = (&cv[t * 4096..(t + 1) * 4096], &mv[t * 4096..(t + 1) * 4096]);
+            let c = cosine(a, b);
             let m = a
                 .iter()
-                .zip(b.iter())
-                .map(|(p, q): (&f32, &f32)| (p - q).abs())
+                .zip(b)
+                .map(|(p, q)| (p - q).abs())
                 .fold(0.0f32, f32::max);
-            println!("  pos {t}: cosine = {:.6}  max_abs = {m:.5}", d / (x * y));
+            println!("  pos {t}: cosine = {c:.6}  max_abs = {m:.5}");
+            assert!(c > 0.999, "pos {t}: candle/MLX cosine {c}");
         }
-        println!("candle[0..6] = {:?}", &cv[..6]);
-        println!("mlx   [0..6] = {:?}", &mv[..6]);
-        // last token's hidden state is what the next block actually consumes
-        let off = cv.len() - 4096;
-        let lmax = cv[off..]
-            .iter()
-            .zip(mv[off..].iter())
-            .map(|(a, b): (&f32, &f32)| (a - b).abs())
-            .fold(0.0f32, f32::max);
-        println!("last-token max_abs_diff = {lmax:.5}");
     }
 
-    /// Which axis does `fast::rope` treat as the sequence position?
+    /// `fast::rope` takes axis -2 as the sequence position — the fact the
+    /// attention layout in `MlxAttention::forward` rests on.
     ///
-    /// Position 0 is the identity rotation (cos 0 = 1, sin 0 = 0), so with an
-    /// all-ones input the slice that comes back unchanged marks the position
-    /// axis. Shape [1, 2, 3, 4]: if axis -2 (len 3) is the sequence, the c=0
-    /// row of every a is untouched; if axis 1 (len 2) is, the whole a=0 block is.
+    /// Every [a, c, :] row must equal the reference rotation at position c.
+    /// If the position were axis 1 the row would be rotated by a instead,
+    /// which differs wherever a != c.
     #[test]
     fn test_rope_position_axis() {
-        let x = Array::ones::<f32>(&[1, 2, 3, 4]).unwrap();
+        let xs: Vec<f32> = (0..24).map(|i| 0.5 + 0.1 * i as f32).collect();
+        let x = Array::from_slice::<f32>(&xs, &[1, 2, 3, 4]);
         let r = mlx_rs::fast::rope(&x, 4, false, Some(10000.0), 1.0, 0, None).unwrap();
         r.eval().unwrap();
         let v = r.as_slice::<f32>();
-        let at = |a: usize, c: usize| -> Vec<f32> {
-            let base = (a * 3 + c) * 4;
-            v[base..base + 4].to_vec()
-        };
+        let mut differs = 0;
         for a in 0..2 {
             for c in 0..3 {
-                println!("a={a} c={c} -> {:?}", at(a, c));
+                let base = (a * 3 + c) * 4;
+                let got = &v[base..base + 4];
+                let want = rope_ref(&xs[base..base + 4], c, 10000.0);
+                let wrong = rope_ref(&xs[base..base + 4], a, 10000.0);
+                for i in 0..4 {
+                    assert!(
+                        (got[i] - want[i]).abs() < 1e-4,
+                        "a={a} c={c}: {got:?} vs {want:?}"
+                    );
+                }
+                if got.iter().zip(&wrong).any(|(g, w)| (g - w).abs() > 1e-3) {
+                    differs += 1;
+                }
             }
         }
-        let unchanged = |w: &[f32]| w.iter().all(|&z| (z - 1.0).abs() < 1e-3);
-        println!(
-            "axis -2 is sequence: {}",
-            unchanged(&at(0, 0)) && unchanged(&at(1, 0)) && !unchanged(&at(0, 1))
+        assert!(differs >= 4, "rows rotated by axis 1 would look the same");
+    }
+
+    /// One attention layer against a scalar reference: q/k/v projections,
+    /// half-split RoPE at the *token* position, causal softmax, GQA, o_proj.
+    /// Rotating before the [0,2,1,3] transpose (the pre-fix layout) ropes each
+    /// token by its head index and fails here at every position past 0.
+    #[test]
+    fn test_attention_matches_reference() {
+        let (hid, nh, nkv, hd, seq) = (8usize, 2usize, 1usize, 4usize, 3usize);
+        let cfg = super::MlxShardConfig {
+            num_total_blocks: 1,
+            hidden_dim: hid,
+            num_heads: nh,
+            num_kv_heads: nkv,
+            head_dim: hd,
+            intermediate_dim: 16,
+            vocab_size: 16,
+            rope_theta: 10000.0,
+            rms_norm_eps: 1e-5,
+        };
+        let w = |n_out: usize, n_in: usize, seed: usize| -> Vec<f32> {
+            (0..n_out * n_in)
+                .map(|i| ((i * 7 + seed * 3) % 11) as f32 / 11.0 - 0.5)
+                .collect()
+        };
+        let (wq, wk, wv, wo) = (
+            w(hid, hid, 1),
+            w(nkv * hd, hid, 2),
+            w(nkv * hd, hid, 3),
+            w(hid, hid, 4),
         );
-        println!(
-            "axis  1 is sequence: {}",
-            unchanged(&at(0, 0)) && unchanged(&at(0, 1)) && !unchanged(&at(1, 0))
-        );
+        let xs: Vec<f32> = (0..seq * hid)
+            .map(|i| ((i * 5) % 7) as f32 / 7.0 - 0.3)
+            .collect();
+
+        let mut attn = super::MlxAttention::new(&cfg).unwrap();
+        *attn.q_proj.weight = Array::from_slice(&wq, &[hid as i32, hid as i32]);
+        *attn.k_proj.weight = Array::from_slice(&wk, &[(nkv * hd) as i32, hid as i32]);
+        *attn.v_proj.weight = Array::from_slice(&wv, &[(nkv * hd) as i32, hid as i32]);
+        *attn.o_proj.weight = Array::from_slice(&wo, &[hid as i32, hid as i32]);
+        attn.pretranspose().unwrap();
+        let x = Array::from_slice(&xs, &[1, seq as i32, hid as i32]);
+        let mut kv = None;
+        let y = attn.forward(&x, &mut kv, 0).unwrap();
+        y.eval().unwrap();
+        let got = y.as_slice::<f32>();
+
+        // reference
+        let q = linear_ref(&xs, &wq, hid, hid);
+        let k = linear_ref(&xs, &wk, hid, nkv * hd);
+        let v = linear_ref(&xs, &wv, hid, nkv * hd);
+        let scale = (hd as f32).sqrt().recip();
+        let mut ao = vec![0.0f32; seq * hid];
+        for t in 0..seq {
+            for h in 0..nh {
+                let g = h / (nh / nkv);
+                let qr = rope_ref(&q[t * hid + h * hd..t * hid + (h + 1) * hd], t, 10000.0);
+                let kr: Vec<Vec<f32>> = (0..=t)
+                    .map(|j| {
+                        rope_ref(
+                            &k[j * nkv * hd + g * hd..j * nkv * hd + (g + 1) * hd],
+                            j,
+                            10000.0,
+                        )
+                    })
+                    .collect();
+                let sc: Vec<f32> = kr
+                    .iter()
+                    .map(|kj| qr.iter().zip(kj).map(|(a, b)| a * b).sum::<f32>() * scale)
+                    .collect();
+                let mx = sc.iter().cloned().fold(f32::MIN, f32::max);
+                let ex: Vec<f32> = sc.iter().map(|s| (s - mx).exp()).collect();
+                let z: f32 = ex.iter().sum();
+                for (j, e) in ex.iter().enumerate() {
+                    for d in 0..hd {
+                        ao[t * hid + h * hd + d] += e / z * v[j * nkv * hd + g * hd + d];
+                    }
+                }
+            }
+        }
+        let want = linear_ref(&ao, &wo, hid, hid);
+        assert_eq!(got.len(), want.len());
+        for t in 0..seq {
+            let (g, w) = (&got[t * hid..(t + 1) * hid], &want[t * hid..(t + 1) * hid]);
+            for i in 0..hid {
+                assert!((g[i] - w[i]).abs() < 1e-3, "pos {t}: {g:?} vs {w:?}");
+            }
+        }
     }
 
     #[test]

--- a/core/crates/kwaai-inference/src/mlx_shard.rs
+++ b/core/crates/kwaai-inference/src/mlx_shard.rs
@@ -7,7 +7,7 @@
 
 use crate::error::{InferenceError, InferenceResult};
 use crate::tokenizer::BpeTokenizer;
-use mlx_rs::module::{Module, Param};
+use mlx_rs::module::Module;
 use mlx_rs::ops::indexing::IndexOp;
 use mlx_rs::{nn, Array};
 use std::collections::HashMap;
@@ -21,9 +21,6 @@ fn err(msg: impl std::fmt::Display) -> InferenceError {
 }
 fn load_err(msg: impl std::fmt::Display) -> InferenceError {
     InferenceError::ModelLoadError(msg.to_string())
-}
-fn scalar(v: f32) -> Array {
-    Array::from_slice::<f32>(&[v], &[1])
 }
 
 fn load_tensor(shards: &[safetensors::SafeTensors<'_>], name: &str) -> InferenceResult<Array> {
@@ -71,15 +68,6 @@ fn set_linear(
     *l.weight = load_tensor(s, &format!("{p}.weight"))?; // eval'd + F16 by load_tensor
     Ok(())
 }
-
-/// Quantize a Linear layer in-place to 4-bit (reduces memory 4x, faster matmul).
-fn quantize_linear(l: &mut nn::Linear) -> InferenceResult<()> {
-    // nn::quantize converts Linear → QuantizedLinear internally.
-    // For now we just ensure weights are Float16 — full quantization
-    // requires replacing Linear with QuantizedLinear throughout.
-    // TODO: Replace nn::Linear with nn::QuantizedLinear for 4-bit inference.
-    Ok(())
-}
 fn set_rms(
     n: &mut nn::RmsNorm,
     s: &[safetensors::SafeTensors<'_>],
@@ -101,11 +89,6 @@ pub struct MlxShardConfig {
     pub rope_theta: f64,
     pub rms_norm_eps: f64,
 }
-impl MlxShardConfig {
-    fn n_rep(&self) -> usize {
-        self.num_heads / self.num_kv_heads
-    }
-}
 
 struct MlxAttention {
     q_proj: nn::Linear,
@@ -121,16 +104,15 @@ struct MlxAttention {
     n_heads: i32,
     n_kv_heads: i32,
     head_dim: i32,
-    n_rep: usize,
 }
 impl MlxAttention {
     fn new(c: &MlxShardConfig) -> InferenceResult<Self> {
         let (h, kv) = (c.hidden_dim as i32, (c.num_kv_heads * c.head_dim) as i32);
         Ok(Self {
-            q_proj: nn::Linear::new(h, h).map_err(|e| load_err(e))?,
-            k_proj: nn::Linear::new(h, kv).map_err(|e| load_err(e))?,
-            v_proj: nn::Linear::new(h, kv).map_err(|e| load_err(e))?,
-            o_proj: nn::Linear::new(h, h).map_err(|e| load_err(e))?,
+            q_proj: nn::Linear::new(h, h).map_err(load_err)?,
+            k_proj: nn::Linear::new(h, kv).map_err(load_err)?,
+            v_proj: nn::Linear::new(h, kv).map_err(load_err)?,
+            o_proj: nn::Linear::new(h, h).map_err(load_err)?,
             rope: {
                 let mut r = nn::Rope::new(c.head_dim as i32);
                 r.base = c.rope_theta as f32;
@@ -143,7 +125,6 @@ impl MlxAttention {
             n_heads: c.num_heads as i32,
             n_kv_heads: c.num_kv_heads as i32,
             head_dim: c.head_dim as i32,
-            n_rep: c.n_rep(),
         })
     }
     fn load_w(&mut self, s: &[safetensors::SafeTensors<'_>], p: &str) -> InferenceResult<()> {
@@ -153,13 +134,13 @@ impl MlxAttention {
         set_linear(&mut self.o_proj, s, &format!("{p}.o_proj"))?;
         // Pre-transpose and materialize — eliminates lazy .t() per forward call
         self.q_wt = self.q_proj.weight.as_ref().t();
-        self.q_wt.eval().map_err(|e| load_err(e))?;
+        self.q_wt.eval().map_err(load_err)?;
         self.k_wt = self.k_proj.weight.as_ref().t();
-        self.k_wt.eval().map_err(|e| load_err(e))?;
+        self.k_wt.eval().map_err(load_err)?;
         self.v_wt = self.v_proj.weight.as_ref().t();
-        self.v_wt.eval().map_err(|e| load_err(e))?;
+        self.v_wt.eval().map_err(load_err)?;
         self.o_wt = self.o_proj.weight.as_ref().t();
-        self.o_wt.eval().map_err(|e| load_err(e))?;
+        self.o_wt.eval().map_err(load_err)?;
         Ok(())
     }
     fn forward(
@@ -171,20 +152,29 @@ impl MlxAttention {
         let (b, s) = (x.shape()[0], x.shape()[1]);
 
         // QKV projections using pre-transposed weights
-        let q = x.matmul(&self.q_wt).map_err(|e| err(e))?;
-        let k = x.matmul(&self.k_wt).map_err(|e| err(e))?;
-        let v = x.matmul(&self.v_wt).map_err(|e| err(e))?;
+        let q = x.matmul(&self.q_wt).map_err(err)?;
+        let k = x.matmul(&self.k_wt).map_err(err)?;
+        let v = x.matmul(&self.v_wt).map_err(err)?;
 
         // Reshape to [b, seq, n_heads, head_dim]
         let q = q
             .reshape(&[b, s, self.n_heads, self.head_dim])
-            .map_err(|e| err(e))?;
+            .map_err(err)?;
         let k = k
             .reshape(&[b, s, self.n_kv_heads, self.head_dim])
-            .map_err(|e| err(e))?;
+            .map_err(err)?;
         let v = v
             .reshape(&[b, s, self.n_kv_heads, self.head_dim])
-            .map_err(|e| err(e))?;
+            .map_err(err)?;
+
+        // Attention runs on [b, heads, seq, head_dim] — and so must RoPE.
+        // `fast::rope` takes the *second-to-last* axis as the sequence position
+        // (see `test_rope_position_axis`), so rotating the [b, seq, heads, dim]
+        // layout encodes every token by its head index instead of its position:
+        // plausible-looking logits, wrong answer. Transpose first, then rotate.
+        let q = q.transpose_axes(&[0, 2, 1, 3]).map_err(err)?;
+        let k = k.transpose_axes(&[0, 2, 1, 3]).map_err(err)?;
+        let v = v.transpose_axes(&[0, 2, 1, 3]).map_err(err)?;
 
         // fast::rope — optimized Metal kernel
         let q = mlx_rs::fast::rope(
@@ -196,7 +186,7 @@ impl MlxAttention {
             sp as i32,
             None,
         )
-        .map_err(|e| err(e))?;
+        .map_err(err)?;
         let k = mlx_rs::fast::rope(
             &k,
             self.head_dim,
@@ -206,23 +196,18 @@ impl MlxAttention {
             sp as i32,
             None,
         )
-        .map_err(|e| err(e))?;
+        .map_err(err)?;
 
-        // KV-cache append
+        // KV-cache append — the sequence is axis 2 in this layout, not axis 1.
         let (k, v): (Array, Array) = if let Some((ck, cv)) = kv.take() {
             (
-                mlx_rs::ops::concatenate_axis(&[&ck, &k], 1).map_err(|e| err(e))?,
-                mlx_rs::ops::concatenate_axis(&[&cv, &v], 1).map_err(|e| err(e))?,
+                mlx_rs::ops::concatenate_axis(&[&ck, &k], 2).map_err(err)?,
+                mlx_rs::ops::concatenate_axis(&[&cv, &v], 2).map_err(err)?,
             )
         } else {
             (k, v)
         };
         *kv = Some((k.clone(), v.clone()));
-
-        // Transpose to [b, heads, seq, head_dim] for attention
-        let q = q.transpose_axes(&[0, 2, 1, 3]).map_err(|e| err(e))?;
-        let k = k.transpose_axes(&[0, 2, 1, 3]).map_err(|e| err(e))?;
-        let v = v.transpose_axes(&[0, 2, 1, 3]).map_err(|e| err(e))?;
 
         // fast::scaled_dot_product_attention — fused Metal kernel
         // Handles GQA (different Q vs KV head counts) internally
@@ -232,30 +217,19 @@ impl MlxAttention {
         } else {
             None
         };
-        let ao = mlx_rs::fast::scaled_dot_product_attention(&q, &k, &v, scale, mask)
-            .map_err(|e| err(e))?;
+        let ao =
+            mlx_rs::fast::scaled_dot_product_attention(&q, &k, &v, scale, mask).map_err(err)?;
 
         // Merge heads → [b, seq, hidden]
         let ao = ao
             .transpose_axes(&[0, 2, 1, 3])
-            .map_err(|e| err(e))?
+            .map_err(err)?
             .reshape(&[b, s, self.n_heads * self.head_dim])
-            .map_err(|e| err(e))?;
+            .map_err(err)?;
 
         // Output projection
-        ao.matmul(&self.o_wt).map_err(|e| err(e))
+        ao.matmul(&self.o_wt).map_err(err)
     }
-}
-fn repeat_kv(x: &Array, n: usize) -> InferenceResult<Array> {
-    let s = x.shape();
-    let (b, nk, sq, hd) = (s[0], s[1], s[2], s[3]);
-    mlx_rs::ops::tile(
-        &x.reshape(&[b, nk, 1, sq, hd]).map_err(|e| err(e))?,
-        &[1, 1, n as i32, 1, 1],
-    )
-    .map_err(|e| err(e))?
-    .reshape(&[b, nk * n as i32, sq, hd])
-    .map_err(|e| err(e))
 }
 
 struct MlxBlock {
@@ -274,19 +248,19 @@ impl MlxBlock {
         let (h, i) = (c.hidden_dim as i32, c.intermediate_dim as i32);
         Ok(Self {
             in_n: {
-                let mut n = nn::RmsNorm::new(h).map_err(|e| load_err(e))?;
+                let mut n = nn::RmsNorm::new(h).map_err(load_err)?;
                 n.eps = c.rms_norm_eps as f32;
                 n
             },
             attn: MlxAttention::new(c)?,
             post_n: {
-                let mut n = nn::RmsNorm::new(h).map_err(|e| load_err(e))?;
+                let mut n = nn::RmsNorm::new(h).map_err(load_err)?;
                 n.eps = c.rms_norm_eps as f32;
                 n
             },
-            gate: nn::Linear::new(h, i).map_err(|e| load_err(e))?,
-            up: nn::Linear::new(h, i).map_err(|e| load_err(e))?,
-            down: nn::Linear::new(i, h).map_err(|e| load_err(e))?,
+            gate: nn::Linear::new(h, i).map_err(load_err)?,
+            up: nn::Linear::new(h, i).map_err(load_err)?,
+            down: nn::Linear::new(i, h).map_err(load_err)?,
             gate_wt: Array::from_slice::<f32>(&[0.0], &[1]),
             up_wt: Array::from_slice::<f32>(&[0.0], &[1]),
             down_wt: Array::from_slice::<f32>(&[0.0], &[1]),
@@ -305,11 +279,11 @@ impl MlxBlock {
         set_linear(&mut self.up, s, &format!("{p}.mlp.up_proj"))?;
         set_linear(&mut self.down, s, &format!("{p}.mlp.down_proj"))?;
         self.gate_wt = self.gate.weight.as_ref().t();
-        self.gate_wt.eval().map_err(|e| load_err(e))?;
+        self.gate_wt.eval().map_err(load_err)?;
         self.up_wt = self.up.weight.as_ref().t();
-        self.up_wt.eval().map_err(|e| load_err(e))?;
+        self.up_wt.eval().map_err(load_err)?;
         self.down_wt = self.down.weight.as_ref().t();
-        self.down_wt.eval().map_err(|e| load_err(e))?;
+        self.down_wt.eval().map_err(load_err)?;
         Ok(())
     }
     fn forward(
@@ -319,19 +293,18 @@ impl MlxBlock {
         sp: usize,
     ) -> InferenceResult<Array> {
         // fast::rms_norm — optimized Metal kernel
-        let n = mlx_rs::fast::rms_norm(x, self.in_n.weight.as_ref(), self.in_n.eps)
-            .map_err(|e| err(e))?;
+        let n = mlx_rs::fast::rms_norm(x, self.in_n.weight.as_ref(), self.in_n.eps).map_err(err)?;
         let a = self.attn.forward(&n, kv, sp)?;
-        let x = x.add(&a).map_err(|e| err(e))?;
+        let x = x.add(&a).map_err(err)?;
         let n = mlx_rs::fast::rms_norm(&x, self.post_n.weight.as_ref(), self.post_n.eps)
-            .map_err(|e| err(e))?;
+            .map_err(err)?;
         // SwiGLU MLP with pre-transposed weights
-        let g = nn::silu(&n.matmul(&self.gate_wt).map_err(|e| err(e))?).map_err(|e| err(e))?;
+        let g = nn::silu(&n.matmul(&self.gate_wt).map_err(err)?).map_err(err)?;
         let f = g
-            .multiply(&n.matmul(&self.up_wt).map_err(|e| err(e))?)
-            .map_err(|e| err(e))?;
-        let f = f.matmul(&self.down_wt).map_err(|e| err(e))?;
-        x.add(&f).map_err(|e| err(e))
+            .multiply(&n.matmul(&self.up_wt).map_err(err)?)
+            .map_err(err)?;
+        let f = f.matmul(&self.down_wt).map_err(err)?;
+        x.add(&f).map_err(err)
     }
 }
 
@@ -430,7 +403,6 @@ pub struct MlxTransformerShard {
     embedding: Option<nn::Embedding>,
     blocks: Vec<MlxBlock>,
     norm: Option<nn::RmsNorm>,
-    lm_head: Option<nn::Linear>,
     lm_head_wt: Option<Array>,
     pub tokenizer: BpeTokenizer,
     pub start_block: usize,
@@ -460,9 +432,8 @@ impl MlxTransformerShard {
         fn dtheta() -> f64 {
             10000.0
         }
-        let hf: Hf =
-            serde_json::from_str(&std::fs::read_to_string(cfg_path).map_err(|e| load_err(e))?)
-                .map_err(|e| load_err(e))?;
+        let hf: Hf = serde_json::from_str(&std::fs::read_to_string(cfg_path).map_err(load_err)?)
+            .map_err(load_err)?;
         let c = MlxShardConfig {
             num_total_blocks: hf.num_hidden_layers,
             hidden_dim: hf.hidden_size,
@@ -480,17 +451,17 @@ impl MlxTransformerShard {
         );
         let sd: Vec<Vec<u8>> = st_paths
             .iter()
-            .map(|p| std::fs::read(p).map_err(|e| load_err(e)))
+            .map(|p| std::fs::read(p).map_err(load_err))
             .collect::<InferenceResult<_>>()?;
         let shards: Vec<safetensors::SafeTensors<'_>> = sd
             .iter()
-            .map(|d| safetensors::SafeTensors::deserialize(d).map_err(|e| load_err(e)))
+            .map(|d| safetensors::SafeTensors::deserialize(d).map_err(load_err))
             .collect::<InferenceResult<_>>()?;
         let (is_f, is_l) = (start == 0, end == c.num_total_blocks);
         let embedding = if is_f {
             info!("  MLX: embedding");
-            let mut e = nn::Embedding::new(c.vocab_size as i32, c.hidden_dim as i32)
-                .map_err(|e| load_err(e))?;
+            let mut e =
+                nn::Embedding::new(c.vocab_size as i32, c.hidden_dim as i32).map_err(load_err)?;
             *e.weight = load_tensor(&shards, "model.embed_tokens.weight")?;
             Some(e)
         } else {
@@ -503,22 +474,22 @@ impl MlxTransformerShard {
             b.load_w(&shards, i)?;
             blocks.push(b);
         }
-        let (norm, lm_head, lm_head_wt) = if is_l {
+        let (norm, lm_head_wt) = if is_l {
             info!("  MLX: norm+lm_head");
             let mut n = {
-                let mut x = nn::RmsNorm::new(c.hidden_dim as i32).map_err(|e| load_err(e))?;
+                let mut x = nn::RmsNorm::new(c.hidden_dim as i32).map_err(load_err)?;
                 x.eps = c.rms_norm_eps as f32;
                 x
             };
             set_rms(&mut n, &shards, "model.norm")?;
-            let mut l = nn::Linear::new(c.hidden_dim as i32, c.vocab_size as i32)
-                .map_err(|e| load_err(e))?;
+            let mut l =
+                nn::Linear::new(c.hidden_dim as i32, c.vocab_size as i32).map_err(load_err)?;
             set_linear(&mut l, &shards, "lm_head")?;
             let lwt = l.weight.as_ref().t();
-            lwt.eval().map_err(|e| load_err(e))?;
-            (Some(n), Some(l), Some(lwt))
+            lwt.eval().map_err(load_err)?;
+            (Some(n), Some(lwt))
         } else {
-            (None, None, None)
+            (None, None)
         };
         let tok = BpeTokenizer::from_file(
             &cfg_path
@@ -542,9 +513,9 @@ impl MlxTransformerShard {
             let test_data = vec![1.0f32; c.hidden_dim];
             let test_in = Array::from_slice::<f32>(&test_data, &[1, c.hidden_dim as i32])
                 .as_dtype(mlx_rs::Dtype::Float16)
-                .map_err(|e| load_err(e))?;
+                .map_err(load_err)?;
             let t = Instant::now();
-            let _ = blocks[0].gate.forward(&test_in).map_err(|e| load_err(e))?;
+            let _ = blocks[0].gate.forward(&test_in).map_err(load_err)?;
             let _ = test_in.eval();
             info!(
                 "MLX: test matmul [{},{}] took {:.1}ms",
@@ -564,17 +535,14 @@ impl MlxTransformerShard {
             let test_data = vec![1.0f32; c.hidden_dim];
             let x = Array::from_slice::<f32>(&test_data, &[1, c.hidden_dim as i32])
                 .as_dtype(mlx_rs::Dtype::Float16)
-                .map_err(|e| load_err(e))?;
+                .map_err(load_err)?;
             // Warm up
-            let wt = w
-                .as_ref()
-                .transpose_axes(&[1, 0])
-                .map_err(|e| load_err(e))?;
-            let _ = x.matmul(&wt).map_err(|e| load_err(e))?.eval();
+            let wt = w.as_ref().transpose_axes(&[1, 0]).map_err(load_err)?;
+            let _ = x.matmul(&wt).map_err(load_err)?.eval();
             // Timed
             let t = Instant::now();
-            let y = x.matmul(&wt).map_err(|e| load_err(e))?;
-            y.eval().map_err(|e| load_err(e))?;
+            let y = x.matmul(&wt).map_err(load_err)?;
+            y.eval().map_err(load_err)?;
             eprintln!(
                 "[DIAG] model weight matmul: {:.1}ms",
                 t.elapsed().as_secs_f64() * 1e3
@@ -582,12 +550,12 @@ impl MlxTransformerShard {
         }
         // Enable MLX global compilation — caches compiled graphs automatically
         mlx_rs::transforms::compile::enable_compile();
-        info!("MLX: Shard [{start}..{end}) ready — emb={is_f} head={is_l} (compile enabled)");
+        let compiled = std::env::var("KWAAINET_MLX_COMPILE").as_deref() == Ok("1");
+        info!("MLX: Shard [{start}..{end}) ready — emb={is_f} head={is_l} compiled={compiled}");
         Ok(Self {
             embedding,
             blocks,
             norm,
-            lm_head,
             lm_head_wt,
             tokenizer: tok,
             start_block: start,
@@ -611,6 +579,22 @@ impl MlxTransformerShard {
         }
     }
     fn run_blocks(&mut self, mut x: Array, sp: usize, sid: u64) -> InferenceResult<Array> {
+        // `compiled_block_forward` cannot read a traced scalar, so it ropes every
+        // decode step at offset 0. The uncompiled path is the default;
+        // KWAAINET_MLX_COMPILE=1 opts back in for A/B timing.
+        if std::env::var("KWAAINET_MLX_COMPILE").as_deref() != Ok("1") {
+            let mut ss = self.sessions.lock().unwrap();
+            let sess = ss
+                .entry(sid)
+                .or_insert_with(|| MlxSession::new(self.blocks.len()));
+            sess.last_access = Instant::now();
+            for (i, b) in self.blocks.iter_mut().enumerate() {
+                x = b.forward(&x, &mut sess.kv[i], sp)?;
+            }
+            x.eval().map_err(err)?;
+            return Ok(x);
+        }
+
         // Set global config (once) for the compiled function
         BLOCK_CFG.get_or_init(|| {
             let b = &self.blocks[0];
@@ -624,17 +608,19 @@ impl MlxTransformerShard {
         });
 
         // Create compiled forward (cached after first compilation)
-        static INIT: std::sync::Once = std::sync::Once::new();
-        static mut COMPILED_FN: Option<
-            Box<dyn FnMut(&[Array]) -> Result<Vec<Array>, mlx_rs::error::Exception> + Send>,
-        > = None;
-        INIT.call_once(|| {
-            // shapeless=true: don't recompile when input shapes change (KV-cache grows each token)
-            let f = mlx_rs::transforms::compile::compile(compiled_block_forward, Some(true));
-            unsafe {
-                COMPILED_FN = Some(Box::new(f));
-            }
-        });
+        type CompiledFn =
+            Box<dyn FnMut(&[Array]) -> Result<Vec<Array>, mlx_rs::error::Exception> + Send>;
+        static COMPILED_FN: std::sync::OnceLock<Mutex<CompiledFn>> = std::sync::OnceLock::new();
+        // shapeless=true: don't recompile when input shapes change (KV-cache grows each token)
+        let mut compiled = COMPILED_FN
+            .get_or_init(|| {
+                Mutex::new(Box::new(mlx_rs::transforms::compile::compile(
+                    compiled_block_forward,
+                    Some(true),
+                )))
+            })
+            .lock()
+            .unwrap();
 
         let mut ss = self.sessions.lock().unwrap();
         let s = ss
@@ -664,21 +650,65 @@ impl MlxTransformerShard {
                 b.down_wt.clone(),
             ];
 
-            let out = unsafe { COMPILED_FN.as_mut().unwrap()(&inputs).map_err(|e| err(e))? };
+            let out = compiled(&inputs).map_err(err)?;
 
             x = out[0].clone();
             s.kv[i] = Some((out[1].clone(), out[2].clone()));
         }
 
-        x.eval().map_err(|e| err(e))?;
+        x.eval().map_err(err)?;
         Ok(x)
     }
+    /// **First node**: embed token IDs, run this shard's blocks, return hidden
+    /// states `[1, seq_len, hidden_dim]`.
+    ///
+    /// Mirrors [`crate::TransformerShard::forward_first`] so a shard chain can
+    /// mix Candle and MLX nodes.
+    pub fn forward_first(&mut self, sid: u64, tids: &[u32], sp: usize) -> InferenceResult<Array> {
+        let emb = self.embedding.as_mut().ok_or_else(|| {
+            err("forward_first() called on a shard that does not hold the embedding (start_block != 0)")
+        })?;
+        let ids: Vec<i32> = tids.iter().map(|&i| i as i32).collect();
+        let tok = Array::from_slice::<i32>(&ids, &[1, ids.len() as i32]);
+        let h = emb.forward(&tok).map_err(err)?;
+        self.run_blocks(h, sp, sid)
+    }
+
+    /// **Middle node**: hidden states in, this shard's blocks, hidden states out.
+    pub fn forward_middle(&mut self, sid: u64, hidden: Array, sp: usize) -> InferenceResult<Array> {
+        self.run_blocks(hidden, sp, sid)
+    }
+
+    /// **Last node**: hidden states in, run blocks, final RMSNorm + LM head,
+    /// logits `[1, 1, vocab_size]` out.
+    pub fn forward_last(&mut self, sid: u64, hidden: Array, sp: usize) -> InferenceResult<Array> {
+        let x = self.run_blocks(hidden, sp, sid)?;
+        let norm = self
+            .norm
+            .as_ref()
+            .ok_or_else(|| err("forward_last() called on a shard that is not the last node"))?;
+        let lm_wt = self
+            .lm_head_wt
+            .as_ref()
+            .ok_or_else(|| err("no lm_head_wt"))?;
+        let s = x.shape()[1];
+        let xl = if s > 1 {
+            x.index((.., (s - 1).., ..))
+        } else {
+            x
+        };
+        let xl = mlx_rs::fast::rms_norm(&xl, norm.weight.as_ref(), norm.eps).map_err(err)?;
+        let logits = xl.matmul(lm_wt).map_err(err)?;
+        logits.eval().map_err(err)?;
+        Ok(logits)
+    }
+
     pub fn forward_full(&mut self, sid: u64, tids: &[u32], sp: usize) -> InferenceResult<Array> {
         let emb = self.embedding.as_mut().ok_or_else(|| err("no emb"))?;
         let t0 = Instant::now();
         let ids: Vec<i32> = tids.iter().map(|&i| i as i32).collect();
         let tok = Array::from_slice::<i32>(&ids, &[1, ids.len() as i32]);
-        let h = emb.forward(&tok).map_err(|e| err(e))?;
+        let h = emb.forward(&tok).map_err(err)?;
         let te = t0.elapsed();
         let t1 = Instant::now();
         let x = self.run_blocks(h, sp, sid)?;
@@ -695,9 +725,9 @@ impl MlxTransformerShard {
         } else {
             x
         };
-        let xl = mlx_rs::fast::rms_norm(&xl, norm.weight.as_ref(), norm.eps).map_err(|e| err(e))?;
-        let logits = xl.matmul(lm_wt).map_err(|e| err(e))?;
-        logits.eval().map_err(|e| err(e))?;
+        let xl = mlx_rs::fast::rms_norm(&xl, norm.weight.as_ref(), norm.eps).map_err(err)?;
+        let logits = xl.matmul(lm_wt).map_err(err)?;
+        logits.eval().map_err(err)?;
         let th = t2.elapsed();
         eprintln!("[PERF-MLX] forward_full: {} tok, embed={:.1}ms blocks={:.0}ms head={:.1}ms total={:.0}ms",
             tids.len(), te.as_secs_f64()*1e3, tb.as_secs_f64()*1e3, th.as_secs_f64()*1e3, t0.elapsed().as_secs_f64()*1e3);
@@ -742,6 +772,142 @@ mod tests {
         eprintln!("[OK] raw_matmul [1,{h}]x[{inter},{h}]^T = {ms:.1}ms (expect <5ms on Metal)");
     }
 
+    /// Bisect MLX against candle on identical weights and inputs.
+    ///
+    /// Both load blocks [0, 1) from the same SafeTensors file and run the same
+    /// token IDs through `forward_first`, so any divergence is MLX's block math
+    /// — not the tokenizer, the sampler, the head, or the shard chain.
+    /// Ignored by default: needs the real model on disk.
+    #[test]
+    #[ignore]
+    fn test_mlx_vs_candle_block0() {
+        let dir = std::path::PathBuf::from(
+            std::env::var("KWAAI_TEST_MODEL").expect("set KWAAI_TEST_MODEL to a HF snapshot dir"),
+        );
+        let f1 = dir.join("model-00001-of-00004.safetensors");
+        let cfgp = dir.join("config.json");
+        let ids: Vec<u32> = vec![128000, 3923, 374, 279, 6864];
+
+        // ── raw weight load: does BF16 -> F16 survive? ───────────────────────
+        let data = std::fs::read(&f1).unwrap();
+        let st = safetensors::SafeTensors::deserialize(&data).unwrap();
+        let mlx_w = super::load_tensor(&[st], "model.layers.0.self_attn.q_proj.weight").unwrap();
+        let mlx_w32 = mlx_w.as_dtype(mlx_rs::Dtype::Float32).unwrap();
+        mlx_w32.eval().unwrap();
+        let mw: Vec<f32> = mlx_w32.as_slice::<f32>()[..8].to_vec();
+
+        let dev = candle_core::Device::Cpu;
+        let vb = unsafe {
+            candle_nn::VarBuilder::from_mmaped_safetensors(
+                std::slice::from_ref(&f1),
+                candle_core::DType::F32,
+                &dev,
+            )
+            .unwrap()
+        };
+        let cw = vb
+            .get((4096, 4096), "model.layers.0.self_attn.q_proj.weight")
+            .unwrap();
+        let cwv: Vec<f32> = cw.flatten_all().unwrap().to_vec1().unwrap()[..8].to_vec();
+        println!("q_proj[0..8] mlx    = {:?}", mw);
+        println!("q_proj[0..8] candle = {:?}", cwv);
+
+        // ── one block through both engines ──────────────────────────────────
+        let cshard = crate::TransformerShard::load(&[f1.as_path()], &cfgp, &dev, 0, 1).unwrap();
+        let mut mshard = super::MlxTransformerShard::load(&[f1.as_path()], &cfgp, 0, 1).unwrap();
+
+        let ch = cshard.forward_first(1, &ids, 0).unwrap();
+        let cv: Vec<f32> = ch
+            .to_dtype(candle_core::DType::F32)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1()
+            .unwrap();
+
+        let mh = mshard.forward_first(1, &ids, 0).unwrap();
+        let mh32 = mh.as_dtype(mlx_rs::Dtype::Float32).unwrap();
+        mh32.eval().unwrap();
+        let mv: Vec<f32> = mh32.as_slice::<f32>().to_vec();
+
+        println!(
+            "candle hidden shape {:?}  mlx shape {:?}",
+            ch.dims(),
+            mh.shape()
+        );
+        assert_eq!(cv.len(), mv.len(), "hidden state length mismatch");
+
+        let max_abs = cv
+            .iter()
+            .zip(mv.iter())
+            .map(|(a, b): (&f32, &f32)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        let dot: f32 = cv.iter().zip(&mv).map(|(a, b)| a * b).sum();
+        let na: f32 = cv.iter().map(|a| a * a).sum::<f32>().sqrt();
+        let nb: f32 = mv.iter().map(|b| b * b).sum::<f32>().sqrt();
+        println!(
+            "max_abs_diff = {max_abs:.5}   cosine = {:.6}",
+            dot / (na * nb)
+        );
+        // Per-position cosine: a RoPE fault grows with position; an f16
+        // rounding difference does not.
+        for t in 0..ids.len() {
+            let a = &cv[t * 4096..(t + 1) * 4096];
+            let b = &mv[t * 4096..(t + 1) * 4096];
+            let d: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+            let x: f32 = a.iter().map(|v| v * v).sum::<f32>().sqrt();
+            let y: f32 = b.iter().map(|v| v * v).sum::<f32>().sqrt();
+            let m = a
+                .iter()
+                .zip(b.iter())
+                .map(|(p, q): (&f32, &f32)| (p - q).abs())
+                .fold(0.0f32, f32::max);
+            println!("  pos {t}: cosine = {:.6}  max_abs = {m:.5}", d / (x * y));
+        }
+        println!("candle[0..6] = {:?}", &cv[..6]);
+        println!("mlx   [0..6] = {:?}", &mv[..6]);
+        // last token's hidden state is what the next block actually consumes
+        let off = cv.len() - 4096;
+        let lmax = cv[off..]
+            .iter()
+            .zip(mv[off..].iter())
+            .map(|(a, b): (&f32, &f32)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        println!("last-token max_abs_diff = {lmax:.5}");
+    }
+
+    /// Which axis does `fast::rope` treat as the sequence position?
+    ///
+    /// Position 0 is the identity rotation (cos 0 = 1, sin 0 = 0), so with an
+    /// all-ones input the slice that comes back unchanged marks the position
+    /// axis. Shape [1, 2, 3, 4]: if axis -2 (len 3) is the sequence, the c=0
+    /// row of every a is untouched; if axis 1 (len 2) is, the whole a=0 block is.
+    #[test]
+    fn test_rope_position_axis() {
+        let x = Array::ones::<f32>(&[1, 2, 3, 4]).unwrap();
+        let r = mlx_rs::fast::rope(&x, 4, false, Some(10000.0), 1.0, 0, None).unwrap();
+        r.eval().unwrap();
+        let v = r.as_slice::<f32>();
+        let at = |a: usize, c: usize| -> Vec<f32> {
+            let base = (a * 3 + c) * 4;
+            v[base..base + 4].to_vec()
+        };
+        for a in 0..2 {
+            for c in 0..3 {
+                println!("a={a} c={c} -> {:?}", at(a, c));
+            }
+        }
+        let unchanged = |w: &[f32]| w.iter().all(|&z| (z - 1.0).abs() < 1e-3);
+        println!(
+            "axis -2 is sequence: {}",
+            unchanged(&at(0, 0)) && unchanged(&at(1, 0)) && !unchanged(&at(0, 1))
+        );
+        println!(
+            "axis  1 is sequence: {}",
+            unchanged(&at(0, 0)) && unchanged(&at(0, 1)) && !unchanged(&at(1, 0))
+        );
+    }
+
     #[test]
     fn test_mlx_array_basic() {
         let a = Array::from_slice::<f32>(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
@@ -752,7 +918,7 @@ mod tests {
     #[test]
     fn test_mlx_matmul() {
         let c = Array::from_slice::<f32>(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3])
-            .matmul(&Array::from_slice::<f32>(
+            .matmul(Array::from_slice::<f32>(
                 &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
                 &[3, 2],
             ))
@@ -792,7 +958,7 @@ mod tests {
     #[test]
     fn test_mlx_softmax() {
         let s: f32 = mlx_rs::ops::softmax_axis(
-            &Array::from_slice::<f32>(&[1.0, 2.0, 3.0, 4.0], &[1, 4]),
+            Array::from_slice::<f32>(&[1.0, 2.0, 3.0, 4.0], &[1, 4]),
             -1,
             None,
         )
@@ -806,7 +972,7 @@ mod tests {
     #[test]
     fn test_mlx_silu() {
         assert_eq!(
-            mlx_rs::nn::silu(&Array::from_slice::<f32>(&[-1.0, 0.0, 1.0, 2.0], &[4]))
+            mlx_rs::nn::silu(Array::from_slice::<f32>(&[-1.0, 0.0, 1.0, 2.0], &[4]))
                 .unwrap()
                 .shape(),
             &[4]
@@ -829,7 +995,7 @@ mod tests {
     #[test]
     fn test_mlx_eval_lazy() {
         let c = Array::from_slice::<f32>(&[1.0, 2.0], &[2])
-            .add(&Array::from_slice::<f32>(&[3.0, 4.0], &[2]))
+            .add(Array::from_slice::<f32>(&[3.0, 4.0], &[2]))
             .unwrap();
         c.eval().unwrap();
         let v: f32 = c.index(0).item();
@@ -885,9 +1051,9 @@ mod tests {
             .transpose_axes(&[0, 2, 1, 3])
             .unwrap();
         let sc = qr
-            .matmul(&kr.transpose_axes(&[0, 1, 3, 2]).unwrap())
+            .matmul(kr.transpose_axes(&[0, 1, 3, 2]).unwrap())
             .unwrap()
-            .multiply(&Array::from_slice::<f32>(
+            .multiply(Array::from_slice::<f32>(
                 &[(hd as f32).sqrt().recip()],
                 &[1],
             ))
@@ -900,13 +1066,13 @@ mod tests {
             .unwrap()
             .reshape(&[1, 2, h])
             .unwrap();
-        let x = x.add(&o.forward(&ao).unwrap()).unwrap();
+        let x = x.add(o.forward(&ao).unwrap()).unwrap();
         let nm = n2.forward(&x).unwrap();
         let f = d
             .forward(
-                &mlx_rs::nn::silu(&g.forward(&nm).unwrap())
+                &mlx_rs::nn::silu(g.forward(&nm).unwrap())
                     .unwrap()
-                    .multiply(&u.forward(&nm).unwrap())
+                    .multiply(u.forward(&nm).unwrap())
                     .unwrap(),
             )
             .unwrap();


### PR DESCRIPTION
Relates to #198 (stretch goal) and resolves the premise of #117: Macs can serve block shards, on MLX.

## Problem
`shard serve` on macOS routes to whole-model-via-Ollama because candle's Metal backend decodes slower than CPU (#117). That is a property of one backend's kernels, not of Apple GPUs. `kwaai-inference` already had an MLX shard (`mlx_shard.rs`, `mlx` feature) but it decoded incorrectly on `main` and nothing in the CLI could enable or route to it.

## Change
- Ports the two RoPE fixes that lived only on `wip/mlx-shard`: apply RoPE after the transpose (`fast::rope` takes axis −2 as position), and use the uncompiled block forward by default so the decode offset is honoured (`KWAAINET_MLX_COMPILE=1` opts back in). `forward_first/middle/last` ported; clippy-clean (`static mut` → `OnceLock<Mutex<_>>`).
- `kwaainet` gains an `mlx` feature; the loaded shard becomes `LoadedShard::{Candle, Mlx}` behind the same f16 wire format, so MLX and candle halves mix in one chain.
- `shard serve --mlx` (implies `--force-blocks`; errors on a binary built without the feature).

## Evidence (isolated LAN, Llama-3.1-8B f16)
| | candle CPU | MLX |
|---|---|---|
| M1 Max, 16 blocks | ~150 ms/token | 25 ms/token |
| M4 mini, 16 blocks + LM head | ~180 ms/token | ~90 ms/token |
| 2-hop chain decode | 2.4–2.6 tok/s | 5.4–5.7 tok/s |
| 2-hop chain prefill, 15–17 tokens | 5–6 s | 0.3–1.3 s |

Output identical and correct. Compute-only figures are within ~75–80 % of each chip's memory-bandwidth floor. Tests: `mlx_shard` 16 pass / 1 ignored with `--test-threads=1` (MLX's scheduler does not tolerate parallel test threads); `block_rpc` 10/10; clippy clean with and without the feature.

## Known rough edges (follow-ups, not blockers)
- First request after load pays 20–48 s of Metal kernel warmup and can trip a client's 30 s call timeout; a warmup forward at load would fix it.
- MLX loads kernels from `mlx.metallib` (88 MB) resolved via a compile-time path or a file beside the executable; release packaging must ship it.
- Building needs the Metal Toolchain (`xcodebuild -downloadComponent MetalToolchain`), ~5 min per profile for mlx-sys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
