### PR TITLE
fix(p2p): a call to our own peer id loops back to the local handler

### DIFF
--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -1172,6 +1172,10 @@ impl NetworkService {
     /// first when we have none — Go's routed-host semantics (see
     /// [`RoutedRequest`]). With a live connection, dispatch is immediate.
     fn dispatch_routed(&mut self, peer: PeerId, request: RoutedRequest) {
+        if peer == *self.swarm.local_peer_id() {
+            self.dispatch_local(request);
+            return;
+        }
         if self.swarm.is_connected(&peer) {
             self.forward_routed(peer, request);
             return;
@@ -1188,6 +1192,50 @@ impl NetworkService {
 
         if !self.dial_routed(peer) {
             self.start_routed_lookup(peer);
+        }
+    }
+
+    /// A routed request addressed to ourselves: the swarm refuses to dial its
+    /// own peer id, but we are trivially connected and our unary handlers are
+    /// right here. A raw stream has no loopback transport and is refused.
+    fn dispatch_local(&mut self, request: RoutedRequest) {
+        let local = *self.swarm.local_peer_id();
+        match request {
+            RoutedRequest::Connect { reply } => {
+                let _ = reply.send(Ok(local));
+            }
+            RoutedRequest::Unary { proto, data, reply } => {
+                // The same refusal a remote gives during negotiation.
+                if !self.unary_handlers.contains_key(&proto) {
+                    let _ = reply.send(Err(unary::UnaryError::UnsupportedProtocol(proto)));
+                    return;
+                }
+                let (responder, result) = oneshot::channel();
+                self.dispatch_unary(
+                    local,
+                    unary::InboundRequest {
+                        proto: UnaryProtocol::new(proto),
+                        data,
+                        responder,
+                    },
+                );
+                tokio::spawn(async move {
+                    let outcome = match result.await {
+                        Ok(Ok(data)) => Ok(data),
+                        Ok(Err(e)) => Err(unary::UnaryError::Remote(e)),
+                        Err(_) => Err(unary::UnaryError::Wire(
+                            "local handler dropped the call".to_string(),
+                        )),
+                    };
+                    let _ = reply.send(outcome);
+                });
+            }
+            RoutedRequest::RawStream { protos, reply } => {
+                let _ = reply.send(Err(raw_stream::RawStreamError::Io(format!(
+                    "no loopback transport for a stream to self ({})",
+                    protos.join(", ")
+                ))));
+            }
         }
     }
 

--- a/core/crates/kwaai-p2p/src/service.rs
+++ b/core/crates/kwaai-p2p/src/service.rs
@@ -1202,6 +1202,8 @@ impl NetworkService {
         let local = *self.swarm.local_peer_id();
         match request {
             RoutedRequest::Connect { reply } => {
+                // Nothing is recorded in `connections`: self is deliberately
+                // not a peer in `list_peers`, there is no connection to close.
                 let _ = reply.send(Ok(local));
             }
             RoutedRequest::Unary { proto, data, reply } => {
@@ -1219,13 +1221,17 @@ impl NetworkService {
                         responder,
                     },
                 );
+                // Same budget as a remote call: callers rely on the handle
+                // to bound every request and carry no timeout of their own.
+                let timeout = self.swarm.behaviour().unary.request_timeout();
                 tokio::spawn(async move {
-                    let outcome = match result.await {
-                        Ok(Ok(data)) => Ok(data),
-                        Ok(Err(e)) => Err(unary::UnaryError::Remote(e)),
-                        Err(_) => Err(unary::UnaryError::Wire(
+                    let outcome = match tokio::time::timeout(timeout, result).await {
+                        Ok(Ok(Ok(data))) => Ok(data),
+                        Ok(Ok(Err(e))) => Err(unary::UnaryError::Remote(e)),
+                        Ok(Err(_)) => Err(unary::UnaryError::Wire(
                             "local handler dropped the call".to_string(),
                         )),
+                        Err(_) => Err(unary::UnaryError::Timeout),
                     };
                     let _ = reply.send(outcome);
                 });

--- a/core/crates/kwaai-p2p/src/unary.rs
+++ b/core/crates/kwaai-p2p/src/unary.rs
@@ -746,6 +746,11 @@ impl Behaviour {
         }
     }
 
+    /// The per-call budget, so a loopback call can be bounded like a remote one.
+    pub fn request_timeout(&self) -> Duration {
+        self.config.request_timeout
+    }
+
     /// Start advertising `proto` on inbound negotiation. Idempotent. Takes
     /// effect for every subsequent inbound stream, including on connections
     /// that already exist.

--- a/core/crates/kwaai-p2p/tests/service_unary.rs
+++ b/core/crates/kwaai-p2p/tests/service_unary.rs
@@ -882,6 +882,38 @@ async fn a_unary_call_to_self_without_a_handler_is_a_protocol_refusal() {
     );
 }
 
+/// The loopback path is bounded by the same `request_timeout` as a remote
+/// call. Callers rely on the handle for that and carry no timeout of their
+/// own, so a hung local handler must surface as `Timeout`, not hang forever.
+#[tokio::test]
+async fn a_unary_call_to_self_times_out_like_a_remote_call() {
+    let keypair = Keypair::generate_ed25519();
+    let node_id = keypair.public().to_peer_id();
+    let config = NetworkConfig {
+        request_timeout: Duration::from_millis(200),
+        ..NetworkConfig::for_tests()
+    };
+    let (node, _task) = NetworkService::spawn(config, keypair).expect("service should start");
+
+    node.add_unary_handler(PROTO, |_data: Vec<u8>| async move {
+        std::future::pending::<()>().await;
+        Ok(Vec::new())
+    })
+    .await
+    .expect("register handler");
+
+    let err = within(
+        "the hung loopback call",
+        node.call_unary_handler(node_id, PROTO, b"hello"),
+    )
+    .await
+    .expect_err("a hung local handler must time out");
+    assert!(
+        matches!(err, P2PError::Timeout(_)),
+        "expected a timeout, got {err:?}"
+    );
+}
+
 /// Connecting to self succeeds: a chain builder that pre-dials every server,
 /// itself included, must not be told its own node is unreachable.
 #[tokio::test]

--- a/core/crates/kwaai-p2p/tests/service_unary.rs
+++ b/core/crates/kwaai-p2p/tests/service_unary.rs
@@ -835,3 +835,64 @@ async fn an_evicted_entry_is_restored_when_the_lookup_finds_nothing_better() {
         "the failed lookup must hand the old entry back, not leave the peer forgotten",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Calls to self
+// ---------------------------------------------------------------------------
+
+/// The swarm refuses to dial its own peer id, which used to make a node the
+/// one peer it could not call. A unary call to self must loop back to the
+/// local handler exactly as an inbound call would.
+#[tokio::test]
+async fn a_unary_call_to_self_loops_back_to_the_local_handler() {
+    let (node, _task, node_id) = spawn_service();
+
+    node.add_unary_handler(PROTO, |data: Vec<u8>| async move {
+        let mut out = b"self:".to_vec();
+        out.extend_from_slice(&data);
+        Ok(out)
+    })
+    .await
+    .expect("register handler");
+
+    let response = within(
+        "the loopback round trip",
+        node.call_unary_handler(node_id, PROTO, b"hello"),
+    )
+    .await
+    .expect("our own handler must answer");
+    assert_eq!(response, b"self:hello");
+}
+
+/// No handler for the protocol on this node is the same clean refusal a
+/// remote gives during negotiation — not a dial failure.
+#[tokio::test]
+async fn a_unary_call_to_self_without_a_handler_is_a_protocol_refusal() {
+    let (node, _task, node_id) = spawn_service();
+
+    let err = within(
+        "the refused loopback call",
+        node.call_unary_handler(node_id, PROTO, b"hello"),
+    )
+    .await
+    .expect_err("no handler must refuse");
+    assert!(
+        matches!(err, P2PError::Protocol(_)),
+        "expected a protocol refusal, got {err:?}"
+    );
+}
+
+/// Connecting to self succeeds: a chain builder that pre-dials every server,
+/// itself included, must not be told its own node is unreachable.
+#[tokio::test]
+async fn connecting_to_self_succeeds() {
+    let (node, _task, node_id) = spawn_service();
+
+    let connected = within(
+        "the self connect",
+        node.connect_peer(&format!("/p2p/{node_id}")),
+    )
+    .await
+    .expect("connect to self must succeed");
+    assert_eq!(connected, node_id);
+}


### PR DESCRIPTION
libp2p refuses to dial its own peer id, so the local node was the one peer the daemon could never connect to or call. Every client of the daemon had to special-case itself, and the chain builder's pre-dial reported the local node as unreachable on every session (the "you: unreachable" row in the GUI).

A routed request addressed to the local peer id now resolves inside the daemon:

- connect succeeds (the node is trivially connected to itself),
- a unary call dispatches to the registered handler exactly as an inbound call does; no handler registered is the same protocol refusal a remote gives during negotiation,
- a raw stream is refused, since there is no loopback transport for one.

Tests: loopback round trip, refusal without a handler, connect to self, in `tests/service_unary.rs`.

Demonstrated on the isolated LAN: `p2p peers connect --addr /p2p/<own id>` answers Connected, and a 3-hop session's local hop runs through the daemon at 34 ms per token.

The client-side cleanup that this enables is #210. Part of #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
