### PR TITLE
fix(installer): source cargo env in same shell; skip broken CUDA upgrade on musl fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ This quickstart shows how to install the native Rust CLI, start a node, and send
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Kwaai-AI-Lab/KwaaiNet/releases/latest/download/kwaainet-installer.sh | sh
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+```
+
+The second line puts `kwaainet` on `PATH` in the *current* shell — the
+installer itself only updates `.bashrc`/`.profile`/`.zshrc` for future
+shells, so without it you'd need to open a new terminal first. Then
+confirm:
+
+```bash
+kwaainet --version
 ```
 
 **PowerShell installer (Windows):**
@@ -181,6 +191,13 @@ On Linux and Windows machines with an NVIDIA GPU, the installer automatically de
 ```bash
 kwaainet benchmark --gpu
 ```
+
+Only a glibc-linked CUDA build is published, so on a host whose glibc is
+too old for it (e.g. RHEL/EL9, Amazon Linux 2-family), the shell installer
+falls back to the CPU build instead of installing a binary that can't run.
+To get CUDA acceleration there anyway, use the Nix build above — it links
+against its own glibc and isn't affected by the host's system glibc at
+all.
 
 **Apple Silicon (Metal):**
 

--- a/scripts/patch-installer-cuda.sh
+++ b/scripts/patch-installer-cuda.sh
@@ -22,10 +22,18 @@ cat > "$CUDA_FUNC" <<'CUDA_PATCH'
 _cuda_selected=""
 _cuda_libs_staged=""
 _try_cuda_upgrade() {
-    # Only applies to x86_64 linux targets (gnu or musl fallback)
+    # Only applies to the x86_64 gnu-linux target. No musl-linked CUDA build
+    # is published, so a musl-fallback host (glibc too old for the gnu
+    # build) must not be "upgraded" to the gnu-cuda archive — it would
+    # install a binary that can't run there (missing libcudart at runtime).
     case "${_artifact_name:-}" in
         kwaainet-x86_64-unknown-linux-gnu*) ;;
-        kwaainet-x86_64-unknown-linux-musl*) ;;
+        kwaainet-x86_64-unknown-linux-musl*)
+            if command -v nvidia-smi >/dev/null 2>&1 && [ -n "$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)" ]; then
+                say "NVIDIA GPU detected, but this system's glibc is too old for the CUDA-enabled build — installing CPU build instead"
+            fi
+            return 0
+            ;;
         *) return 0 ;;
     esac
     if ! command -v nvidia-smi >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- The README's `curl | sh` install command left `kwaainet` unreachable in the same terminal — the installer only edits rc files for *future* shells. The recommended command now chains `[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"` so it works immediately, plus a confirm step.
- On hosts with an old glibc (RHEL/EL9, Amazon Linux 2-family), the CI-injected CUDA auto-detection unconditionally "upgraded" any GPU host to the gnu-linked CUDA archive — the only one ever published — which then fails at runtime (`error while loading shared libraries: libcudart.so.12`) on exactly the systems that needed the musl fallback in the first place. The CUDA upgrade in `scripts/patch-installer-cuda.sh` is now restricted to `gnu` targets only.
- Added a README note pointing GPU + old-glibc hosts at the Nix build (`nix build github:Kwaai-AI-Lab/KwaaiNet`) as the way to still get CUDA acceleration, since it's unaffected by the host's system glibc.

## Test plan
- [x] Reproduced both bugs against a real, live release installer on an EL9/glibc-2.34 host with a real NVIDIA GPU.
- [x] Reconstructed a pristine (pre-CI-patch) installer and applied the fixed `patch-installer-cuda.sh` exactly once, mirroring real CI, then ran it end-to-end: installer now prints "NVIDIA GPU detected, but this system's glibc is too old for the CUDA-enabled build — installing CPU build instead", stays on the working musl build, and `kwaainet --version` succeeds in the same shell immediately after the two-line install command (no restart needed).
- [x] Unit-tested `_try_cuda_upgrade` in isolation for both branches: `gnu` target still upgrades to CUDA correctly (unchanged behavior); `musl` target now skips the upgrade and warns instead of installing a broken binary.
- [x] `sh -n` syntax-checked both the patch script and the resulting patched installer.
- [x] No Rust code changed — `cargo test` not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)